### PR TITLE
Keep RequestCollector running

### DIFF
--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -74,6 +74,9 @@ class MatrixListener(gevent.Greenlet):
             )
             sys.exit(1)
 
+    def listen_forever(self):
+        self.client.listen_forever()
+
     def _run(self):
         self.client.start_listener_thread()
         self.client.sync_thread.get()

--- a/src/request_collector/cli.py
+++ b/src/request_collector/cli.py
@@ -78,21 +78,12 @@ def main(
 
     database = SharedDatabase(state_db)
 
-    service = None
-    try:
-        service = RequestCollector(
-            private_key=encode_hex(private_key),
-            state_db=database,
-        )
+    RequestCollector(
+        private_key=encode_hex(private_key),
+        state_db=database,
+    ).listen_forever()
 
-        service.run()
-    except (KeyboardInterrupt, SystemExit):
-        print('Exiting...')
-    finally:
-        log.info('Stopping Request Collector...')
-        if service:
-            service.stop()
-
+    print('Exiting...')
     return 0
 
 

--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -52,6 +52,9 @@ class RequestCollector(gevent.Greenlet):
             )
             sys.exit(1)
 
+    def listen_forever(self):
+        self.matrix_listener.listen_forever()
+
     def _run(self):
         register_error_handler(error_handler)
         self.matrix_listener.start()

--- a/tests/monitoring/request_collector/test_cli.py
+++ b/tests/monitoring/request_collector/test_cli.py
@@ -46,7 +46,7 @@ def test_shutdown(keystore_file, default_cli_args):
         )
         assert result.exit_code == 0
         assert 'Exiting' in result.output
-        assert mocks['RequestCollector'].return_value.stop.called
+        assert mocks['RequestCollector'].return_value.listen_forever.called
 
 
 def test_log_level(keystore_file, default_cli_args):


### PR DESCRIPTION
Before, the RC exited immediately on startup. Now the process control is
given to `GMatrixClient.listen_forever`, which keeps the RC running until
the MatrixListener fails.

We could remove the `Greenlet` superclass from `RequestCollector` and
`MatrixListener`, as well as the `_run` and `stop` methods if we don't
plan to run them as greenlets at all. Currently we still do that in some
tests.