### PR TITLE
Update to latest raiden-contracts release

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,4 @@ exclude_lines =
 ignore_errors = True
 omit =
     tests/*
+    setup.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 #git+https://github.com/raiden-network/raiden-contracts.git
-git+https://github.com/raiden-network/raiden.git
+git+https://github.com/raiden-network/raiden.git@f7fdcf786dbe270523bec214e43c825cc520889e
 
-raiden-contracts==0.14
+raiden-contracts==0.15.0
 
 structlog==18.2.0
 colorama==0.3.9
 
 click==6.7
-coincurve==8.0.2
+coincurve==11.0.0
 
 web3==4.7.1
 eth-utils==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 #git+https://github.com/raiden-network/raiden-contracts.git
-git+https://github.com/raiden-network/raiden.git@4c38ec6b4562b3fe12476fd1a0f26b23124078ad
+git+https://github.com/raiden-network/raiden.git
 
-raiden-contracts==0.10.1
+raiden-contracts==0.14
 
 structlog==18.2.0
 colorama==0.3.9

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup
 REQ_REPLACE = {
     'git+https://github.com/matrix-org/matrix-python-sdk.git': 'matrix-client',
     # 'git+https://github.com/raiden-network/raiden-contracts.git': 'raiden-contracts',
-    'git+https://github.com/raiden-network/raiden.git': 'raiden',
+    'git+https://github.com/raiden-network/raiden.git@f7fdcf786dbe270523bec214e43c825cc520889e': 'raiden',
 }
 
 DESCRIPTION = 'Raiden Services contain additional tools for the Raiden Network.'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup
 REQ_REPLACE = {
     'git+https://github.com/matrix-org/matrix-python-sdk.git': 'matrix-client',
     # 'git+https://github.com/raiden-network/raiden-contracts.git': 'raiden-contracts',
-    'git+https://github.com/raiden-network/raiden.git@4c38ec6b4562b3fe12476fd1a0f26b23124078ad': 'raiden',
+    'git+https://github.com/raiden-network/raiden.git': 'raiden',
 }
 
 DESCRIPTION = 'Raiden Services contain additional tools for the Raiden Network.'

--- a/src/raiden_libs/test/fixtures/address.py
+++ b/src/raiden_libs/test/fixtures/address.py
@@ -1,27 +1,7 @@
-import random
-from typing import Callable
-
 import pytest
 from eth_utils import denoms, is_address
 
-from raiden_libs.utils import UINT256_MAX, private_key_to_address
-
-
-@pytest.fixture
-def get_random_privkey() -> Callable:
-    """Returns a random private key"""
-    return lambda: "0x%064x" % random.randint(
-        1,
-        UINT256_MAX,
-    )
-
-
-@pytest.fixture
-def get_random_address(get_random_privkey) -> Callable:
-    """Returns a random valid ethereum address"""
-    def f():
-        return private_key_to_address(get_random_privkey())
-    return f
+from raiden_libs.utils import private_key_to_address
 
 
 @pytest.fixture(scope='session')

--- a/src/raiden_libs/test/fixtures/client.py
+++ b/src/raiden_libs/test/fixtures/client.py
@@ -1,5 +1,6 @@
 import pytest
 
+from raiden_contracts.tests.utils import get_random_privkey
 from raiden_libs.test.mocks.client import MockRaidenNode
 
 
@@ -13,7 +14,6 @@ def client_registry():
 def generate_raiden_client(
         token_network,
         custom_token,
-        get_random_privkey,
         client_registry,
         send_funds,
         ethereum_tester,

--- a/src/raiden_libs/test/fixtures/web3.py
+++ b/src/raiden_libs/test/fixtures/web3.py
@@ -23,42 +23,6 @@ def ethereum_tester():
     return EthereumTester(PyEVMBackend())
 
 
-@pytest.fixture
-def deploy_contract_txhash(revert_chain):
-    """Returns a function that deploys a compiled contract, returning a txhash"""
-    def fn(
-            web3,
-            deployer_address,
-            abi,
-            bytecode,
-            args,
-    ):
-        if args is None:
-            args = []
-        contract = web3.eth.contract(abi=abi, bytecode=bytecode)
-        return contract.constructor(*args).transact({'from': deployer_address})
-    return fn
-
-
-@pytest.fixture
-def deploy_contract(revert_chain, deploy_contract_txhash):
-    """Returns a function that deploys a compiled contract"""
-    def fn(
-            web3,
-            deployer_address,
-            abi,
-            bytecode,
-            args,
-    ):
-        contract = web3.eth.contract(abi=abi, bytecode=bytecode)
-        txhash = deploy_contract_txhash(web3, deployer_address, abi, bytecode, args)
-        contract_address = web3.eth.getTransactionReceipt(txhash).contractAddress
-        web3.testing.mine(1)
-
-        return contract(contract_address)
-    return fn
-
-
 @pytest.fixture(scope='session')
 def patch_genesis_gas_limit():
     import eth_tester.backends.pyevm.main as pyevm_main
@@ -117,18 +81,3 @@ def wait_for_transaction(web3):
             block_diff = web3.eth.blockNumber - block
             assert block_diff < max_blocks
     return wait_for_transaction
-
-
-@pytest.fixture
-def revert_chain(web3: Web3):
-    """Reverts chain to its initial state.
-    If this fixture is used, the chain will revert on each test teardown.
-
-    This is useful especially when using ethereum tester - its log filtering
-    is very slow once enough events are present on-chain.
-
-    Note that `deploy_contract` fixture uses `revert_chain` by default.
-    """
-    snapshot_id = web3.testing.snapshot()
-    yield
-    web3.testing.revert(snapshot_id)

--- a/tests/monitoring/fixtures/contracts.py
+++ b/tests/monitoring/fixtures/contracts.py
@@ -3,7 +3,7 @@ import pytest
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def contracts_manager():
     return ContractManager(contracts_precompiled_path())
 

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -10,6 +10,7 @@ from request_collector.server import RequestCollector
 from monitoring_service.database import Database
 from monitoring_service.service import MonitoringService
 from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.tests.utils import get_random_privkey
 from raiden_libs.utils import private_key_to_address
 
 log = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ KEYSTORE_PASSWORD = 'password'
 
 
 @pytest.fixture
-def server_private_key(get_random_privkey, ethereum_tester):
+def server_private_key(ethereum_tester):
     key = get_random_privkey()
     ethereum_tester.add_account(key)
     return key

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -31,7 +31,6 @@ def test_crash(
     token_network_registry_contract,
     monitoring_service_contract,
     user_deposit_contract,
-    get_random_address,
     tmpdir,
     generate_raiden_clients,
     token_network,

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -25,6 +25,7 @@ from monitoring_service.handlers import (
 )
 from monitoring_service.states import HashedBalanceProof, MonitorRequest, UnsignedMonitorRequest
 from raiden_contracts.constants import ChannelState
+from raiden_contracts.tests.utils import get_random_privkey
 from raiden_libs.utils import private_key_to_address
 
 DEFAULT_TOKEN_NETWORK_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -604,7 +605,6 @@ def test_mr_available_before_channel_triggers_monitor_call(
 
 def test_mr_with_unknown_signatures(
     context: Context,
-    get_random_privkey,
 ):
     """ The signatures are valid but don't belong to the participants.
     """

--- a/tests/monitoring/monitoring_service/test_states.py
+++ b/tests/monitoring/monitoring_service/test_states.py
@@ -12,25 +12,9 @@ from monitoring_service.states import (
 )
 from raiden.constants import UINT64_MAX, UINT256_MAX
 from raiden_contracts.constants import ChannelState
+from raiden_contracts.tests.utils import get_random_address, get_random_privkey
 from raiden_libs.types import ChannelIdentifier
 from raiden_libs.utils import keccak, private_key_to_address
-
-
-@pytest.fixture
-def get_random_private_key() -> Callable:
-    """Returns a function returning a random private key"""
-    return lambda: "0x%064x" % random.randint(
-        1,
-        UINT256_MAX,
-    )
-
-
-@pytest.fixture
-def get_random_address(get_random_private_key) -> Callable:
-    """Returns a function returning a random valid ethereum address"""
-    def f():
-        return private_key_to_address(get_random_private_key())
-    return f
 
 
 @pytest.fixture
@@ -42,7 +26,7 @@ def get_random_identifier() -> Callable:
 
 
 @pytest.fixture
-def get_random_monitor_request(get_random_address, get_random_private_key, get_random_identifier):
+def get_random_monitor_request(get_random_identifier):
     def f():
         contract_address = get_random_address()
         channel_identifier = get_random_identifier()
@@ -55,8 +39,8 @@ def get_random_monitor_request(get_random_address, get_random_private_key, get_r
         additional_hash = encode_hex(keccak(additional_hash_data.encode()))
         chain_id = 1
 
-        privkey = get_random_private_key()
-        privkey_non_closing = get_random_private_key()
+        privkey = get_random_privkey()
+        privkey_non_closing = get_random_privkey()
 
         bp = HashedBalanceProof(  # type: ignore
             channel_identifier=channel_identifier,
@@ -94,7 +78,7 @@ def test_save_and_load_mr(get_random_monitor_request, ms_database):
     assert loaded_request == request
 
 
-def test_save_and_load_channel(ms_database, get_random_address):
+def test_save_and_load_channel(ms_database):
     token_network_address = get_random_address()
     ms_database.conn.execute(
         "INSERT INTO token_network (address) VALUES (?)",

--- a/tests/monitoring/request_collector/test_server.py
+++ b/tests/monitoring/request_collector/test_server.py
@@ -4,10 +4,11 @@ from eth_utils import decode_hex, to_checksum_address
 from raiden.messages import RequestMonitoring, SignedBlindedBalanceProof
 from raiden.tests.utils.messages import make_balance_proof
 from raiden.utils.signer import LocalSigner
+from raiden_contracts.tests.utils import get_random_privkey
 
 
 @pytest.fixture
-def build_request_monitoring(get_random_privkey):
+def build_request_monitoring():
     signer = LocalSigner(decode_hex(get_random_privkey()))
     non_closing_signer = LocalSigner(decode_hex(get_random_privkey()))
 

--- a/tests/pathfinding/fixtures/contracts.py
+++ b/tests/pathfinding/fixtures/contracts.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 import pytest
 
 from pathfinding_service.model.token_network import TokenNetwork
@@ -17,13 +15,5 @@ def contracts_manager():
 
 
 @pytest.fixture
-def token_network_model(
-    add_and_register_token: Callable,
-) -> TokenNetwork:
-    token = add_and_register_token(
-        initial_amount=1000000,
-        decimals=18,
-        token_name='PFSTestToken',
-        token_symbol='PFS',
-    )
-    return TokenNetwork(token.address, token.address)
+def token_network_model(token_network) -> TokenNetwork:
+    return TokenNetwork(token_network.address, token_network.address)

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -21,7 +21,6 @@ def test_pfs_with_mocked_client(
     token_network_registry_contract,
     channel_descriptions_case_1: List,
     generate_raiden_clients,
-    get_random_address,
     wait_for_blocks,
 ):
     """ Instantiates some MockClients and the PathfindingService.

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -5,6 +5,7 @@ import pathfinding_service.exceptions as exceptions
 from pathfinding_service.api.rest import process_payment
 from pathfinding_service.config import MIN_IOU_EXPIRY
 from pathfinding_service.model import IOU
+from raiden_contracts.tests.utils import get_random_address, get_random_privkey
 from raiden_contracts.utils import sign_one_to_n_iou
 from raiden_libs.utils import private_key_to_address
 
@@ -26,10 +27,7 @@ def make_iou(sender_priv_key, receiver, amount=1, expiration_block=MIN_IOU_EXPIR
     return iou
 
 
-def test_load_and_save_iou(
-    pathfinding_service_mocked_listeners,
-    get_random_privkey,
-):
+def test_load_and_save_iou(pathfinding_service_mocked_listeners):
     pfs = pathfinding_service_mocked_listeners
     iou_dict = make_iou(get_random_privkey(), pfs.address)
     iou = IOU.Schema().load(iou_dict)[0]
@@ -39,12 +37,7 @@ def test_load_and_save_iou(
     assert stored_iou == iou
 
 
-def test_process_payment_errors(
-    pathfinding_service_mocked_listeners,
-    get_random_privkey,
-    get_random_address,
-    web3,
-):
+def test_process_payment_errors(pathfinding_service_mocked_listeners, web3):
     pfs = pathfinding_service_mocked_listeners
     pfs.service_fee = 1
 
@@ -81,10 +74,7 @@ def test_process_payment_errors(
         process_payment(iou, pfs)
 
 
-def test_process_payment(
-    pathfinding_service_mocked_listeners,
-    get_random_privkey,
-):
+def test_process_payment(pathfinding_service_mocked_listeners):
     pfs = pathfinding_service_mocked_listeners
     pfs.service_fee = 1
     priv_key = get_random_privkey()

--- a/tests/pathfinding/test_rest.py
+++ b/tests/pathfinding/test_rest.py
@@ -13,6 +13,7 @@ from pathfinding_service.api.rest import DEFAULT_MAX_PATHS, ServiceApi
 from pathfinding_service.model import IOU, TokenNetwork
 from raiden.utils.signer import LocalSigner
 from raiden.utils.signing import pack_data
+from raiden_contracts.tests.utils import get_random_privkey
 from raiden_libs.types import Address
 from raiden_libs.utils import private_key_to_address
 
@@ -31,7 +32,6 @@ def test_get_paths_validation(
     initiator_address: str,
     target_address: str,
     token_network_model: TokenNetwork,
-    get_random_privkey,
 ):
     url = api_url + f'/{token_network_model.address}/paths'
     default_params = {
@@ -216,7 +216,6 @@ def test_get_iou(
     api_url: str,
     pathfinding_service_full_mock: PathfindingService,
     token_network_model: TokenNetwork,
-    get_random_privkey,
 ):
     privkey = get_random_privkey()
     sender = private_key_to_address(privkey)


### PR DESCRIPTION
The problems are solved by using the more recently maintained fixtures
from the raiden-contracts repo. Less code duplication, more brittle
cross repo dependencies.

Currently throws import errors due to circular import in raiden-contracts. Those are fixed in https://github.com/raiden-network/raiden-contracts/commit/ef561cbc2e396e239d97b97b40e610415d513f87 and should thus disappear once raiden gets a new contracts version. 

Closes https://github.com/raiden-network/raiden-services/issues/166.