### PR TITLE
Fix types after declaring raiden as typed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 #git+https://github.com/raiden-network/raiden-contracts.git
-git+https://github.com/raiden-network/raiden.git@928dc306c75b2036b13a3af0c2b2fa8bf15f18a1
+git+https://github.com/raiden-network/raiden.git@ffbfcee9405a95e6a64d2282dc174d4b020d68f5
 
 raiden-contracts==0.17.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 #git+https://github.com/raiden-network/raiden-contracts.git
 git+https://github.com/raiden-network/raiden.git@928dc306c75b2036b13a3af0c2b2fa8bf15f18a1
 
-raiden-contracts==0.16.0
+raiden-contracts==0.17.0
 
 structlog==18.2.0
 colorama==0.3.9
 
-click==6.7
+click>=7.0
 coincurve==11.0.0
 
 web3==4.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 current_version = major
 
 [flake8]
-ignore = E701, E731, E402, W504, C814, E241
+ignore = E701, E731, E402, W504, C814, E241, B008
 max-line-length = 99
 exclude = build,dist,.git,.venv
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup
 REQ_REPLACE = {
     'git+https://github.com/matrix-org/matrix-python-sdk.git': 'matrix-client',
     # 'git+https://github.com/raiden-network/raiden-contracts.git': 'raiden-contracts',
-    'git+https://github.com/raiden-network/raiden.git@928dc306c75b2036b13a3af0c2b2fa8bf15f18a1': 'raiden',
+    'git+https://github.com/raiden-network/raiden.git@ffbfcee9405a95e6a64d2282dc174d4b020d68f5': 'raiden',
 }
 
 DESCRIPTION = 'Raiden Services contain additional tools for the Raiden Network.'

--- a/src/monitoring_service/blockchain.py
+++ b/src/monitoring_service/blockchain.py
@@ -19,7 +19,7 @@ from monitoring_service.events import (
     UpdatedHeadBlockEvent,
 )
 from monitoring_service.states import BlockchainState
-from raiden.utils.typing import ABI, Address, BlockNumber
+from raiden.utils.typing import ABI, BlockNumber
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_TOKEN_NETWORK,
@@ -29,6 +29,7 @@ from raiden_contracts.constants import (
     MonitoringServiceEvent,
 )
 from raiden_contracts.contract_manager import ContractManager
+from raiden_libs.types import Address, TokenNetworkAddress
 
 log = structlog.get_logger(__name__)
 
@@ -131,14 +132,14 @@ class BlockchainListener:
 
     def _get_token_networks_events(
             self,
-            network_address: Address,
+            network_address: TokenNetworkAddress,
             from_block: BlockNumber,
             to_block: BlockNumber,
     ) -> List[Dict]:
         return query_blockchain_events(
             web3=self.w3,
             contract_manager=self.contract_manager,
-            contract_address=network_address,
+            contract_address=Address(network_address),
             contract_name=CONTRACT_TOKEN_NETWORK,
             topics=[None],
             from_block=from_block,
@@ -167,7 +168,7 @@ class BlockchainListener:
         to_block: BlockNumber,
     ) -> Tuple[BlockchainState, List[Event]]:
         # increment by one, as latest_known_block has been queried last time already
-        from_block = chain_state.latest_known_block + 1
+        from_block = BlockNumber(chain_state.latest_known_block + 1)
 
         # Check if the current block was already processed
         if from_block > to_block:

--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -12,6 +12,7 @@ from web3.middleware import geth_poa_middleware
 
 from monitoring_service.constants import DEFAULT_REQUIRED_CONFIRMATIONS
 from monitoring_service.service import MonitoringService
