### PR TITLE
Add payment handling to PFS

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     build: ../
     environment:
       - PFS_ETH_RPC=http://geth.ropsten.ethnodes.brainbot.com:8545
+      - PFS_STATE_DB=/state/pfs-ropsten.db
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host: pfs-ropsten.services-dev.raiden.network"
@@ -22,6 +23,7 @@ services:
     << : *defaults
     environment:
       - PFS_ETH_RPC=http://geth.rinkeby.ethnodes.brainbot.com:8545
+      - PFS_STATE_DB=/state/pfs-rinkeby.db
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host: pfs-rinkeby.services-dev.raiden.network"
@@ -30,6 +32,7 @@ services:
     << : *defaults
     environment:
       - PFS_ETH_RPC=http://parity.kovan.ethnodes.brainbot.com:8545
+      - PFS_STATE_DB=/state/pfs-kovan.db
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host: pfs-kovan.services-dev.raiden.network"

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ networkx==2.1
 requests==2.20.0
 
 jsonschema==2.6.0
+marshmallow-dataclass==0.5
+#marshmallow-dataclass==6.0.0b7

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ networkx==2.1
 requests==2.20.0
 
 jsonschema==2.6.0
-marshmallow-dataclass==0.5
+marshmallow-dataclass==0.5.5
 #marshmallow-dataclass==6.0.0b7

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,5 @@ networkx==2.1
 requests==2.20.0
 
 jsonschema==2.6.0
+marshmallow==2.15.4
 marshmallow-dataclass==0.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,3 @@ requests==2.20.0
 
 jsonschema==2.6.0
 marshmallow-dataclass==0.5.5
-#marshmallow-dataclass==6.0.0b7

--- a/src/pathfinding_service/api/rest.py
+++ b/src/pathfinding_service/api/rest.py
@@ -26,11 +26,11 @@ from pathfinding_service.config import (
     MIN_IOU_EXPIRY,
 )
 from pathfinding_service.model import IOU
+from raiden.exceptions import InvalidSignature
+from raiden.utils.signer import recover
 from raiden.utils.typing import Signature, TokenNetworkAddress
-from raiden_libs.exceptions import InvalidSignature
 from raiden_libs.marshmallow import HexedBytes
 from raiden_libs.types import Address
-from raiden_libs.utils import eth_recover
 
 log = structlog.get_logger(__name__)
 
@@ -216,7 +216,7 @@ class IOURequest:
             Web3.toBytes(text=self.timestamp_str)
         )
         try:
-            recovered_address = eth_recover(packed_data, self.signature)
+            recovered_address = recover(packed_data, self.signature)
         except InvalidSignature:
             return False
         return is_same_address(recovered_address, self.sender)

--- a/src/pathfinding_service/api/rest.py
+++ b/src/pathfinding_service/api/rest.py
@@ -182,9 +182,7 @@ def process_payment(iou_dict, pathfinding_service):
 
     # Save latest IOU
     iou.claimed = False
-    pathfinding_service.database.upsert_iou(
-        IOU.Schema().dump(iou)[0],
-    )
+    pathfinding_service.database.upsert_iou(iou)
 
 
 class InfoResource(PathfinderResource):

--- a/src/pathfinding_service/api/rest.py
+++ b/src/pathfinding_service/api/rest.py
@@ -163,7 +163,7 @@ def process_payment(iou_dict, pathfinding_service):
         iou.expiration_block,
     )
     if last_iou:
-        expected_amount = last_iou['amount'] + pathfinding_service.service_fee
+        expected_amount = last_iou.amount + pathfinding_service.service_fee
     else:
         min_expiry = pathfinding_service.web3.eth.blockNumber + MIN_IOU_EXPIRY
         if iou.expiration_block < min_expiry:

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -3,6 +3,7 @@ from gevent import monkey  # isort:skip # noqa
 monkey.patch_all()  # isort:skip # noqa
 
 import json
+import os
 import sys
 
 import click
@@ -103,6 +104,18 @@ def get_default_registry_and_start_block(
     type=click.Choice(['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']),
     help='Print log messages of this level and more important ones',
 )
