### PR TITLE
Suppress urllib3 connectionpool warnings

### DIFF
--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -65,6 +65,9 @@ def setup_logging(log_level: str, log_config: TextIO):
         datefmt='%m-%d %H:%M:%S',
     )
 
+    # don't show urllib3.connectionpoool errors
+    logging.getLogger('urllib3.connectionpool').setLevel('ERROR')
+
     if log_config:
         config = json.load(log_config)
         logging.config.dictConfig(config)


### PR DESCRIPTION
When starting to test we don't want to have all this noise hiding the message.

Related to #84 