### PR TITLE
Mock MonitoringService in all MS cli tests

### DIFF
--- a/tests/monitoring/monitoring_service/test_cli.py
+++ b/tests/monitoring/monitoring_service/test_cli.py
@@ -52,11 +52,13 @@ def test_shutdown(keystore_file, default_cli_args):
 def test_log_level(keystore_file, default_cli_args):
     """ Setting of log level via command line switch """
     runner = CliRunner()
-    with patch('request_collector.cli.logging.basicConfig') as basicConfig:
+    with patch.multiple(**patch_args), \
+            patch('request_collector.cli.logging.basicConfig') as basicConfig:
         for log_level in ('CRITICAL', 'WARNING'):
             runner.invoke(
                 main,
                 default_cli_args + ['--log-level', log_level],
+                catch_exceptions=False,
             )
             # pytest already initializes logging, so basicConfig does not have
             # an effect. Use mocking to check that it's called properly.


### PR DESCRIPTION
The logging test did not terminate for me because it got stuck in
`MonitoringService.start`. The actual MS implementation was meant to be
mocked in that test, too.