+@click.option(
+    '--state-db',
+    default=os.path.join(click.get_app_dir('raiden-monitoring-service'), 'state.db'),
+    type=str,
+    help='Path to SQLite3 db which stores the application state',
+)
+@click.option(
+    '--service-fee',
+    default=0,
+    type=click.IntRange(min=0),
+    help='Service fee which is required before processing requests',
+)
 def main(
     keystore_file: str,
     password: str,
@@ -112,6 +125,8 @@ def main(
     confirmations: int,
     host: str,
     log_level: str,
+    state_db: str,
+    service_fee: int,
 ):
     """Console script for pathfinding_service.
 
@@ -178,6 +193,8 @@ def main(
             required_confirmations=confirmations,
             private_key=private_key,
             poll_interval=DEFAULT_POLL_INTERVALL,
+            db_filename=state_db,
+            service_fee=service_fee,
         )
 
         api = ServiceApi(service)

--- a/src/pathfinding_service/config.py
+++ b/src/pathfinding_service/config.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 API_PATH: str = '/api/v1'
 DEFAULT_API_HOST: str = 'localhost'
 DEFAULT_API_PORT: int = 6000
@@ -18,4 +20,6 @@ DEFAULT_POLL_INTERVALL = 10
 
 # When a new IOU session is started, this is the minimum number of blocks
 # between the current block and `expiration_block`.
-MIN_IOU_EXPIRY = 1000
+MIN_IOU_EXPIRY: int = 7 * 24 * 60 * 4
+
+MAX_AGE_OF_IOU_REQUESTS: timedelta = timedelta(hours=1)

--- a/src/pathfinding_service/config.py
+++ b/src/pathfinding_service/config.py
@@ -15,3 +15,7 @@ DEFAULT_REVEAL_TIMEOUT: int = 50
 DEFAULT_SETTLE_TO_REVEAL_TIMEOUT_RATIO = 2
 
 DEFAULT_POLL_INTERVALL = 10
+
+# When a new IOU session is started, this is the minimum number of blocks
+# between the current block and `expiration_block`.
+MIN_IOU_EXPIRY = 1000

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -75,4 +75,4 @@ class PFSDatabase:
             return None
 
         iou_dict = dict(zip(row.keys(), row))
-        return IOU(receiver=self.pfs_address, **iou_dict)  # type: ignore
+        return IOU(receiver=self.pfs_address, **iou_dict)

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -51,8 +51,8 @@ class PFSDatabase:
         iou_dict = IOU.Schema(strict=True).dump(iou)[0]
         self.conn.execute("""
             INSERT OR REPLACE INTO iou (
-                sender, amount, expiration_block, signature
-            ) VALUES (:sender, :amount, :expiration_block, :signature)
+                sender, amount, expiration_block, signature, claimed
+            ) VALUES (:sender, :amount, :expiration_block, :signature, :claimed)
         """, iou_dict)
 
     def get_iou(self, sender: Address, expiration_block: int) -> Optional[IOU]:

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -55,15 +55,22 @@ class PFSDatabase:
             ) VALUES (:sender, :amount, :expiration_block, :signature, :claimed)
         """, iou_dict)
 
-    def get_iou(self, sender: Address, expiration_block: int) -> Optional[IOU]:
-        row = self.conn.execute(
-            """
-                SELECT *
-                FROM iou
-                WHERE sender = ? AND expiration_block = ?
-            """,
-            [sender, expiration_block],
-        ).fetchone()
+    def get_iou(
+        self,
+        sender: Address,
+        expiration_block: int = None,
+        claimed: bool = None,
+    ) -> Optional[IOU]:
+        query = "SELECT * FROM iou WHERE sender = ?"
+        args: list = [sender]
+        if expiration_block is not None:
+            query += " AND expiration_block = ?"
+            args.append(expiration_block)
+        if claimed is not None:
+            query += " AND claimed = ?"
+            args.append(claimed)
+
+        row = self.conn.execute(query, args).fetchone()
         if row is None:
             return None
 

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -1,0 +1,69 @@
+import os
+import sqlite3
+
+import structlog
+
+from raiden_libs.types import Address
+
+log = structlog.get_logger(__name__)
+SCHEMA_FILENAME = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    'schema.sql',
+)
+
+
+def convert_hex(raw: bytes) -> int:
+    return int(raw, 16)
+
+
+sqlite3.register_converter('HEX_INT', convert_hex)
+
+
+class PFSDatabase:
+    """ Store data that needs to persist between PFS restarts """
+
+    def __init__(self, filename: str, pfs_address: Address):
+        log.info('Opening database at ' + filename)
+        self.conn = sqlite3.connect(
+            filename,
+            detect_types=sqlite3.PARSE_DECLTYPES,
+        )
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys = ON")
+        self.pfs_address = pfs_address
+        self._setup()
+
+    def _setup(self) -> None:
+        """ Make sure that the db is initialized """
+        initialized = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='iou'",
+        ).fetchone()
+
+        if not initialized:
+            # create db schema
+            with self.conn:
+                with open(SCHEMA_FILENAME) as schema_file:
+                    self.conn.executescript(schema_file.read())
+
+    def upsert_iou(self, iou: dict):
+        self.conn.execute("""
+            INSERT OR REPLACE INTO iou (
+                sender, amount, expiration_block, signature
+            ) VALUES (:sender, :amount, :expiration_block, :signature)
+        """, iou)
+
+    def get_iou(self, sender: Address, expiration_block: int):
+        row = self.conn.execute(
+            """
+                SELECT *
+                FROM iou
+                WHERE sender = ? AND expiration_block = ?
+            """,
+            [sender, expiration_block],
+        ).fetchone()
+        if row is None:
+            return None
+
+        iou = dict(zip(row.keys(), row))
+        iou['receiver'] = self.pfs_address
+        return iou

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -75,4 +75,5 @@ class PFSDatabase:
             return None
 
         iou_dict = dict(zip(row.keys(), row))
