### PR TITLE
Include schema files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include README.md
 include CHANGELOG.md
+include src/pathfinding_service/schema.sql
+include src/monitoring_service/schema.sql


### PR DESCRIPTION
They are required to run the services and since they are not python
files, they need to be included explicitly.

This should solve @rakanalh's error when running from the released version.