### PR TITLE
Remove obsolete comment, only matching MR is used

### DIFF
--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -356,7 +356,6 @@ def action_monitoring_triggered_event_handler(event: Event, context: Context) ->
         monitor_request.nonce > last_onchain_nonce
     )
     if call_monitor:
-        # FIXME: don't monitor when closer is MR signer
         try:
             tx_hash = context.monitoring_service_contract.functions.monitor(
                 monitor_request.signer,


### PR DESCRIPTION
We already use `non_closing_signer` to fetch the MR. If the MR is not by the non-closing participant, `None` is returned from the db and we correctly do nothing.

Closes #136