-        return IOU(receiver=self.pfs_address, **iou_dict)
+        iou_dict['receiver'] = self.pfs_address
+        return IOU.Schema().load(iou_dict)[0]

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -29,6 +29,7 @@ class PFSDatabase:
         self.conn = sqlite3.connect(
             filename,
             detect_types=sqlite3.PARSE_DECLTYPES,
+            isolation_level=None,  # Disable sqlite3 module’s implicit transaction management
         )
         self.conn.row_factory = sqlite3.Row
         self.conn.execute("PRAGMA foreign_keys = ON")

--- a/src/pathfinding_service/exceptions.py
+++ b/src/pathfinding_service/exceptions.py
@@ -17,10 +17,23 @@ class ApiException(Exception):
         return f'{self.__class__.__name__}({self.error_details})'
 
 
+# ### Generic Service Exceptions 20xx ###
+
+
 class InvalidRequest(ApiException):
     """Request arguments failed schema validation"""
     error_code = 2000
     msg = 'Request parameter failed validation. See `error_details`.'
+
+
+class InvalidSignature(ApiException):
+    error_code = 2001
+    msg = 'The signature did not match the signed content'
+
+
+class RequestOutdated(ApiException):
+    error_code = 2002
+    msg = 'The request contains too old timestamps or nonces'
 
 
 # ### BadIOU 21xx ###
@@ -44,18 +57,13 @@ class IOUExpiredTooEarly(BadIOU):
     msg = 'Please use a higher `expiration_block`'
 
 
-class InvalidIOUSignature(BadIOU):
-    error_code = 2104
-    msg = 'The signature did not match the IOU content'
-
-
 class InsufficientServicePayment(BadIOU):
-    error_code = 2105
+    error_code = 2104
     msg = 'The provided payment is lower than service fee'
 
 
 class IOUAlreadyClaimed(BadIOU):
-    error_code = 2106
+    error_code = 2105
     msg = 'The IOU is already claimed. Please start new session with different `expiration_block`.'
 
 

--- a/src/pathfinding_service/exceptions.py
+++ b/src/pathfinding_service/exceptions.py
@@ -52,3 +52,8 @@ class InvalidIOUSignature(BadIOU):
 class InsufficientServicePayment(BadIOU):
     error_code = 2105
     msg = 'The provided payment is lower than service fee'
+
+
+class IOUAlreadyClaimed(BadIOU):
+    error_code = 2106
+    msg = 'The IOU is already claimed. Please start new session with different `expiration_block`.'

--- a/src/pathfinding_service/exceptions.py
+++ b/src/pathfinding_service/exceptions.py
@@ -57,3 +57,8 @@ class InsufficientServicePayment(BadIOU):
 class IOUAlreadyClaimed(BadIOU):
     error_code = 2106
     msg = 'The IOU is already claimed. Please start new session with different `expiration_block`.'
+
+
+class UseThisIOU(BadIOU):
+    error_code = 2106
+    msg = 'Please increase the amount of the existing IOU instead of creating a new one.'

--- a/src/pathfinding_service/exceptions.py
+++ b/src/pathfinding_service/exceptions.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, Optional
+
+
+class ApiException(Exception):
+    """An exception that can be returned via the REST API"""
+    msg: str = 'Unknown Error'
+    http_code: int = 400
+    error_code: int = 0
+    error_details: Optional[Dict[str, Any]] = None
+
+    def __init__(self, msg=None, **details):
+        if msg:
+            self.msg = msg
+        self.error_details = details
+
+    def __str__(self):
+        return f'{self.__class__.__name__}({self.error_details})'
+
+
+class InvalidRequest(ApiException):
+    """Request arguments failed schema validation"""
+    error_code = 2000
+    msg = 'Request parameter failed validation. See `error_details`.'
+
+
+# ### BadIOU 21xx ###
+
+class BadIOU(ApiException):
+    error_code = 2100
+
+
+class MissingIOU(BadIOU):
+    error_code = 2101
+    msg = 'No IOU for service fees has been provided'
+
+
+class WrongIOURecipient(BadIOU):
+    error_code = 2102
+    msg = 'IOU not addressed to the correct receiver'
+
+
+class IOUExpiredTooEarly(BadIOU):
+    error_code = 2103
+    msg = 'Please use a higher `expiration_block`'
+
+
+class InvalidIOUSignature(BadIOU):
+    error_code = 2104
+    msg = 'The signature did not match the IOU content'
+
+
+class InsufficientServicePayment(BadIOU):
+    error_code = 2105
+    msg = 'The provided payment is lower than service fee'

