### PR TITLE
Remove `sync_start_block` from `load_state`

### DIFF
--- a/src/monitoring_service/database.py
+++ b/src/monitoring_service/database.py
@@ -240,12 +240,8 @@ class SharedDatabase:
             [tx_hash],
         )
 
-    def load_state(self, sync_start_block: int) -> MonitoringServiceState:
+    def load_state(self) -> MonitoringServiceState:
         """ Load MS state from db or return a new empty state if not saved one is present
-
-        An empty state is initialized with `latest_known_block =
-        sync_start_block - 1`. If a saved state is present, `sync_start_block`
-        is ignored.
         """
         blockchain = self.conn.execute("SELECT * FROM blockchain").fetchone()
         token_network_addresses = [

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -98,7 +98,7 @@ class MonitoringService:
             receiver=self.address,
             msc_address=monitor_contract_address,
         )
-        ms_state = self.database.load_state(sync_start_block)
+        ms_state = self.database.load_state()
 
         self.bcl = BlockchainListener(
             web3=self.web3,

--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -37,7 +37,7 @@ class RequestCollector(gevent.Greenlet):
         self.private_key = private_key
         self.state_db = state_db
 
-        state = self.state_db.load_state(0)
+        state = self.state_db.load_state()
         try:
             self.matrix_listener = MatrixListener(
                 private_key=private_key,

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -105,7 +105,7 @@ def get_signed_monitor_request(
 @pytest.fixture
 def context(ms_database):
     return Context(
-        ms_state=ms_database.load_state(sync_start_block=0),
+        ms_state=ms_database.load_state(),
         db=ms_database,
         w3=Mock(),
         contract_manager=Mock(),


### PR DESCRIPTION
This is left over from the time where we accepted a `sync_start_block`
parameter on the command line. Now we either start from the saved sync
block or from 0 if none has been saved before.

Closes https://github.com/raiden-network/raiden-services/issues/168.