### PR TITLE
Mock MatrixListener in tests

### DIFF
--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -19,7 +19,7 @@ KEYSTORE_FILE_NAME = 'keystore.txt'
 KEYSTORE_PASSWORD = 'password'
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def channel_descriptions_case_1() -> List:
     """ Creates a network with some edge cases.
 
@@ -202,7 +202,7 @@ def populate_token_network_random(
         )
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def populate_token_network() -> Callable:
     def populate_token_network(
         token_network: TokenNetwork,
@@ -325,7 +325,8 @@ def pathfinding_service_full_mock(
     contracts_manager: ContractManager,
     token_network_model: TokenNetwork,
 ) -> Generator[PathfindingService, None, None]:
-    with patch('pathfinding_service.service.BlockchainListener', new=Mock):
+    with patch('pathfinding_service.service.BlockchainListener', new=Mock), \
+            patch('pathfinding_service.service.MatrixListener', new=Mock):
         web3_mock = Mock()
         web3_mock.net.version = '1'
         web3_mock.eth.blockNumber = 1
@@ -351,10 +352,8 @@ def pathfinding_service_mocked_listeners(
     web3: Web3,
 ) -> Generator[PathfindingService, None, None]:
     """ Returns a PathfindingService with mocked blockchain listeners. """
-    with patch(
-        'pathfinding_service.service.BlockchainListener',
-        new=BlockchainListenerMock,
-    ):
+    with patch('pathfinding_service.service.BlockchainListener', new=BlockchainListenerMock), \
+            patch('pathfinding_service.service.MatrixListener', new=Mock):
         pathfinding_service = PathfindingService(
             web3=web3,
             contract_manager=contracts_manager,

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -5,6 +5,7 @@ interaction of many moving parts - yet, it is currently really slow.
 Therefore, usually mocked_integration should be used.
 """
 from typing import List
+from unittest.mock import Mock, patch
 
 import gevent
 
@@ -31,15 +32,16 @@ def test_pfs_with_mocked_client(
     clients = generate_raiden_clients(7)
     token_network_address = clients[0].contract.address
 
-    pfs = PathfindingService(
-        web3=web3,
-        contract_manager=contracts_manager,
-        registry_address=token_network_registry_contract.address,
-        required_confirmations=1,
-        db_filename=':memory:',
-        poll_interval=0,
-        private_key='3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
-    )
+    with patch('pathfinding_service.service.MatrixListener', new=Mock):
+        pfs = PathfindingService(
+            web3=web3,
+            contract_manager=contracts_manager,
+            registry_address=token_network_registry_contract.address,
+            required_confirmations=1,
+            db_filename=':memory:',
+            poll_interval=0,
+            private_key='3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266',
+        )
 
     # greenlet needs to be started and context switched to
     pfs.start()


### PR DESCRIPTION
Tests should not connect to real matrix rooms. This is slow and makes
tests flaky.