--- a/src/pathfinding_service/model/__init__.py
+++ b/src/pathfinding_service/model/__init__.py
@@ -1,7 +1,9 @@
 from .channel_view import ChannelView
 from .token_network import TokenNetwork
+from .iou import IOU
 
 __all__ = [
     'ChannelView',
     'TokenNetwork',
+    'IOU',
 ]

--- a/src/pathfinding_service/model/iou.py
+++ b/src/pathfinding_service/model/iou.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Type
+from typing import ClassVar, Optional, Type
 
 import marshmallow
 from eth_abi import encode_single
@@ -24,6 +24,7 @@ from raiden_libs.utils import eth_recover
 #     amount: TokenAmount
 #     expiration_block: BlockNumber
 #     signature: Signature
+#     claimed: bool
 #     Schema: ClassVar[Type[marshmallow.Schema]]
 
 #     def is_signature_valid(self):
@@ -46,6 +47,7 @@ class IOU:
     amount: int
     expiration_block: int
     signature: str
+    claimed: Optional[bool] = None
     Schema: ClassVar[Type[marshmallow.Schema]]
 
     def is_signature_valid(self):

--- a/src/pathfinding_service/model/iou.py
+++ b/src/pathfinding_service/model/iou.py
@@ -3,7 +3,7 @@ from typing import ClassVar, Optional, Type
 import marshmallow
 from dataclasses import dataclass, field
 from eth_abi import encode_single
-from eth_utils import to_checksum_address
+from eth_utils import is_same_address
 from marshmallow_dataclass import add_schema
 from web3 import Web3
 
@@ -36,4 +36,4 @@ class IOU:
             recovered_address = eth_recover(packed_data, self.signature)
         except InvalidSignature:
             return False
-        return to_checksum_address(recovered_address) == to_checksum_address(self.sender)
+        return is_same_address(recovered_address, self.sender)

--- a/src/pathfinding_service/model/iou.py
+++ b/src/pathfinding_service/model/iou.py
@@ -7,11 +7,11 @@ from eth_utils import is_same_address
 from marshmallow_dataclass import add_schema
 from web3 import Web3
 
+from raiden.exceptions import InvalidSignature
+from raiden.utils.signer import recover
 from raiden.utils.typing import BlockNumber, Signature, TokenAmount
-from raiden_libs.exceptions import InvalidSignature
 from raiden_libs.marshmallow import HexedBytes
 from raiden_libs.types import Address
-from raiden_libs.utils import eth_recover
 
 
 @add_schema
@@ -33,7 +33,7 @@ class IOU:
             encode_single('uint256', self.expiration_block)
         )
         try:
-            recovered_address = eth_recover(packed_data, self.signature)
+            recovered_address = recover(packed_data, self.signature)
         except InvalidSignature:
             return False
         return is_same_address(recovered_address, self.sender)

--- a/src/pathfinding_service/model/iou.py
+++ b/src/pathfinding_service/model/iou.py
@@ -1,0 +1,61 @@
+from typing import ClassVar, Type
+
+import marshmallow
+from eth_abi import encode_single
+from eth_utils import decode_hex
+from marshmallow_dataclass import dataclass
+from web3 import Web3
+
+from raiden_libs.exceptions import InvalidSignature
+from raiden_libs.utils import eth_recover
+
+# from raiden_libs.types import Address
+# from raiden.utils.typing import (
+#     BlockNumber,
+#     Signature,
+#     TokenAmount,
+# )
+
+
+# @dataclass
+# class IOU:
+#     sender: Address
+#     receiver: Address
+#     amount: TokenAmount
+#     expiration_block: BlockNumber
+#     signature: Signature
+#     Schema: ClassVar[Type[marshmallow.Schema]]
+
+#     def is_signature_valid(self):
+#         packed_data = (
+#             Web3.toBytes(hexstr=self.sender) +
+#             Web3.toBytes(hexstr=self.receiver) +
+#             encode_single('uint256', self.amount) +
+#             encode_single('uint256', self.expiration_block)
+#         )
+#         try:
+#             return eth_recover(packed_data, decode_hex(self.signature)) == self.sender
+#         except InvalidSignature:
+#             return False
+
+
+@dataclass
+class IOU:
+    sender: str
+    receiver: str
+    amount: int
+    expiration_block: int
+    signature: str
+    Schema: ClassVar[Type[marshmallow.Schema]]
+
+    def is_signature_valid(self):
+        packed_data = (
+            Web3.toBytes(hexstr=self.sender) +
+            Web3.toBytes(hexstr=self.receiver) +
+            encode_single('uint256', self.amount) +
+            encode_single('uint256', self.expiration_block)
+        )
+        try:
+            return eth_recover(packed_data, decode_hex(self.signature)) == self.sender
+        except InvalidSignature:
+            return False

