### PR TITLE
Disable gevent `thread` resolver for PFS

### DIFF
--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -1,5 +1,7 @@
 """Console script for pathfinding_service."""
-from gevent import monkey  # isort:skip # noqa
+from gevent import monkey, config  # isort:skip # noqa
+# there were some issues with the 'thread' resolver, remove it from the options
+config.resolver = ['dnspython', 'ares', 'block'] # noqa
 monkey.patch_all()  # isort:skip # noqa
 
 import json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
-from gevent import monkey  # isort:skip # noqa
+from gevent import monkey, config  # isort:skip # noqa
+# there were some issues with the 'thread' resolver, remove it from the options
+config.resolver = ['dnspython', 'ares', 'block'] # noqa
 monkey.patch_all()  # isort:skip # noqa
 
 import gc


### PR DESCRIPTION
It was causing `socket.gaierror: [Errno -2] Name or service not known`
errors when run inside docker.