+from raiden.utils.typing import BlockNumber, ChainID
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -106,7 +107,7 @@ def main(
     registry_address: Address,
     monitor_contract_address: Address,
     user_deposit_contract_address: Address,
-    start_block: int,
+    start_block: BlockNumber,
     confirmations: int,
     log_level: str,
     state_db: str,
@@ -135,7 +136,7 @@ def main(
 
     contract_manager = ContractManager(contracts_precompiled_path())
     contract_infos = get_contract_addresses_and_start_block(
-        chain_id=int(web3.net.version),
+        chain_id=ChainID(int(web3.net.version)),
         contracts_version=None,
         token_network_registry_address=registry_address,
         monitor_contract_address=monitor_contract_address,

--- a/src/monitoring_service/database.py
+++ b/src/monitoring_service/database.py
@@ -18,6 +18,7 @@ from monitoring_service.states import (
     OnChainUpdateStatus,
 )
 from raiden.utils.typing import BlockNumber
+from raiden_libs.types import Address
 
 SubEvent = Union[ActionMonitoringTriggeredEvent, ActionClaimRewardTriggeredEvent]
 
@@ -272,8 +273,8 @@ class Database(SharedDatabase):
         self,
         filename: str,
         chain_id: int,
-        msc_address: str,
-        registry_address: str,
+        msc_address: Address,
+        registry_address: Address,
         receiver: str,
     ) -> None:
         super(Database, self).__init__(filename, allow_create=True)

--- a/src/monitoring_service/events.py
+++ b/src/monitoring_service/events.py
@@ -1,13 +1,7 @@
 from dataclasses import dataclass
 
-from raiden.utils.typing import (
-    Address,
-    BlockNumber,
-    ChannelID,
-    Nonce,
-    TokenAmount,
-    TokenNetworkAddress,
-)
+from raiden.utils.typing import BlockNumber, ChannelID, Nonce, TokenAmount
+from raiden_libs.types import Address, TokenNetworkAddress
 
 
 class Event:

--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -30,6 +30,7 @@ from monitoring_service.states import (
     MonitorRequest,
     OnChainUpdateStatus,
 )
+from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.contract_manager import ContractManager
 
@@ -101,7 +102,7 @@ def channel_closed_event_handler(event: Event, context: Context) -> None:
         client_update_period: int = round(
             channel.settle_timeout * RATIO_OF_SETTLE_TIMEOUT_BEFORE_MONITOR,
         )
-        trigger_block = event.block_number + client_update_period
+        trigger_block = BlockNumber(event.block_number + client_update_period)
 
         triggered_event = ActionMonitoringTriggeredEvent(
             token_network_address=channel.token_network_address,
@@ -309,7 +310,7 @@ def monitor_new_balance_proof_event_handler(event: Event, context: Context) -> N
     # it will be checked there that our update was the latest one
     if event.ms_address == context.ms_state.address:
         assert channel.closing_block is not None, 'closing_block not set'
-        trigger_block: int = channel.closing_block + channel.settle_timeout + 5
+        trigger_block = BlockNumber(channel.closing_block + channel.settle_timeout + 5)
 
         # trigger the claim reward action by an event
         e = ActionClaimRewardTriggeredEvent(

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -16,13 +16,14 @@ from monitoring_service.constants import (
 from monitoring_service.database import Database
 from monitoring_service.events import Event
 from monitoring_service.handlers import HANDLERS, Context
-from raiden.utils.typing import Address, BlockNumber
+from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_USER_DEPOSIT,
     GAS_REQUIRED_FOR_MS_MONITOR,
 )
 from raiden_contracts.contract_manager import ContractManager
+from raiden_libs.types import Address
 from raiden_libs.utils import private_key_to_address
 
 log = structlog.get_logger(__name__)
@@ -61,7 +62,7 @@ class MonitoringService:
         monitor_contract_address: Address,
         user_deposit_contract_address: Address,
         db_filename: str,
-        sync_start_block: BlockNumber = 0,
+        sync_start_block: BlockNumber = BlockNumber(0),
         required_confirmations: int = DEFAULT_REQUIRED_CONFIRMATIONS,
         poll_interval: float = 1,
         min_reward: int = 0,

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -9,7 +9,6 @@ from raiden.utils.signer import LocalSigner, recover
 from raiden.utils.signing import pack_data
 from raiden.utils.typing import (
     AdditionalHash,
-    Address,
     BalanceHash,
     BlockNumber,
     ChainID,
@@ -17,11 +16,11 @@ from raiden.utils.typing import (
     Nonce,
     Signature,
     TokenAmount,
-    TokenNetworkAddress,
     TransactionHash,
 )
 from raiden_contracts.constants import ChannelState, MessageTypeId
 from raiden_libs.messages.json_schema import MONITOR_REQUEST_SCHEMA
+from raiden_libs.types import Address, TokenNetworkAddress
 
 
 @dataclass

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -16,11 +16,10 @@ from raiden.utils.typing import (
     Nonce,
     Signature,
     TokenAmount,
-    TransactionHash,
 )
 from raiden_contracts.constants import ChannelState, MessageTypeId
 from raiden_libs.messages.json_schema import MONITOR_REQUEST_SCHEMA
-from raiden_libs.types import Address, TokenNetworkAddress
+from raiden_libs.types import Address, TokenNetworkAddress, TransactionHash
 
 
 @dataclass

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -20,7 +20,7 @@ from pathfinding_service import PathfindingService
 from pathfinding_service.api.rest import ServiceApi
 from pathfinding_service.config import DEFAULT_API_HOST, DEFAULT_POLL_INTERVALL
 from pathfinding_service.middleware import http_retry_with_backoff_middleware
-from raiden.utils.types import BlockNumber, ChainID
+from raiden.utils.typing import BlockNumber, ChainID
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_libs.contract_info import START_BLOCK_ID, get_contract_addresses_and_start_block

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -20,6 +20,7 @@ from pathfinding_service import PathfindingService
 from pathfinding_service.api.rest import ServiceApi
 from pathfinding_service.config import DEFAULT_API_HOST, DEFAULT_POLL_INTERVALL
 from pathfinding_service.middleware import http_retry_with_backoff_middleware
+from raiden.utils.types import BlockNumber, ChainID
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_libs.contract_info import START_BLOCK_ID, get_contract_addresses_and_start_block
@@ -112,7 +113,7 @@ def main(
     eth_rpc: str,
     registry_address: Address,
     user_deposit_contract_address: Address,
-    start_block: int,
+    start_block: BlockNumber,
     confirmations: int,
     host: str,
     log_level: str,
@@ -149,7 +150,8 @@ def main(
         log.info(f'Starting Web3 client for node at {eth_rpc}')
         provider = HTTPProvider(eth_rpc)
         web3 = Web3(provider)
-        net_version = int(web3.net.version)  # Will throw ConnectionError on bad Ethereum client
+        # Will throw ConnectionError on bad Ethereum client
+        net_version = ChainID(int(web3.net.version))
     except ConnectionError:
         log.error(
             'Can not connect to the Ethereum client. Please check that it is running and that '
@@ -171,7 +173,7 @@ def main(
         contracts_version=contracts_version,
         token_network_registry_address=registry_address,
         # necessary so that the overwrite logic works properly
-        monitor_contract_address='0x' + '1' * 40,
+        monitor_contract_address=Address('0x' + '1' * 40),
         user_deposit_contract_address=user_deposit_contract_address,
         start_block=start_block,
     )

--- a/src/pathfinding_service/model/channel_view.py
+++ b/src/pathfinding_service/model/channel_view.py
@@ -3,7 +3,8 @@ from enum import Enum
 from eth_utils import is_checksum_address
 
 from pathfinding_service.config import DEFAULT_PERCENTAGE_FEE, DEFAULT_REVEAL_TIMEOUT
-from raiden_libs.types import Address, ChannelIdentifier
+from raiden.utils.types import ChannelID
+from raiden_libs.types import Address
 
 
 class ChannelView:
@@ -17,7 +18,7 @@ class ChannelView:
 
     def __init__(
         self,
-        channel_id: ChannelIdentifier,
+        channel_id: ChannelID,
         participant1: Address,
         participant2: Address,
         settle_timeout: int,

--- a/src/pathfinding_service/model/channel_view.py
+++ b/src/pathfinding_service/model/channel_view.py
@@ -3,7 +3,7 @@ from enum import Enum
 from eth_utils import is_checksum_address
 
 from pathfinding_service.config import DEFAULT_PERCENTAGE_FEE, DEFAULT_REVEAL_TIMEOUT
-from raiden.utils.types import ChannelID
+from raiden.utils.typing import ChannelID
 from raiden_libs.types import Address
 
 

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -11,7 +11,8 @@ from pathfinding_service.config import (
     MAX_PATHS_PER_REQUEST,
 )
 from pathfinding_service.model import ChannelView
-from raiden_libs.types import Address, ChannelIdentifier
+from raiden.utils.types import ChannelID
+from raiden_libs.types import Address
 
 log = structlog.get_logger(__name__)
 
@@ -24,7 +25,7 @@ class TokenNetwork:
 
         self.address = token_network_address
         self.token_address = token_address
-        self.channel_id_to_addresses: Dict[ChannelIdentifier, Tuple[Address, Address]] = dict()
+        self.channel_id_to_addresses: Dict[ChannelID, Tuple[Address, Address]] = dict()
         self.G = DiGraph()
         self.max_relative_fee = 0
 
@@ -37,7 +38,7 @@ class TokenNetwork:
 
     def handle_channel_opened_event(
         self,
-        channel_identifier: ChannelIdentifier,
+        channel_identifier: ChannelID,
         participant1: Address,
         participant2: Address,
         settle_timeout: int,
@@ -72,7 +73,7 @@ class TokenNetwork:
 
     def handle_channel_new_deposit_event(
         self,
-        channel_identifier: ChannelIdentifier,
+        channel_identifier: ChannelID,
         receiver: Address,
         total_deposit: int,
     ):
@@ -99,7 +100,7 @@ class TokenNetwork:
                 channel_identifier=channel_identifier,
             )
 
-    def handle_channel_closed_event(self, channel_identifier: ChannelIdentifier):
+    def handle_channel_closed_event(self, channel_identifier: ChannelID):
         """ Close a channel. This doesn't mean that the channel is settled yet, but it cannot
         transfer any more.
 
@@ -119,7 +120,7 @@ class TokenNetwork:
 
     def get_channel_views_for_partner(
             self,
-            channel_identifier: ChannelIdentifier,
+            channel_identifier: ChannelID,
             updating_participant: Address,
             other_participant: Address,
     ) -> Tuple[ChannelView, ChannelView]:
@@ -132,7 +133,7 @@ class TokenNetwork:
 
     def handle_channel_balance_update_message(
         self,
-        channel_identifier: ChannelIdentifier,
+        channel_identifier: ChannelID,
         updating_participant: Address,
         other_participant: Address,
         updating_nonce: int,
@@ -160,7 +161,7 @@ class TokenNetwork:
 
     @staticmethod
     def edge_weight(
-        visited: Dict[ChannelIdentifier, float],
+        visited: Dict[ChannelID, float],
         attr: Dict[str, Any],
     ):
         view: ChannelView = attr['view']
@@ -197,7 +198,7 @@ class TokenNetwork:
     ):
         assert hop_bias == 1, 'Only hop_bias 1 is supported'
         max_paths = min(max_paths, MAX_PATHS_PER_REQUEST)
-        visited: Dict[ChannelIdentifier, float] = {}
+        visited: Dict[ChannelID, float] = {}
         paths: List[List[Address]] = []
 
         for _ in range(max_paths):

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -11,7 +11,7 @@ from pathfinding_service.config import (
     MAX_PATHS_PER_REQUEST,
 )
 from pathfinding_service.model import ChannelView
-from raiden.utils.types import ChannelID
+from raiden.utils.typing import ChannelID
 from raiden_libs.types import Address
 
 log = structlog.get_logger(__name__)

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -17,6 +17,7 @@ from pathfinding_service.utils.blockchain_listener import (
 )
 from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, UINT256_MAX
 from raiden.messages import SignedMessage, UpdatePFS
+from raiden.utils.typing import ChainID
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -76,7 +77,7 @@ class PathfindingService(gevent.Greenlet):
         self.sync_start_block = sync_start_block
         self.required_confirmations = required_confirmations
         self.poll_interval = poll_interval
-        self.chain_id = int(web3.net.version)
+        self.chain_id = ChainID(int(web3.net.version))
         self.private_key = private_key
         self.address = private_key_to_address(private_key)
         self.service_fee = service_fee

--- a/src/raiden_libs/contract_info.py
+++ b/src/raiden_libs/contract_info.py
@@ -2,13 +2,14 @@ from typing import Any, Dict, Optional
 
 import structlog
 
-from raiden.utils.typing import Address, BlockNumber, ChainID
+from raiden.utils.typing import BlockNumber, ChainID
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
 from raiden_contracts.contract_manager import get_contracts_deployment_info
+from raiden_libs.types import Address
 
 log = structlog.get_logger(__name__)
 START_BLOCK_ID = 'block'
@@ -58,7 +59,7 @@ def get_contract_addresses_and_start_block(
     token_network_registry_address: Address = None,
     monitor_contract_address: Address = None,
     user_deposit_contract_address: Address = None,
-    start_block: BlockNumber = 0,
+    start_block: BlockNumber = BlockNumber(0),
 ) -> Optional[Dict[str, Any]]:
     """ Returns contract addresses and start query block for a given chain and contracts version.
 

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from typing import Callable, Iterable, List, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Tuple, Union
 
 import gevent
 import structlog
@@ -27,17 +27,18 @@ from raiden.settings import (
 )
 from raiden.utils.cli import get_matrix_servers
 from raiden.utils.signer import LocalSigner
+from raiden.utils.typing import ChainID
 
 log = structlog.get_logger(__name__)
 
 
-SERVICE_MESSAGES = (UpdatePFS, RequestMonitoring)
-CLASSNAME_TO_CLASS = {klass.__name__: klass for klass in SERVICE_MESSAGES}
+SERVICE_MESSAGES: Tuple = (UpdatePFS, RequestMonitoring)
+CLASSNAME_TO_CLASS: Dict[str, Message] = {klass.__name__: klass for klass in SERVICE_MESSAGES}
 
 
 def message_from_dict(data: dict) -> Message:
     try:
-        klass = CLASSNAME_TO_CLASS[data['type']]
+        klass: Message = CLASSNAME_TO_CLASS[data['type']]
     except KeyError:
         if 'type' in data:
             raise InvalidProtocolMessage(
@@ -55,7 +56,7 @@ class MatrixListener(gevent.Greenlet):
     def __init__(
         self,
         private_key: str,
-        chain_id: int,
+        chain_id: ChainID,
         callback: Callable,
         service_room_suffix: str,
     ) -> None:
@@ -93,8 +94,8 @@ class MatrixListener(gevent.Greenlet):
             # below constants are defined in raiden.app.App.DEFAULT_CONFIG
             return udp_utils.timeout_exponential_backoff(
                 DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
-                DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL / 5,
-                DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL,
+                int(DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL / 5),
+                int(DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL),
             )
 
         client = make_client(

--- a/src/raiden_libs/types.py
+++ b/src/raiden_libs/types.py
@@ -3,5 +3,5 @@ from typing import NewType
 T_Address = str
 Address = NewType('Address', T_Address)
 
-T_ChannelIdentifier = int
-ChannelIdentifier = NewType('ChannelIdentifier', T_ChannelIdentifier)
+T_TokenNetworkAddress = str
+TokenNetworkAddress = NewType('TokenNetworkAddress', T_TokenNetworkAddress)

--- a/src/raiden_libs/types.py
+++ b/src/raiden_libs/types.py
@@ -5,3 +5,6 @@ Address = NewType('Address', T_Address)
 
 T_TokenNetworkAddress = str
 TokenNetworkAddress = NewType('TokenNetworkAddress', T_TokenNetworkAddress)
+
+T_TransactionHash = str
+TransactionHash = NewType('TransactionHash', T_TransactionHash)

--- a/src/raiden_libs/utils.py
+++ b/src/raiden_libs/utils.py
@@ -4,11 +4,12 @@ from coincurve import PrivateKey, PublicKey
 from eth_utils import keccak, to_bytes, to_checksum_address
 
 from raiden.constants import UINT256_MAX
-from raiden_libs.types import Address, ChannelIdentifier, T_ChannelIdentifier
+from raiden.utils.types import ChannelID, T_ChannelID
+from raiden_libs.types import Address
 
 
-def is_channel_identifier(channel_identifier: ChannelIdentifier) -> bool:
-    assert isinstance(channel_identifier, T_ChannelIdentifier)
+def is_channel_identifier(channel_identifier: ChannelID) -> bool:
+    assert isinstance(channel_identifier, T_ChannelID)
     return 0 < channel_identifier <= UINT256_MAX
 
 

--- a/src/raiden_libs/utils.py
+++ b/src/raiden_libs/utils.py
@@ -4,7 +4,7 @@ from coincurve import PrivateKey, PublicKey
 from eth_utils import keccak, to_bytes, to_checksum_address
 
 from raiden.constants import UINT256_MAX
-from raiden.utils.types import ChannelID, T_ChannelID
+from raiden.utils.typing import ChannelID, T_ChannelID
 from raiden_libs.types import Address
 
 

--- a/tests/libs/mocks/client.py
+++ b/tests/libs/mocks/client.py
@@ -13,7 +13,7 @@ from monitoring_service.states import HashedBalanceProof, MonitorRequest, Unsign
 from raiden.constants import UINT256_MAX
 from raiden.messages import RequestMonitoring, SignedBlindedBalanceProof
 from raiden.utils.signer import LocalSigner
-from raiden.utils.types import ChannelID, T_ChannelID, TokenAmount
+from raiden.utils.typing import ChannelID, T_ChannelID, TokenAmount
 from raiden_contracts.constants import MessageTypeId
 from raiden_libs.types import Address
 from raiden_libs.utils import private_key_to_address

--- a/tests/libs/mocks/client.py
+++ b/tests/libs/mocks/client.py
@@ -273,7 +273,7 @@ class MockRaidenNode:
     def get_monitor_request(
         self,
         balance_proof: HashedBalanceProof,
-        reward_amount: int,
+        reward_amount: TokenAmount,
     ) -> MonitorRequest:
         """Get monitor request message for a given balance proof."""
         assert balance_proof.signature

--- a/tests/libs/test_contract_info.py
+++ b/tests/libs/test_contract_info.py
@@ -1,10 +1,11 @@
-from raiden.utils.typing import Address, ChainID
+from raiden.utils.typing import BlockNumber, ChainID
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
 from raiden_libs.contract_info import START_BLOCK_ID, get_contract_addresses_and_start_block
+from raiden_libs.types import Address
 
 DEFAULT_CHAIN_ID = ChainID(3)
 DEFAULT_VERSION = '0.10.1'
@@ -32,7 +33,7 @@ def test_contract_info_overwrite_defaults():
         token_network_registry_address=address1,
         monitor_contract_address=address2,
         user_deposit_contract_address=address3,
-        start_block=123,
+        start_block=BlockNumber(123),
     )
     assert infos is not None
     assert infos[CONTRACT_TOKEN_NETWORK_REGISTRY] == address1
@@ -69,7 +70,7 @@ def test_contract_info_returns_user_defaults_with_full_config():
         token_network_registry_address=address1,
         monitor_contract_address=address2,
         user_deposit_contract_address=address3,
-        start_block=123,
+        start_block=BlockNumber(123),
     )
     assert infos is not None
     assert infos[CONTRACT_TOKEN_NETWORK_REGISTRY] == address1

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -10,6 +10,7 @@ from monitoring_service.database import Database
 from monitoring_service.service import MonitoringService
 from raiden_contracts.contract_manager import ContractManager
 from raiden_contracts.tests.utils import get_random_privkey
+from raiden_libs.types import Address
 from raiden_libs.utils import private_key_to_address
 
 log = logging.getLogger(__name__)
@@ -47,9 +48,9 @@ def ms_database():
     return Database(
         filename=':memory:',
         chain_id=1,
-        msc_address='0x' + '2' * 40,
-        registry_address='0x' + '3' * 40,
-        receiver='0x' + '4' * 40,
+        msc_address=Address('0x' + '2' * 40),
+        registry_address=Address('0x' + '3' * 40),
+        receiver=Address('0x' + '4' * 40),
     )
 
 

--- a/tests/monitoring/monitoring_service/test_blockchain.py
+++ b/tests/monitoring/monitoring_service/test_blockchain.py
@@ -1,14 +1,16 @@
 from web3 import Web3
 
 from monitoring_service.blockchain import query_blockchain_events
+from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, EVENT_TOKEN_NETWORK_CREATED
 from raiden_contracts.contract_manager import ContractManager
+from raiden_libs.types import Address
 
 
 def create_tnr_contract_events_query(
     web3: Web3,
     contract_manager: ContractManager,
-    contract_address: str,
+    contract_address: Address,
 ):
     def query_callback():
         return query_blockchain_events(
@@ -17,7 +19,7 @@ def create_tnr_contract_events_query(
             contract_address=contract_address,
             contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
             topics=[],
-            from_block=0,
+            from_block=BlockNumber(0),
             to_block=web3.eth.blockNumber,
         )
     return query_callback
@@ -41,7 +43,7 @@ def test_limit_inclusivity_in_query_blockchain_events(
     assert len(events) == 1
     event = events[0]
     assert event['event'] == EVENT_TOKEN_NETWORK_CREATED
-    registry_event_block = event['blockNumber']
+    registry_event_block = BlockNumber(event['blockNumber'])
 
     # test to_block is inclusive
     events = query_blockchain_events(
@@ -50,8 +52,8 @@ def test_limit_inclusivity_in_query_blockchain_events(
         contract_address=token_network_registry_contract.address,
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
         topics=[],
-        from_block=0,
-        to_block=registry_event_block - 1,
+        from_block=BlockNumber(0),
+        to_block=BlockNumber(registry_event_block - 1),
     )
     assert len(events) == 0
 
@@ -61,7 +63,7 @@ def test_limit_inclusivity_in_query_blockchain_events(
         contract_address=token_network_registry_contract.address,
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
         topics=[],
-        from_block=0,
+        from_block=BlockNumber(0),
         to_block=registry_event_block,
     )
     assert len(events) == 1
@@ -78,7 +80,7 @@ def test_limit_inclusivity_in_query_blockchain_events(
         contract_address=token_network_registry_contract.address,
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
         topics=[],
-        from_block=registry_event_block + 1,
+        from_block=BlockNumber(registry_event_block + 1),
         to_block=current_block_number,
     )
     assert len(events) == 0

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -9,6 +9,7 @@ from monitoring_service.events import (
     UpdatedHeadBlockEvent,
 )
 from monitoring_service.service import MonitoringService
+from raiden.utils.typing import BlockNumber, ChannelID
 
 
 class MockBlockchainListener:
@@ -40,7 +41,7 @@ def test_crash(
     A somewhat meaninful crash handling is simulated by not including the
     UpdatedHeadBlockEvent in every block.
     """
-    channel_identifier = 3
+    channel_identifier = ChannelID(3)
     c1, c2 = generate_raiden_clients(2)
     monitor_request = c2.get_monitor_request(
         balance_proof=c1.get_balance_proof(
@@ -62,7 +63,8 @@ def test_crash(
                 participant1=c1.address,
                 participant2=c2.address,
                 settle_timeout=20,
-                block_number=0),
+                block_number=BlockNumber(0),
+            ),
         ],
         [
             UpdatedHeadBlockEvent(1),

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -67,7 +67,7 @@ def test_crash(
             ),
         ],
         [
-            UpdatedHeadBlockEvent(1),
+            UpdatedHeadBlockEvent(BlockNumber(1)),
         ],
         [
             ActionMonitoringTriggeredEvent(
@@ -77,7 +77,7 @@ def test_crash(
             ),
         ],
         [
-            UpdatedHeadBlockEvent(3),
+            UpdatedHeadBlockEvent(BlockNumber(3)),
         ],
     ]
 

--- a/tests/monitoring/monitoring_service/test_database.py
+++ b/tests/monitoring/monitoring_service/test_database.py
@@ -1,4 +1,6 @@
 from monitoring_service.events import ActionMonitoringTriggeredEvent, ScheduledEvent
+from raiden.utils.typing import BlockNumber, ChannelID
+from raiden_libs.types import Address, TokenNetworkAddress
 
 
 def test_scheduled_events(ms_database):
@@ -9,11 +11,11 @@ def test_scheduled_events(ms_database):
     )
 
     event1 = ScheduledEvent(
-        trigger_block_number=23,
+        trigger_block_number=BlockNumber(23),
         event=ActionMonitoringTriggeredEvent(
-            token_network_address='a',
-            channel_identifier=1,
-            non_closing_participant='b',
+            token_network_address=TokenNetworkAddress('a'),
+            channel_identifier=ChannelID(1),
+            non_closing_participant=Address('b'),
         ),
     )
 
@@ -22,11 +24,11 @@ def test_scheduled_events(ms_database):
     assert ms_database.scheduled_event_count() == 1
 
     event2 = ScheduledEvent(
-        trigger_block_number=24,
+        trigger_block_number=BlockNumber(24),
         event=ActionMonitoringTriggeredEvent(
-            token_network_address='a',
-            channel_identifier=1,
-            non_closing_participant='b',
+            token_network_address=TokenNetworkAddress('a'),
+            channel_identifier=ChannelID(1),
+            non_closing_participant=Address('b'),
         ),
     )
 

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -4,14 +4,16 @@ from web3 import Web3
 
 from monitoring_service.blockchain import query_blockchain_events
 from monitoring_service.service import MonitoringService
+from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import CONTRACT_MONITORING_SERVICE, MonitoringServiceEvent
 from raiden_contracts.contract_manager import ContractManager
+from raiden_libs.types import Address
 
 
 def create_ms_contract_events_query(
     web3: Web3,
     contract_manager: ContractManager,
-    contract_address: str,
+    contract_address: Address,
 ):
     def f():
         return query_blockchain_events(
@@ -20,7 +22,7 @@ def create_ms_contract_events_query(
             contract_address=contract_address,
             contract_name=CONTRACT_MONITORING_SERVICE,
             topics=[],
-            from_block=0,
+            from_block=BlockNumber(0),
             to_block=web3.eth.blockNumber,
         )
     return f

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -30,17 +30,19 @@ from monitoring_service.states import (
     OnChainUpdateStatus,
     UnsignedMonitorRequest,
 )
+from raiden.utils.typing import BlockNumber, ChannelID, Nonce, TokenAmount
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.tests.utils import get_random_privkey
+from raiden_libs.types import Address, TokenNetworkAddress
 from raiden_libs.utils import private_key_to_address
 
-DEFAULT_TOKEN_NETWORK_ADDRESS = '0x0000000000000000000000000000000000000000'
-DEFAULT_CHANNEL_IDENTIFIER = 3
+DEFAULT_TOKEN_NETWORK_ADDRESS = TokenNetworkAddress('0x0000000000000000000000000000000000000000')
+DEFAULT_CHANNEL_IDENTIFIER = ChannelID(3)
 DEFAULT_PRIVATE_KEY1 = '0x' + '1' * 64
 DEFAULT_PRIVATE_KEY2 = '0x' + '2' * 64
-DEFAULT_PARTICIPANT1 = private_key_to_address(DEFAULT_PRIVATE_KEY1)
-DEFAULT_PARTICIPANT2 = private_key_to_address(DEFAULT_PRIVATE_KEY2)
-DEFAULT_REWARD_AMOUNT = 1
+DEFAULT_PARTICIPANT1 = Address(private_key_to_address(DEFAULT_PRIVATE_KEY1))
+DEFAULT_PARTICIPANT2 = Address(private_key_to_address(DEFAULT_PRIVATE_KEY2))
+DEFAULT_REWARD_AMOUNT = TokenAmount(1)
 DEFAULT_SETTLE_TIMEOUT = 100
 
 
@@ -61,7 +63,7 @@ def setup_state_with_open_channel(context: Context) -> Context:
         participant1=DEFAULT_PARTICIPANT1,
         participant2=DEFAULT_PARTICIPANT2,
         settle_timeout=DEFAULT_SETTLE_TIMEOUT,
-        block_number=42,
+        block_number=BlockNumber(42),
     )
     assert context.db.channel_count() == 0
 
@@ -77,7 +79,7 @@ def setup_state_with_closed_channel(context: Context) -> Context:
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
         closing_participant=DEFAULT_PARTICIPANT2,
-        block_number=52,
+        block_number=BlockNumber(52),
     )
     channel_closed_event_handler(event2, context)
 
@@ -89,7 +91,7 @@ def setup_state_with_closed_channel(context: Context) -> Context:
 
 def get_signed_monitor_request(
     nonce: int = 5,
-    reward_amount: int = DEFAULT_REWARD_AMOUNT,
+    reward_amount: TokenAmount = DEFAULT_REWARD_AMOUNT,
     closing_privkey: str = DEFAULT_PRIVATE_KEY1,
     nonclosing_privkey: str = DEFAULT_PRIVATE_KEY2,
 ) -> MonitorRequest:
@@ -163,7 +165,7 @@ def test_channel_opened_event_handler_adds_channel(
         participant1=DEFAULT_PARTICIPANT1,
         participant2=DEFAULT_PARTICIPANT2,
         settle_timeout=100,
-        block_number=42,
+        block_number=BlockNumber(42),
     )
 
     assert context.db.channel_count() == 0
@@ -183,7 +185,7 @@ def test_channel_closed_event_handler_closes_existing_channel(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
         closing_participant=DEFAULT_PARTICIPANT2,
-        block_number=52,
+        block_number=BlockNumber(52),
     )
     channel_closed_event_handler(event, context)
 
@@ -204,7 +206,7 @@ def test_channel_closed_event_handler_idempotency(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
         closing_participant=DEFAULT_PARTICIPANT2,
-        block_number=52,
+        block_number=BlockNumber(52),
     )
     channel_closed_event_handler(event, context)
 
@@ -228,7 +230,7 @@ def test_channel_closed_event_handler_ignores_existing_channel_after_timeout(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
         closing_participant=DEFAULT_PARTICIPANT2,
-        block_number=52,
+        block_number=BlockNumber(52),
     )
     channel_closed_event_handler(event, context)
 
@@ -246,9 +248,9 @@ def test_channel_closed_event_handler_leaves_existing_channel(
 
     event = ReceiveChannelClosedEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
-        channel_identifier=4,
+        channel_identifier=ChannelID(4),
         closing_participant=DEFAULT_PARTICIPANT2,
-        block_number=52,
+        block_number=BlockNumber(52),
     )
     channel_closed_event_handler(event, context)
 
@@ -267,7 +269,7 @@ def test_channel_closed_event_handler_trigger_action_monitor_event_with_monitor_
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
         closing_participant=DEFAULT_PARTICIPANT2,
-        block_number=52,
+        block_number=BlockNumber(52),
     )
 
     channel_closed_event_handler(event, context)
@@ -283,7 +285,7 @@ def test_channel_closed_event_handler_trigger_action_monitor_event_without_monit
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
         closing_participant=DEFAULT_PARTICIPANT2,
-        block_number=52,
+        block_number=BlockNumber(52),
     )
 
     channel_closed_event_handler(event, context)
@@ -298,7 +300,7 @@ def test_channel_settled_event_handler_settles_existing_channel(
     event = ReceiveChannelSettledEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
-        block_number=52,
+        block_number=BlockNumber(52),
     )
     channel_settled_event_handler(event, context)
 
@@ -313,8 +315,8 @@ def test_channel_settled_event_handler_leaves_existing_channel(
 
     event = ReceiveChannelSettledEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
-        channel_identifier=4,
-        block_number=52,
+        channel_identifier=ChannelID(4),
+        block_number=BlockNumber(52),
     )
     channel_settled_event_handler(event, context)
 
@@ -331,8 +333,8 @@ def test_channel_bp_updated_event_handler_sets_update_status_if_not_set(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
         closing_participant=DEFAULT_PARTICIPANT2,
-        nonce=2,
-        block_number=23,
+        nonce=Nonce(2),
+        block_number=BlockNumber(23),
     )
 
     channel = context.db.get_channel(event_bp.token_network_address, event_bp.channel_identifier)
@@ -352,8 +354,8 @@ def test_channel_bp_updated_event_handler_sets_update_status_if_not_set(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
         closing_participant=DEFAULT_PARTICIPANT2,
-        nonce=5,
-        block_number=53,
+        nonce=Nonce(5),
+        block_number=BlockNumber(53),
     )
 
     channel_non_closing_balance_proof_updated_event_handler(event_bp2, context)
@@ -374,11 +376,11 @@ def test_monitor_new_balance_proof_event_handler_sets_update_status(
     new_balance_event = ReceiveMonitoringNewBalanceProofEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
-        reward_amount=1,
-        nonce=2,
-        ms_address='C',
+        reward_amount=TokenAmount(1),
+        nonce=Nonce(2),
+        ms_address=Address('C'),
         raiden_node_address=DEFAULT_PARTICIPANT2,
-        block_number=23,
+        block_number=BlockNumber(23),
     )
 
     channel = context.db.get_channel(
@@ -403,11 +405,11 @@ def test_monitor_new_balance_proof_event_handler_sets_update_status(
     new_balance_event2 = ReceiveMonitoringNewBalanceProofEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
-        reward_amount=1,
-        nonce=5,
-        ms_address='D',
+        reward_amount=TokenAmount(1),
+        nonce=Nonce(5),
+        ms_address=Address('D'),
         raiden_node_address=DEFAULT_PARTICIPANT2,
-        block_number=23,
+        block_number=BlockNumber(23),
     )
 
     monitor_new_balance_proof_event_handler(new_balance_event2, context)
@@ -431,11 +433,11 @@ def test_monitor_new_balance_proof_event_handler_idempotency(
     new_balance_event = ReceiveMonitoringNewBalanceProofEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
-        reward_amount=1,
-        nonce=2,
-        ms_address='C',
+        reward_amount=TokenAmount(1),
+        nonce=Nonce(2),
+        ms_address=Address('C'),
         raiden_node_address=DEFAULT_PARTICIPANT2,
-        block_number=23,
+        block_number=BlockNumber(23),
     )
 
     channel = context.db.get_channel(
@@ -480,11 +482,11 @@ def test_action_monitoring_triggered_event_handler_does_not_trigger_monitor_call
     event3 = ReceiveMonitoringNewBalanceProofEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,
-        reward_amount=1,
-        nonce=5,
-        ms_address='C',
+        reward_amount=TokenAmount(1),
+        nonce=Nonce(5),
+        ms_address=Address('C'),
         raiden_node_address=DEFAULT_PARTICIPANT2,
-        block_number=23,
+        block_number=BlockNumber(23),
     )
 
     channel = context.db.get_channel(event3.token_network_address, event3.channel_identifier)
@@ -494,7 +496,7 @@ def test_action_monitoring_triggered_event_handler_does_not_trigger_monitor_call
     monitor_new_balance_proof_event_handler(event3, context)
 
     # add MR to DB, with nonce being smaller than in event3
-    context.db.upsert_monitor_request(get_signed_monitor_request(nonce=4))
+    context.db.upsert_monitor_request(get_signed_monitor_request(nonce=Nonce(4)))
 
     event4 = ActionMonitoringTriggeredEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -525,7 +527,10 @@ def test_action_monitoring_triggered_event_handler_with_sufficient_balance_does_
     """
     context = setup_state_with_closed_channel(context)
 
-    context.db.upsert_monitor_request(get_signed_monitor_request(nonce=6, reward_amount=10))
+    context.db.upsert_monitor_request(get_signed_monitor_request(
+        nonce=Nonce(6),
+        reward_amount=TokenAmount(10)),
+    )
 
     trigger_event = ActionMonitoringTriggeredEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -557,7 +562,10 @@ def test_action_monitoring_triggered_event_handler_with_insufficient_reward_amou
     """
     context = setup_state_with_closed_channel(context)
 
-    context.db.upsert_monitor_request(get_signed_monitor_request(nonce=6, reward_amount=0))
+    context.db.upsert_monitor_request(get_signed_monitor_request(
+        nonce=Nonce(6),
+        reward_amount=TokenAmount(0)),
+    )
 
     trigger_event = ActionMonitoringTriggeredEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -591,7 +599,9 @@ def test_action_monitoring_triggered_event_handler_without_sufficient_balance_do
     """
     context = setup_state_with_closed_channel(context)
 
-    context.db.upsert_monitor_request(get_signed_monitor_request(nonce=6, reward_amount=10))
+    context.db.upsert_monitor_request(
+        get_signed_monitor_request(nonce=Nonce(6), reward_amount=TokenAmount(10)),
+    )
 
     trigger_event = ActionMonitoringTriggeredEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -678,7 +688,9 @@ def test_action_claim_reward_triggered_event_handler_does_trigger_claim_call(  #
     """
     context = setup_state_with_closed_channel(context)
 
-    context.db.upsert_monitor_request(get_signed_monitor_request(nonce=6, reward_amount=10))
+    context.db.upsert_monitor_request(
+        get_signed_monitor_request(nonce=Nonce(6), reward_amount=TokenAmount(10)),
+    )
 
     trigger_event = ActionClaimRewardTriggeredEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -696,7 +708,7 @@ def test_action_claim_reward_triggered_event_handler_does_trigger_claim_call(  #
     # Set update state
     channel.update_status = OnChainUpdateStatus(
         update_sender_address=context.ms_state.address,
-        nonce=6,
+        nonce=Nonce(6),
     )
     context.db.upsert_channel(channel)
 
@@ -714,7 +726,9 @@ def test_action_claim_reward_triggered_event_handler_without_reward_doesnt_trigg
     """
     context = setup_state_with_closed_channel(context)
 
-    context.db.upsert_monitor_request(get_signed_monitor_request(nonce=6, reward_amount=0))
+    context.db.upsert_monitor_request(
+        get_signed_monitor_request(nonce=Nonce(6), reward_amount=TokenAmount(0)),
+    )
 
     trigger_event = ActionClaimRewardTriggeredEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -732,7 +746,7 @@ def test_action_claim_reward_triggered_event_handler_without_reward_doesnt_trigg
     # Set update state
     channel.update_status = OnChainUpdateStatus(
         update_sender_address=context.ms_state.address,
-        nonce=6,
+        nonce=Nonce(6),
     )
     context.db.upsert_channel(channel)
 
@@ -750,7 +764,9 @@ def test_action_claim_reward_triggered_event_handler_without_update_state_doesnt
     """
     context = setup_state_with_closed_channel(context)
 
-    context.db.upsert_monitor_request(get_signed_monitor_request(nonce=6, reward_amount=0))
+    context.db.upsert_monitor_request(
+        get_signed_monitor_request(nonce=Nonce(6), reward_amount=TokenAmount(0)),
+    )
 
     trigger_event = ActionClaimRewardTriggeredEvent(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -767,8 +783,8 @@ def test_action_claim_reward_triggered_event_handler_without_update_state_doesnt
 
     # Set update state
     channel.update_status = OnChainUpdateStatus(
-        update_sender_address='0x' + '1' * 40,
-        nonce=6,
+        update_sender_address=Address('0x' + '1' * 40),
+        nonce=Nonce(6),
     )
     context.db.upsert_channel(channel)
 

--- a/tests/monitoring/monitoring_service/test_states.py
+++ b/tests/monitoring/monitoring_service/test_states.py
@@ -11,9 +11,10 @@ from monitoring_service.states import (
     UnsignedMonitorRequest,
 )
 from raiden.constants import UINT64_MAX, UINT256_MAX
-from raiden.utils.types import BlockNumber, ChannelID, TokenAmount, TransactionHash
+from raiden.utils.typing import BlockNumber, ChannelID, TokenAmount
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.tests.utils import get_random_address, get_random_privkey
+from raiden_libs.types import TransactionHash
 from raiden_libs.utils import keccak, private_key_to_address
 
 

--- a/tests/monitoring/monitoring_service/test_states.py
+++ b/tests/monitoring/monitoring_service/test_states.py
@@ -11,9 +11,9 @@ from monitoring_service.states import (
     UnsignedMonitorRequest,
 )
 from raiden.constants import UINT64_MAX, UINT256_MAX
+from raiden.utils.types import ChannelID
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.tests.utils import get_random_address, get_random_privkey
-from raiden_libs.types import ChannelIdentifier
 from raiden_libs.utils import keccak, private_key_to_address
 
 
@@ -21,7 +21,7 @@ from raiden_libs.utils import keccak, private_key_to_address
 def get_random_identifier() -> Callable:
     """Returns a function returning a random valid ethereum address"""
     def f():
-        return ChannelIdentifier(random.randint(0, UINT256_MAX))
+        return ChannelID(random.randint(0, UINT256_MAX))
     return f
 
 

--- a/tests/monitoring/monitoring_service/test_states.py
+++ b/tests/monitoring/monitoring_service/test_states.py
@@ -11,7 +11,7 @@ from monitoring_service.states import (
     UnsignedMonitorRequest,
 )
 from raiden.constants import UINT64_MAX, UINT256_MAX
-from raiden.utils.types import ChannelID
+from raiden.utils.types import BlockNumber, ChannelID, TokenAmount, TransactionHash
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.tests.utils import get_random_address, get_random_privkey
 from raiden_libs.utils import keccak, private_key_to_address
@@ -53,7 +53,7 @@ def get_random_monitor_request(get_random_identifier):
         )
         monitor_request = UnsignedMonitorRequest.from_balance_proof(
             bp,
-            reward_amount=0,
+            reward_amount=TokenAmount(0),
         ).sign(privkey_non_closing)
         return monitor_request, privkey, privkey_non_closing
     return f
@@ -93,15 +93,15 @@ def test_save_and_load_channel(ms_database):
     ]:
         channel = Channel(
             token_network_address=token_network_address,
-            identifier=random.randint(0, UINT256_MAX),
+            identifier=ChannelID(random.randint(0, UINT256_MAX)),
             participant1=get_random_address(),
             participant2=get_random_address(),
             settle_timeout=random.randint(0, UINT256_MAX),
             state=random.choice(list(ChannelState)),
-            closing_block=random.randint(0, UINT256_MAX),
+            closing_block=BlockNumber(random.randint(0, UINT256_MAX)),
             closing_participant=get_random_address(),
-            closing_tx_hash='%d' % random.randint(0, UINT64_MAX),
-            claim_tx_hash='%d' % random.randint(0, UINT64_MAX),
+            closing_tx_hash=TransactionHash('%d' % random.randint(0, UINT64_MAX)),
+            claim_tx_hash=TransactionHash('%d' % random.randint(0, UINT64_MAX)),
             update_status=update_status,
         )
         ms_database.upsert_channel(channel)

--- a/tests/monitoring/request_collector/test_server.py
+++ b/tests/monitoring/request_collector/test_server.py
@@ -26,7 +26,8 @@ def build_request_monitoring():
 
         # usually not a property of RequestMonitoring, but added for convenience in these tests
         request_monitoring.non_closing_signer = to_checksum_address(  # type: ignore
-            non_closing_signer.address)
+            non_closing_signer.address,
+        )
         return request_monitoring
     return f
 

--- a/tests/monitoring/request_collector/test_server.py
+++ b/tests/monitoring/request_collector/test_server.py
@@ -4,6 +4,7 @@ from eth_utils import decode_hex, to_checksum_address
 from raiden.messages import RequestMonitoring, SignedBlindedBalanceProof
 from raiden.tests.utils.messages import make_balance_proof
 from raiden.utils.signer import LocalSigner
+from raiden.utils.typing import TokenAmount
 from raiden_contracts.tests.utils import get_random_privkey
 
 
@@ -19,10 +20,13 @@ def build_request_monitoring():
         )
         request_monitoring = RequestMonitoring(
             onchain_balance_proof=partner_signed_balance_proof,
-            reward_amount=55,
+            reward_amount=TokenAmount(55),
         )
         request_monitoring.sign(non_closing_signer)
-        request_monitoring.non_closing_signer = to_checksum_address(non_closing_signer.address)
+
+        # usually not a property of RequestMonitoring, but added for convenience in these tests
+        request_monitoring.non_closing_signer = to_checksum_address(  # type: ignore
+            non_closing_signer.address)
         return request_monitoring
     return f
 

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -11,7 +11,7 @@ from web3.contract import Contract
 
 from pathfinding_service import PathfindingService
 from pathfinding_service.model.token_network import TokenNetwork
-from raiden.utils.types import ChannelID
+from raiden.utils.typing import ChannelID
 from raiden_contracts.contract_manager import ContractManager
 from raiden_libs.types import Address
 from raiden_libs.utils import private_key_to_address

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -11,8 +11,9 @@ from web3.contract import Contract
 
 from pathfinding_service import PathfindingService
 from pathfinding_service.model.token_network import TokenNetwork
+from raiden.utils.types import ChannelID
 from raiden_contracts.contract_manager import ContractManager
-from raiden_libs.types import Address, ChannelIdentifier
+from raiden_libs.types import Address
 from raiden_libs.utils import private_key_to_address
 
 
@@ -151,7 +152,7 @@ def populate_token_network_random(
     random.seed(NUMBER_OF_CHANNELS)
 
     for channel_id_int in range(NUMBER_OF_CHANNELS):
-        channel_id = ChannelIdentifier(channel_id_int)
+        channel_id = ChannelID(channel_id_int)
 
         private_key1, private_key2 = random.sample(private_keys, 2)
         address1 = Address(private_key_to_address(private_key1))
@@ -222,25 +223,25 @@ def populate_token_network() -> Callable:
             settle_timeout,
         ) in enumerate(channel_descriptions):
             token_network.handle_channel_opened_event(
-                ChannelIdentifier(channel_id),
+                ChannelID(channel_id),
                 addresses[p1_index],
                 addresses[p2_index],
                 settle_timeout=settle_timeout,
             )
 
             token_network.handle_channel_new_deposit_event(
-                ChannelIdentifier(channel_id),
+                ChannelID(channel_id),
                 addresses[p1_index],
                 p1_deposit,
             )
             token_network.handle_channel_new_deposit_event(
-                ChannelIdentifier(channel_id),
+                ChannelID(channel_id),
                 addresses[p2_index],
                 p2_deposit,
             )
 
             token_network.handle_channel_balance_update_message(
-                channel_identifier=ChannelIdentifier(channel_id),
+                channel_identifier=ChannelID(channel_id),
                 updating_participant=addresses[p1_index],
                 other_participant=addresses[p2_index],
                 updating_nonce=1,
@@ -250,7 +251,7 @@ def populate_token_network() -> Callable:
                 reveal_timeout=p1_reveal_timeout,
             )
             token_network.handle_channel_balance_update_message(
-                channel_identifier=ChannelIdentifier(channel_id),
+                channel_identifier=ChannelID(channel_id),
                 updating_participant=addresses[p2_index],
                 other_participant=addresses[p1_index],
                 updating_nonce=2,

--- a/tests/pathfinding/test_capacity_updates.py
+++ b/tests/pathfinding/test_capacity_updates.py
@@ -7,7 +7,7 @@ The Capacity Updates show different correct and incorrect values to test all edg
 from typing import List
 
 import pytest
-from eth_utils import decode_hex, to_checksum_address
+from eth_utils import decode_hex
 
 from pathfinding_service import PathfindingService
 from pathfinding_service.exceptions import InvalidCapacityUpdate
@@ -51,8 +51,8 @@ def get_updatepfs_message(
             channel_identifier=channel_identifier,
             token_network_address=token_network_address,
         ),
-        updating_participant=to_checksum_address(updating_participant),
-        other_participant=to_checksum_address(other_participant),
+        updating_participant=decode_hex(updating_participant),
+        other_participant=decode_hex(other_participant),
         updating_nonce=updating_nonce,
         other_nonce=other_nonce,
         updating_capacity=updating_capacity,

--- a/tests/pathfinding/test_capacity_updates.py
+++ b/tests/pathfinding/test_capacity_updates.py
@@ -7,7 +7,7 @@ The Capacity Updates show different correct and incorrect values to test all edg
 from typing import List
 
 import pytest
-from eth_utils import decode_hex
+from eth_utils import decode_hex, to_checksum_address
 
 from pathfinding_service import PathfindingService
 from pathfinding_service.exceptions import InvalidCapacityUpdate
@@ -33,17 +33,17 @@ DEFAULT_TOKEN_ADDRESS = Address('0x44Ac22fd9672cC559Ab171603D474cEA8a2D7b4D')
 
 
 def get_updatepfs_message(
-        chain_identifier: ChainID = 1,
-        channel_identifier: ChannelID = 0,
+        updating_participant: Address,
+        other_participant: Address,
+        chain_identifier=ChainID(1),
+        channel_identifier=ChannelID(0),
         token_network_address: TokenNetworkAddress = DEFAULT_TOKEN_NETWORK_ADDRESS_BYTES,
-        updating_participant: Address = None,
-        other_participant: Address = None,
-        updating_nonce: Nonce = 1,
-        other_nonce: Nonce = 0,
-        updating_capacity: TokenAmount = 90,
-        other_capacity: TokenAmount = 110,
+        updating_nonce=Nonce(1),
+        other_nonce=Nonce(0),
+        updating_capacity=TokenAmount(90),
+        other_capacity=TokenAmount(110),
         reveal_timeout: int = 2,
-        signature: Signature = '',
+        signature=Signature(bytes()),
 ) -> UpdatePFS:
     return UpdatePFS(
         canonical_identifier=CanonicalIdentifier(
@@ -51,8 +51,8 @@ def get_updatepfs_message(
             channel_identifier=channel_identifier,
             token_network_address=token_network_address,
         ),
-        updating_participant=updating_participant,
-        other_participant=other_participant,
+        updating_participant=to_checksum_address(updating_participant),
+        other_participant=to_checksum_address(other_participant),
         updating_nonce=updating_nonce,
         other_nonce=other_nonce,
         updating_capacity=updating_capacity,
@@ -82,7 +82,7 @@ def test_pfs_rejects_capacity_update_with_wrong_token_network_address(
     addresses: List[Address],
     pathfinding_service_mocked_listeners: PathfindingService,
 ):
-    pathfinding_service_mocked_listeners.chain_id = 1
+    pathfinding_service_mocked_listeners.chain_id = ChainID(1)
 
     token_network = TokenNetwork(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -107,7 +107,7 @@ def test_pfs_rejects_capacity_update_with_wrong_channel_identifier(
         addresses: List[Address],
         pathfinding_service_mocked_listeners: PathfindingService,
 ):
-    pathfinding_service_mocked_listeners.chain_id = 1
+    pathfinding_service_mocked_listeners.chain_id = ChainID(1)
 
     token_network = TokenNetwork(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -145,7 +145,7 @@ def test_pfs_rejects_capacity_update_with_impossible_updating_capacity(
         addresses: List[Address],
         pathfinding_service_mocked_listeners: PathfindingService,
 ):
-    pathfinding_service_mocked_listeners.chain_id = 1
+    pathfinding_service_mocked_listeners.chain_id = ChainID(1)
 
     token_network = TokenNetwork(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -195,7 +195,7 @@ def test_pfs_rejects_capacity_update_with_impossible_other_capacity(
         addresses: List[Address],
         pathfinding_service_mocked_listeners: PathfindingService,
 ):
-    pathfinding_service_mocked_listeners.chain_id = 1
+    pathfinding_service_mocked_listeners.chain_id = ChainID(1)
 
     token_network = TokenNetwork(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -245,7 +245,7 @@ def test_pfs_rejects_capacity_update_with_wrong_updating_participant(
         addresses: List[Address],
         pathfinding_service_mocked_listeners: PathfindingService,
 ):
-    pathfinding_service_mocked_listeners.chain_id = 1
+    pathfinding_service_mocked_listeners.chain_id = ChainID(1)
 
     token_network = TokenNetwork(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -294,7 +294,7 @@ def test_pfs_rejects_capacity_update_with_wrong_other_participant(
         addresses: List[Address],
         pathfinding_service_mocked_listeners: PathfindingService,
 ):
-    pathfinding_service_mocked_listeners.chain_id = 1
+    pathfinding_service_mocked_listeners.chain_id = ChainID(1)
 
     token_network = TokenNetwork(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
@@ -343,7 +343,7 @@ def test_pfs_rejects_capacity_update_with_wrong_nonces(
         addresses: List[Address],
         pathfinding_service_mocked_listeners: PathfindingService,
 ):
-    pathfinding_service_mocked_listeners.chain_id = 1
+    pathfinding_service_mocked_listeners.chain_id = ChainID(1)
 
     token_network = TokenNetwork(
         token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,

--- a/tests/pathfinding/test_capacity_updates.py
+++ b/tests/pathfinding/test_capacity_updates.py
@@ -23,8 +23,7 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
 )
-from raiden_libs.types import Address, ChannelIdentifier
-
+from raiden_libs.types import Address
 
 DEFAULT_TOKEN_NETWORK_ADDRESS = Address('0x6e46B62a245D9EE7758B8DdCCDD1B85fF56B9Bc9')
 DEFAULT_TOKEN_NETWORK_ADDRESS_BYTES = TokenNetworkAddress(
@@ -119,14 +118,14 @@ def test_pfs_rejects_capacity_update_with_wrong_channel_identifier(
         token_network.address] = token_network
 
     token_network.handle_channel_opened_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         participant1=addresses[0],
         participant2=addresses[1],
         settle_timeout=15,
     )
 
     # Check that the new channel has id == 0
-    assert token_network.channel_id_to_addresses[ChannelIdentifier(0)] == (
+    assert token_network.channel_id_to_addresses[ChannelID(0)] == (
         addresses[0],
         addresses[1],
     )
@@ -157,26 +156,26 @@ def test_pfs_rejects_capacity_update_with_impossible_updating_capacity(
         token_network.address] = token_network
 
     token_network.handle_channel_opened_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         participant1=addresses[0],
         participant2=addresses[1],
         settle_timeout=15,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[0],
         total_deposit=100,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[1],
         total_deposit=100,
     )
 
     # Check that the new channel has id == 0
-    assert token_network.channel_id_to_addresses[ChannelIdentifier(0)] == (
+    assert token_network.channel_id_to_addresses[ChannelID(0)] == (
         addresses[0],
         addresses[1],
     )
@@ -207,26 +206,26 @@ def test_pfs_rejects_capacity_update_with_impossible_other_capacity(
         token_network.address] = token_network
 
     token_network.handle_channel_opened_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         participant1=addresses[0],
         participant2=addresses[1],
         settle_timeout=15,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[0],
         total_deposit=100,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[1],
         total_deposit=100,
     )
 
     # Check that the new channel has id == 0
-    assert token_network.channel_id_to_addresses[ChannelIdentifier(0)] == (
+    assert token_network.channel_id_to_addresses[ChannelID(0)] == (
         addresses[0],
         addresses[1],
     )
@@ -257,26 +256,26 @@ def test_pfs_rejects_capacity_update_with_wrong_updating_participant(
         token_network.address] = token_network
 
     token_network.handle_channel_opened_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         participant1=addresses[0],
         participant2=addresses[1],
         settle_timeout=15,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[0],
         total_deposit=100,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[1],
         total_deposit=100,
     )
 
     # Check that the new channel has id == 0
-    assert token_network.channel_id_to_addresses[ChannelIdentifier(0)] == (
+    assert token_network.channel_id_to_addresses[ChannelID(0)] == (
         addresses[0],
         addresses[1],
     )
@@ -306,26 +305,26 @@ def test_pfs_rejects_capacity_update_with_wrong_other_participant(
         token_network.address] = token_network
 
     token_network.handle_channel_opened_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         participant1=addresses[0],
         participant2=addresses[1],
         settle_timeout=15,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[0],
         total_deposit=100,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[1],
         total_deposit=100,
     )
 
     # Check that the new channel has id == 0
-    assert token_network.channel_id_to_addresses[ChannelIdentifier(0)] == (
+    assert token_network.channel_id_to_addresses[ChannelID(0)] == (
         addresses[0],
         addresses[1],
     )
@@ -355,26 +354,26 @@ def test_pfs_rejects_capacity_update_with_wrong_nonces(
         token_network.address] = token_network
 
     token_network.handle_channel_opened_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         participant1=addresses[0],
         participant2=addresses[1],
         settle_timeout=15,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[0],
         total_deposit=100,
     )
 
     token_network.handle_channel_new_deposit_event(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         receiver=addresses[1],
         total_deposit=100,
     )
 
     # Check that the new channel has id == 0
-    assert token_network.channel_id_to_addresses[ChannelIdentifier(0)] == (
+    assert token_network.channel_id_to_addresses[ChannelID(0)] == (
         addresses[0],
         addresses[1],
     )
@@ -387,7 +386,7 @@ def test_pfs_rejects_capacity_update_with_wrong_nonces(
     # Check first capacity update succeeded
     pathfinding_service_mocked_listeners.on_pfs_update(message)
     view_to_partner, view_from_partner = token_network.get_channel_views_for_partner(
-        channel_identifier=ChannelIdentifier(0),
+        channel_identifier=ChannelID(0),
         updating_participant=addresses[0],
         other_participant=addresses[1],
     )

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -8,7 +8,7 @@ from networkx import NetworkXNoPath
 
 from pathfinding_service.config import DEFAULT_PERCENTAGE_FEE
 from pathfinding_service.model import ChannelView, TokenNetwork
-from raiden.utils.types import ChannelID
+from raiden.utils.typing import ChannelID
 from raiden_libs.types import Address
 
 

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -8,13 +8,14 @@ from networkx import NetworkXNoPath
 
 from pathfinding_service.config import DEFAULT_PERCENTAGE_FEE
 from pathfinding_service.model import ChannelView, TokenNetwork
-from raiden_libs.types import Address, ChannelIdentifier
+from raiden.utils.types import ChannelID
+from raiden_libs.types import Address
 
 
 # This test is boring right now, but should get more interesting as the routing
 # gets more options.
 def test_edge_weight(addresses):
-    channel_id = ChannelIdentifier(1)
+    channel_id = ChannelID(1)
     participant1 = addresses[0]
     participant2 = addresses[1]
     settle_timeout = 15

--- a/tests/pathfinding/test_mocked_integration.py
+++ b/tests/pathfinding/test_mocked_integration.py
@@ -10,7 +10,7 @@ from eth_utils import decode_hex
 
 from pathfinding_service import PathfindingService
 from pathfinding_service.model import TokenNetwork
-from raiden.utils.types import ChannelID
+from raiden.utils.typing import ChannelID
 from raiden_libs.types import Address
 
 

--- a/tests/pathfinding/test_mocked_integration.py
+++ b/tests/pathfinding/test_mocked_integration.py
@@ -10,7 +10,8 @@ from eth_utils import decode_hex
 
 from pathfinding_service import PathfindingService
 from pathfinding_service.model import TokenNetwork
-from raiden_libs.types import Address, ChannelIdentifier
+from raiden.utils.types import ChannelID
+from raiden_libs.types import Address
 
 
 def test_pfs_with_mocked_events(
@@ -90,7 +91,7 @@ def test_pfs_with_mocked_events(
         ))
 
         token_network.handle_channel_balance_update_message(
-            channel_identifier=ChannelIdentifier(index),
+            channel_identifier=ChannelID(index),
             updating_participant=addresses[p1_index],
             other_participant=addresses[p2_index],
             updating_nonce=1,
@@ -100,7 +101,7 @@ def test_pfs_with_mocked_events(
             reveal_timeout=p1_reveal_timeout,
         )
         token_network.handle_channel_balance_update_message(
-            channel_identifier=ChannelIdentifier(index),
+            channel_identifier=ChannelID(index),
             updating_participant=addresses[p2_index],
             other_participant=addresses[p1_index],
             updating_nonce=2,
@@ -126,7 +127,7 @@ def test_pfs_with_mocked_events(
         _p2_reveal_timeout,
         _settle_timeout,
     ) in enumerate(channel_descriptions_case_1):
-        p1, p2 = token_network.channel_id_to_addresses[ChannelIdentifier(index)]
+        p1, p2 = token_network.channel_id_to_addresses[ChannelID(index)]
         assert p1 == addresses[p1_index]
         assert p2 == addresses[p2_index]
 


### PR DESCRIPTION
I had to exclude one error for flake8 which prevented using
`varname: Type = Type(constant)` assignments for defaults in the
constructor. If you know how to get the types right without excluding
this error, let me know!

Fixes #167 