--- a/src/pathfinding_service/model/iou.py
+++ b/src/pathfinding_service/model/iou.py
@@ -1,54 +1,36 @@
 from typing import ClassVar, Optional, Type
 
 import marshmallow
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from eth_abi import encode_single
-from eth_utils import decode_hex
+from eth_utils import decode_hex, encode_hex
 from marshmallow_dataclass import add_schema
 from web3 import Web3
 
+from raiden.utils.typing import BlockNumber, Signature, TokenAmount
 from raiden_libs.exceptions import InvalidSignature
+from raiden_libs.types import Address
 from raiden_libs.utils import eth_recover
 
-# from raiden_libs.types import Address
-# from raiden.utils.typing import (
-#     BlockNumber,
-#     Signature,
-#     TokenAmount,
-# )
 
+class HexedBytes(marshmallow.fields.Field):
+    """ Use `bytes` in the dataclass, serialize to hex encoding"""
 
-# @dataclass
-# class IOU:
-#     sender: Address
-#     receiver: Address
-#     amount: TokenAmount
-#     expiration_block: BlockNumber
-#     signature: Signature
-#     claimed: bool
-#     Schema: ClassVar[Type[marshmallow.Schema]]
+    def _serialize(self, value, attr, obj):
+        return encode_hex(value)
 
-#     def is_signature_valid(self):
-#         packed_data = (
-#             Web3.toBytes(hexstr=self.sender) +
-#             Web3.toBytes(hexstr=self.receiver) +
-#             encode_single('uint256', self.amount) +
-#             encode_single('uint256', self.expiration_block)
-#         )
-#         try:
-#             return eth_recover(packed_data, decode_hex(self.signature)) == self.sender
-#         except InvalidSignature:
-#             return False
+    def _deserialize(self, value, attr, data):
+        return decode_hex(value)
 
 
 @add_schema
 @dataclass
 class IOU:
-    sender: str
-    receiver: str
-    amount: int
-    expiration_block: int
-    signature: str
+    sender: Address
+    receiver: Address
+    amount: TokenAmount
+    expiration_block: BlockNumber
+    signature: Signature = field(metadata={"marshmallow_field": HexedBytes()})
     claimed: Optional[bool] = None
     Schema: ClassVar[Type[marshmallow.Schema]]
 
@@ -60,6 +42,6 @@ class IOU:
             encode_single('uint256', self.expiration_block)
         )
         try:
-            return eth_recover(packed_data, decode_hex(self.signature)) == self.sender
+            return eth_recover(packed_data, self.signature) == self.sender
         except InvalidSignature:
             return False

--- a/src/pathfinding_service/model/iou.py
+++ b/src/pathfinding_service/model/iou.py
@@ -1,9 +1,10 @@
 from typing import ClassVar, Optional, Type
 
 import marshmallow
+from dataclasses import dataclass
 from eth_abi import encode_single
 from eth_utils import decode_hex
-from marshmallow_dataclass import dataclass
+from marshmallow_dataclass import add_schema
 from web3 import Web3
 
 from raiden_libs.exceptions import InvalidSignature
@@ -40,6 +41,7 @@ from raiden_libs.utils import eth_recover
 #             return False
 
 
+@add_schema
 @dataclass
 class IOU:
     sender: str

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE iou (
+    sender TEXT NOT NULL,
+    amount HEXINT NOT NULL,
+    expiration_block HEXINT NOT NULL,
+    signature TEXT NOT NULL,
+    PRIMARY KEY (sender, expiration_block)
+);

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -6,3 +6,5 @@ CREATE TABLE iou (
     claimed BOOL NOT NULL,
     PRIMARY KEY (sender, expiration_block)
 );
+CREATE UNIQUE INDEX one_active_session_per_sender
+    ON iou(sender) WHERE NOT claimed;

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -3,5 +3,6 @@ CREATE TABLE iou (
     amount HEXINT NOT NULL,
     expiration_block HEXINT NOT NULL,
     signature TEXT NOT NULL,
+    claimed BOOL NOT NULL,
     PRIMARY KEY (sender, expiration_block)
 );

