### PR TITLE
Store scheduled events in DB as well

### DIFF
--- a/src/monitoring_service/database.py
+++ b/src/monitoring_service/database.py
@@ -185,8 +185,8 @@ class SharedDatabase:
         ).fetchall()
 
         def create_scheduled_event(row: sqlite3.Row) -> ScheduledEvent:
-            klass = EVENT_ID_TYPE_MAP[row['event_type']]
-            sub_event = klass(
+            event_type = EVENT_ID_TYPE_MAP[row['event_type']]
+            sub_event = event_type(
                 row['token_network_address'],
                 row['channel_identifier'],
                 row['non_closing_participant'],

--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -401,11 +401,12 @@ def action_monitoring_triggered_event_handler(event: Event, context: Context) ->
             )
             assert tx_hash is not None
 
-            # Add tx hash to list of waiting transactions
-            context.db.add_waiting_transaction(encode_hex(tx_hash))
+            with context.db.conn:
+                # Add tx hash to list of waiting transactions
+                context.db.add_waiting_transaction(encode_hex(tx_hash))
 
-            channel.closing_tx_hash = tx_hash
-            context.db.upsert_channel(channel)
+                channel.closing_tx_hash = tx_hash
+                context.db.upsert_channel(channel)
         except Exception as e:
             log.error('Sending tx failed', exc_info=True, err=e)
 
@@ -457,11 +458,12 @@ def action_claim_reward_triggered_event_handler(event: Event, context: Context) 
             )
             assert tx_hash is not None
 
-            # Add tx hash to list of waiting transactions
-            context.db.add_waiting_transaction(encode_hex(tx_hash))
+            with context.db.conn:
+                # Add tx hash to list of waiting transactions
+                context.db.add_waiting_transaction(encode_hex(tx_hash))
 
-            channel.claim_tx_hash = tx_hash
-            context.db.upsert_channel(channel)
+                channel.claim_tx_hash = tx_hash
+                context.db.upsert_channel(channel)
         except Exception as e:
             log.error('Sending tx failed', exc_info=True, err=e)
 

--- a/src/monitoring_service/schema.sql
+++ b/src/monitoring_service/schema.sql
@@ -56,3 +56,14 @@ CREATE TABLE monitor_request (
 CREATE TABLE waiting_transactions (
     transaction_hash        CHAR(66)    NOT NULL
 );
+
+CREATE TABLE scheduled_events (
+    trigger_block_number    HEX_INT     NOT NULL,
+    event_type              INT NOT NULL CHECK (event_type >= 0 AND event_type <=1),
+
+    token_network_address   CHAR(42)    NOT NULL,
+    channel_identifier      HEX_INT     NOT NULL,
+    non_closing_participant CHAR(42)    NOT NULL,
+
+    PRIMARY KEY (trigger_block_number, channel_identifier, token_network_address)
+);

--- a/src/monitoring_service/schema.sql
+++ b/src/monitoring_service/schema.sql
@@ -65,5 +65,7 @@ CREATE TABLE scheduled_events (
     channel_identifier      HEX_INT     NOT NULL,
     non_closing_participant CHAR(42)    NOT NULL,
 
-    PRIMARY KEY (trigger_block_number, channel_identifier, token_network_address)
+    PRIMARY KEY (trigger_block_number, event_type, token_network_address, channel_identifier, non_closing_participant),
+    FOREIGN KEY (token_network_address)
+        REFERENCES token_network(address)
 );

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -107,7 +107,6 @@ def context(ms_database):
     return Context(
         ms_state=ms_database.load_state(sync_start_block=0),
         db=ms_database,
-        scheduled_events=[],
         w3=Mock(),
         contract_manager=Mock(),
         last_known_block=0,
@@ -181,7 +180,7 @@ def test_channel_closed_event_handler_closes_existing_channel(
     channel_closed_event_handler(event, context)
 
     # ActionMonitoringTriggeredEvent has been triggered
-    assert len(context.scheduled_events) == 1
+    assert context.db.scheduled_event_count() == 1
 
     assert context.db.channel_count() == 1
     assert_channel_state(context, ChannelState.CLOSED)
@@ -202,7 +201,7 @@ def test_channel_closed_event_handler_ignores_existing_channel_after_timeout(
     channel_closed_event_handler(event, context)
 
     # no ActionMonitoringTriggeredEvent has been triggered
-    assert len(context.scheduled_events) == 0
+    assert context.db.scheduled_event_count() == 0
 
     assert context.db.channel_count() == 1
     assert_channel_state(context, ChannelState.CLOSED)
@@ -240,7 +239,7 @@ def test_channel_closed_event_handler_trigger_action_monitor_event_with_monitor_
     )
 
     channel_closed_event_handler(event, context)
-    assert len(context.scheduled_events) == 1
+    assert context.db.scheduled_event_count() == 1
 
 
 def test_channel_closed_event_handler_trigger_action_monitor_event_without_monitor_request(
@@ -256,7 +255,7 @@ def test_channel_closed_event_handler_trigger_action_monitor_event_without_monit
     )
 
     channel_closed_event_handler(event, context)
-    assert len(context.scheduled_events) == 1
+    assert context.db.scheduled_event_count() == 1
 
 
 def test_channel_settled_event_handler_settles_existing_channel(


### PR DESCRIPTION
Merge after #159 .

Store scheduled events in DB as well

This commit moves scheduled events from memory to the database.
This makes them persistent, so that they are available after restarts
and makes sure that the DB is the single source of truth.

Fixes #157 