### PR TITLE
Use the RC in the end-to-end test

### DIFF
--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -57,7 +57,7 @@ class MonitoringService:
         db_filename: str,
         sync_start_block: BlockNumber = 0,
         required_confirmations: int = DEFAULT_REQUIRED_CONFIRMATIONS,
-        poll_interval: int = 1,
+        poll_interval: float = 1,
     ):
         self.web3 = web3
         self.contract_manager = contract_manager

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -79,6 +79,7 @@ def monitoring_service(
     contracts_manager: ContractManager,
     service_registry,
     custom_token,
+    ms_database,
 ):
     # register MS in ServiceRegistry
     ms_address = private_key_to_address(server_private_key)
@@ -98,9 +99,11 @@ def monitoring_service(
         registry_address=token_network_registry_contract.address,
         monitor_contract_address=monitoring_service_contract.address,
         required_confirmations=1,  # for faster tests
-        poll_interval=1,  # for faster tests
+        poll_interval=0.01,  # for faster tests
         db_filename=':memory:',
     )
+    # We need a shared db between MS and RC so the MS can use MR saved by the RC
+    ms.context.db = ms_database
     return ms
 
 


### PR DESCRIPTION
The matrix listener is still mocked out, but that can be tested well separately.

Closes #134.