--- a/src/raiden_libs/marshmallow.py
+++ b/src/raiden_libs/marshmallow.py
@@ -1,0 +1,12 @@
+import marshmallow
+from eth_utils import decode_hex, encode_hex
+
+
+class HexedBytes(marshmallow.fields.Field):
+    """ Use `bytes` in the dataclass, serialize to hex encoding"""
+
+    def _serialize(self, value, attr, obj):
+        return encode_hex(value)
+
+    def _deserialize(self, value, attr, data):
+        return decode_hex(value)

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -328,12 +328,14 @@ def pathfinding_service_full_mock(
     with patch('pathfinding_service.service.BlockchainListener', new=Mock):
         web3_mock = Mock()
         web3_mock.net.version = '1'
+        web3_mock.eth.blockNumber = 1
 
         pathfinding_service = PathfindingService(
             web3=web3_mock,
             contract_manager=contracts_manager,
             registry_address=Address('0xB9633dd9a9a71F22C933bF121d7a22008f66B908'),
             private_key='3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
+            db_filename=':memory:',
         )
         pathfinding_service.token_networks = {
             token_network_model.address: token_network_model,
@@ -358,6 +360,7 @@ def pathfinding_service_mocked_listeners(
             contract_manager=contracts_manager,
             registry_address=Address(''),
             private_key='3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
+            db_filename=':memory:',
         )
 
         yield pathfinding_service

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -37,6 +37,7 @@ def test_pfs_with_mocked_client(
         contract_manager=contracts_manager,
         registry_address=token_network_registry_contract.address,
         required_confirmations=1,
+        db_filename=':memory:',
         poll_interval=0,
         private_key='3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
     )

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -96,6 +96,11 @@ def test_process_payment(
     iou = make_iou(priv_key, pfs.address, amount=2)
     process_payment(iou, pfs)
 
+    # Make sure the client does not create new sessions unnecessarily
+    iou = make_iou(priv_key, pfs.address, expiration_block=20000)
+    with pytest.raises(exceptions.UseThisIOU):
+        process_payment(iou, pfs)
+
     # Complain if the IOU has been claimed
     iou = make_iou(priv_key, pfs.address, amount=3)
     pfs.database.conn.execute("UPDATE iou SET claimed=1")

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -70,7 +70,7 @@ def test_process_payment_errors(
     # bad signature
     iou = make_iou(get_random_privkey(), pfs.address)
     iou['signature'] = hex(int(iou['signature'], 16) + 1)
-    with pytest.raises(exceptions.InvalidIOUSignature):
+    with pytest.raises(exceptions.InvalidSignature):
         process_payment(iou, pfs)
 
     # payment too low

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -2,11 +2,12 @@ import pytest
 
 import pathfinding_service.exceptions as exceptions
 from pathfinding_service.api.rest import process_payment
+from pathfinding_service.model import IOU
 from raiden_contracts.utils import sign_one_to_n_iou
 from raiden_libs.utils import private_key_to_address
 
 
-def make_iou(sender_priv_key, receiver, amount=1, expiration_block=10000):
+def make_iou(sender_priv_key, receiver, amount=1, expiration_block=10000) -> dict:
     iou = {
         'sender': private_key_to_address(sender_priv_key),
         'receiver': receiver,
@@ -28,9 +29,9 @@ def test_load_and_save_iou(
     get_random_privkey,
 ):
     pfs = pathfinding_service_mocked_listeners
-    iou = make_iou(get_random_privkey(), pfs.address)
+    iou = IOU(**make_iou(get_random_privkey(), pfs.address))  # type: ignore
     pfs.database.upsert_iou(iou)
-    stored_iou = pfs.database.get_iou(iou['sender'], iou['expiration_block'])
+    stored_iou = pfs.database.get_iou(iou.sender, iou.expiration_block)
     assert stored_iou == iou
 
 

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -1,0 +1,89 @@
+import pytest
+
+import pathfinding_service.exceptions as exceptions
+from pathfinding_service.api.rest import process_payment
+from raiden_contracts.utils import sign_one_to_n_iou
+from raiden_libs.utils import private_key_to_address
+
+
+def make_iou(sender_priv_key, receiver, amount=1, expiration_block=10000):
+    iou = {
+        'sender': private_key_to_address(sender_priv_key),
+        'receiver': receiver,
+        'amount': amount,
+        'expiration_block': expiration_block,
+    }
+    iou['signature'] = sign_one_to_n_iou(
+        privatekey=sender_priv_key,
+        sender=iou['sender'],
+        receiver=receiver,
+        amount=amount,
+        expiration=expiration_block,
+    ).hex()
+    return iou
+
+
+def test_load_and_save_iou(
+    pathfinding_service_mocked_listeners,
+    get_random_privkey,
+):
+    pfs = pathfinding_service_mocked_listeners
+    iou = make_iou(get_random_privkey(), pfs.address)
+    pfs.database.upsert_iou(iou)
+    stored_iou = pfs.database.get_iou(iou['sender'], iou['expiration_block'])
+    assert stored_iou == iou
+
+
+def test_process_payment_errors(
+    pathfinding_service_mocked_listeners,
+    get_random_privkey,
+    get_random_address,
+    web3,
+):
+    pfs = pathfinding_service_mocked_listeners
+    pfs.service_fee = 1
+
+    # first make sure that it usually doesn't raise errors
+    iou = make_iou(get_random_privkey(), pfs.address)
+    process_payment(iou, pfs)
+
+    # malformed
+    iou = make_iou(get_random_privkey(), pfs.address)
+    del iou['amount']
+    with pytest.raises(exceptions.InvalidRequest):
+        process_payment(iou, pfs)
+
+    # wrong recipient
+    iou = make_iou(get_random_privkey(), get_random_address())
+    with pytest.raises(exceptions.WrongIOURecipient):
+        process_payment(iou, pfs)
+
+    # expires too early
+    iou = make_iou(get_random_privkey(), pfs.address, expiration_block=web3.eth.blockNumber + 5)
+    with pytest.raises(exceptions.IOUExpiredTooEarly):
+        process_payment(iou, pfs)
+
+    # bad signature
+    iou = make_iou(get_random_privkey(), pfs.address)
+    iou['signature'] = hex(int(iou['signature'], 16) + 1)
+    with pytest.raises(exceptions.InvalidIOUSignature):
+        process_payment(iou, pfs)
+
+    # payment too low
+    pfs.service_fee = 2
+    iou = make_iou(get_random_privkey(), pfs.address)
+    with pytest.raises(exceptions.InsufficientServicePayment):
+        process_payment(iou, pfs)
+
+
+def test_process_payment(
+    pathfinding_service_mocked_listeners,
+    get_random_privkey,
+):
+    pfs = pathfinding_service_mocked_listeners
+    pfs.service_fee = 1
+    iou = make_iou(get_random_privkey(), pfs.address)
+    process_payment(iou, pfs)
+
+    with pytest.raises(exceptions.InsufficientServicePayment):
+        process_payment(iou, pfs)

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -3,12 +3,13 @@ from eth_utils import encode_hex
 
 import pathfinding_service.exceptions as exceptions
 from pathfinding_service.api.rest import process_payment
+from pathfinding_service.config import MIN_IOU_EXPIRY
 from pathfinding_service.model import IOU
 from raiden_contracts.utils import sign_one_to_n_iou
 from raiden_libs.utils import private_key_to_address
 
 
-def make_iou(sender_priv_key, receiver, amount=1, expiration_block=10000) -> dict:
+def make_iou(sender_priv_key, receiver, amount=1, expiration_block=MIN_IOU_EXPIRY + 100) -> dict:
     iou = {
         'sender': private_key_to_address(sender_priv_key),
         'receiver': receiver,

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -29,7 +29,7 @@ def test_load_and_save_iou(
     get_random_privkey,
 ):
     pfs = pathfinding_service_mocked_listeners
-    iou = IOU(**make_iou(get_random_privkey(), pfs.address))  # type: ignore
+    iou = IOU(**make_iou(get_random_privkey(), pfs.address))
     iou.claimed = False
     pfs.database.upsert_iou(iou)
     stored_iou = pfs.database.get_iou(iou.sender, iou.expiration_block)

--- a/tests/pathfinding/test_rest.py
+++ b/tests/pathfinding/test_rest.py
@@ -1,16 +1,18 @@
 import gc
+from datetime import datetime, timedelta
 from typing import List
 
 import gevent
 import pkg_resources
 import requests
-from eth_utils import to_normalized_address
+from eth_utils import encode_hex, to_normalized_address
 
 import pathfinding_service.exceptions as exceptions
 from pathfinding_service import PathfindingService
 from pathfinding_service.api.rest import DEFAULT_MAX_PATHS, ServiceApi
-from pathfinding_service.model import TokenNetwork
+from pathfinding_service.model import IOU, TokenNetwork
 from raiden_libs.types import Address
+from raiden_libs.utils import eth_sign, pack_data, private_key_to_address
 
 from .test_payment import make_iou
 
@@ -198,6 +200,71 @@ def test_get_info(
         'message': 'PLACEHOLDER FOR ADDITIONAL MESSAGE BY THE PFS',
     }
     # killen aller greenlets
+    gevent.killall(
+        [obj for obj in gc.get_objects() if isinstance(obj, gevent.Greenlet)],
+    )
+
+
+#
+# tests for iou endpoint
+#
+
+def test_get_iou(
+    api_sut: ServiceApi,
+    api_url: str,
+    pathfinding_service_full_mock: PathfindingService,
+    token_network_model: TokenNetwork,
+    get_random_privkey,
+):
+    privkey = get_random_privkey()
+    sender = private_key_to_address(privkey)
+    url = api_url + f'/{token_network_model.address}/payment/iou'
+
+    def make_params(timestamp: datetime):
+        params = {
+            'sender': sender,
+            'receiver': api_sut.pathfinding_service.address,
+            'timestamp': timestamp.isoformat(),
+        }
+        params['signature'] = encode_hex(eth_sign(
+            privkey,
+            pack_data(
+                ['address', 'address', 'string'],
+                [params['sender'], params['receiver'], params['timestamp']],
+            ),
+        ))
+        return params
+
+    # Request withou IOU in database
+    params = make_params(datetime.utcnow())
+    response = requests.get(url, params=params)
+    assert response.status_code == 200, response.json()
+    assert response.json() == {'last_iou': None}
+
+    # Add IOU to database
+    iou_dict = make_iou(privkey, api_sut.pathfinding_service.address)
+    iou = IOU.Schema().load(iou_dict)[0]
+    iou.claimed = False
+    api_sut.pathfinding_service.database.upsert_iou(iou)
+
+    # Is returned IOU the one save into the db?
+    response = requests.get(url, params=params)
+    assert response.status_code == 200, response.json()
+    assert response.json()['last_iou'] == iou_dict
+
+    # Invalid signatures must fail
+    params['signature'] = hex(int(params['signature'], 16) + 1)
+    response = requests.get(url, params=params)
+    assert response.status_code == 400, response.json()
+    assert response.json()['error_code'] == exceptions.InvalidSignature.error_code
+
+    # Timestamp must no be too old to prevent replay attacks
+    params = make_params(datetime.utcnow() - timedelta(days=1))
+    response = requests.get(url, params=params)
+    assert response.status_code == 400, response.json()
+    assert response.json()['error_code'] == exceptions.RequestOutdated.error_code
+
+    # kill all running greenlets
     gevent.killall(
         [obj for obj in gc.get_objects() if isinstance(obj, gevent.Greenlet)],
     )

--- a/tests/pathfinding/test_rest.py
+++ b/tests/pathfinding/test_rest.py
@@ -5,14 +5,16 @@ from typing import List
 import gevent
 import pkg_resources
 import requests
-from eth_utils import encode_hex, to_normalized_address
+from eth_utils import decode_hex, encode_hex, to_normalized_address
 
 import pathfinding_service.exceptions as exceptions
 from pathfinding_service import PathfindingService
 from pathfinding_service.api.rest import DEFAULT_MAX_PATHS, ServiceApi
 from pathfinding_service.model import IOU, TokenNetwork
+from raiden.utils.signer import LocalSigner
+from raiden.utils.signing import pack_data
 from raiden_libs.types import Address
-from raiden_libs.utils import eth_sign, pack_data, private_key_to_address
+from raiden_libs.utils import private_key_to_address
 
 from .test_payment import make_iou
 
@@ -226,8 +228,8 @@ def test_get_iou(
             'receiver': api_sut.pathfinding_service.address,
             'timestamp': timestamp.isoformat(),
         }
-        params['signature'] = encode_hex(eth_sign(
-            privkey,
+        local_signer = LocalSigner(private_key=decode_hex(privkey))
+        params['signature'] = encode_hex(local_signer.sign(
             pack_data(
                 ['address', 'address', 'string'],
                 [params['sender'], params['receiver'], params['timestamp']],

--- a/tests/pathfinding/test_rest.py
+++ b/tests/pathfinding/test_rest.py
@@ -235,10 +235,10 @@ def test_get_iou(
         ))
         return params
 
-    # Request withou IOU in database
+    # Request without IOU in database
     params = make_params(datetime.utcnow())
     response = requests.get(url, params=params)
-    assert response.status_code == 200, response.json()
+    assert response.status_code == 404, response.json()
     assert response.json() == {'last_iou': None}
 
     # Add IOU to database


### PR DESCRIPTION
In addition to the main feature, two things in this PR need review/discussion:

## Using marshmallow for serialization/deserialization/validation
I tried to consolidate the following tasks into a single dataclass:
* validating data passed via HTTP
* serializing data for HTTP responses
* serializing into basic types for db storage
* providing detailed types for typechecking
Have a look at the `IOU` and `IOURequest` classes and check if this is a good way to do this. We might also compare with raiden.

## Handling exceptions with error codes
All subclasses of `APIException` will be automatically converted into proper HTTP error responses when raised. This allows raising errors in all functions instead of only allowing a return from the `Resource`. Right now I created a separate `exceptions.py` for the PFS, but if we keep this approach we probably want to move all or part of the exceptions into `raiden_libs`. Are there any approaches to error code in other raiden projects?

Required followups:
* Add error codes to spec
* Check deposit in UDC

closes #149