### PR TITLE
Log received messages properly

### DIFF
--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -283,4 +283,4 @@ class PathfindingService(gevent.Greenlet):
             log.info('Ignoring unknown message type')
 
     def on_pfs_update(self, message: UpdatePFS):
-        print(f"This is the message: {message}")
+        log.info('Received message', **message.to_dict())


### PR DESCRIPTION
Just display stuff a bit nicer for debugging:

```
2019-03-12 16:11:33.954389 [info     ] Received message               [pathfinding_service.service] chain_id=4 channel_identifier=1 locked_amount=0 locksroot=0x0000000000000000000000000000000000000000000000000000000000000000 nonce=2 reveal_timeout=50 signature=0x6c996db8696bedae15e95577bc99a19072a95f5cb93aa4f7dd661f0f9f18fc484b3edbac6f770c45b9b36b00c3ef15542f95bde47fff16419d23463cbbc0d3161c token_network_address=0xbefc1ae9854719bb6598a751ee8daa8a04968a2e transferred_amount=5 type=UpdatePFS
```