### PR TITLE
Imrpove version number retrival and cache it

### DIFF
--- a/src/pathfinding_service/api/rest.py
+++ b/src/pathfinding_service/api/rest.py
@@ -121,6 +121,8 @@ class PathsResource(PathfinderResource):
 
 
 class InfoResource(PathfinderResource):
+    version = pkg_resources.get_distribution('raiden-services').version
+
     def get(self):
         price = 0
         settings = 'PLACEHOLDER FOR PATHFINDER SETTINGS'
@@ -134,7 +136,7 @@ class InfoResource(PathfinderResource):
                 'registry_address': self.pathfinding_service.registry_address,
             },
             'settings': settings,
-            'version': pkg_resources.require('raiden-services')[0].version,
+            'version': self.version,
             'operator': operator,
             'message': message,
         }, 200


### PR DESCRIPTION
As Ulo said:

> Hm ok apparently pkg_resources.get_distribution(pkg_name).version is the recommended way to do it and it seems to be much faster