### PR TITLE
Emit the UpdatedHeadBlockEvent on every block update

### DIFF
--- a/src/monitoring_service/blockchain.py
+++ b/src/monitoring_service/blockchain.py
@@ -168,7 +168,8 @@ class BlockchainListener:
         # increment by one, as latest_known_block has been queried last time already
         from_block = chain_state.latest_known_block + 1
 
-        if to_block <= from_block:
+        # Check if the current block was already processed
+        if from_block > to_block:
             return chain_state, []
 
         new_chain_state = deepcopy(chain_state)

--- a/tests/monitoring/monitoring_service/test_blockchain.py
+++ b/tests/monitoring/monitoring_service/test_blockchain.py
@@ -93,3 +93,15 @@ def test_limit_inclusivity_in_query_blockchain_events(
         to_block=current_block_number,
     )
     assert len(events) == 1
+
+    # test that querying just one block works
+    events = query_blockchain_events(
+        web3=web3,
+        contract_manager=contracts_manager,
+        contract_address=token_network_registry_contract.address,
+        contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
+        topics=[],
+        from_block=registry_event_block,
+        to_block=registry_event_block,
+    )
+    assert len(events) == 1


### PR DESCRIPTION
This commit fixes a bug that led to the UpdatedHeadBlockEvent only being
emitted every second block. The reason was a wrong comparison in the
blockchain filter logic.