### PR TITLE
Fix db path creation for local dbs

### DIFF
--- a/src/monitoring_service/database.py
+++ b/src/monitoring_service/database.py
@@ -47,7 +47,7 @@ class SharedDatabase:
 
     def __init__(self, filename: str, allow_create: bool = False):
         log.info('Opening database', filename=filename)
-        if filename != ':memory:':
+        if filename != ':memory:' and os.path.dirname(filename):
             os.makedirs(os.path.dirname(filename), exist_ok=True)
         mode = 'rwc' if allow_create else 'rw'
         self.conn = sqlite3.connect(

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -26,7 +26,7 @@ class PFSDatabase:
 
     def __init__(self, filename: str, pfs_address: Address):
         log.info('Opening database at ' + filename)
-        if filename != ':memory:':
+        if filename != ':memory:' and os.path.dirname(filename):
             os.makedirs(os.path.dirname(filename), exist_ok=True)
         self.conn = sqlite3.connect(
             filename,


### PR DESCRIPTION
In accd17fd7b298057260848a604da321e28676855 a bug has been introduced
which causes failure on plain db names without specifying a path.

I thought `os.makedirs(os.path.dirname(filename), exist_ok=True)` would
work in all cases, but if not path segment is in `filename`, the
`dirname(filename) == ''` which is not a valid path for `makedirs`.