### PR TITLE
Disallow untyped defs in whole `src`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,14 @@
 CODE_DIRS = src/ tests/
 ISORT_PARAMS = --ignore-whitespace --settings-path . --recursive $(CODE_DIRS)
 
-all: lint mypy
+all: lint
 
 lint: mypy
 	flake8 $(CODE_DIRS)
 	isort $(ISORT_PARAMS) --diff --check-only
 
 mypy:
-	mypy --ignore-missing-imports --check-untyped-defs $(CODE_DIRS)
-	mypy --ignore-missing-imports --disallow-untyped-defs src/monitoring_service
+	mypy $(CODE_DIRS)
 
 isort:
 	isort $(ISORT_PARAMS)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,13 @@ known_first_party=raiden,raiden_contracts,raiden_libs,monitoring_service,pathfin
 include_trailing_comma=1
 default_section=THIRDPARTY
 combine_as_imports=1
+
+[mypy]
+ignore_missing_imports = True
+check_untyped_defs = True
+disallow_untyped_defs = True
+warn_unused_configs = True
+warn_unused_ignores = True
+
+[mypy-tests.*]
+disallow_untyped_defs = False

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -46,7 +46,7 @@ def main(
     confirmations: int,
     host: str,
     service_fee: int,
-):
+) -> int:
     """Console script for pathfinding_service.
 
     Logging can be quickly set by specifying a global log level or in a

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -91,7 +91,7 @@ def common_options(app_name: str) -> Callable:
                 expose_value=False,
             ),
         ]):
-            func = option(func)  # type: ignore
+            func = option(func)
         return func
 
     return decorator
@@ -131,7 +131,7 @@ def blockchain_options(func: Callable) -> Callable:
             help='Number of block confirmations to wait for',
         ),
     ]):
-        func = option(func)  # type: ignore
+        func = option(func)
 
     return func
 

--- a/src/request_collector/cli.py
+++ b/src/request_collector/cli.py
@@ -16,7 +16,7 @@ log = structlog.get_logger(__name__)
 def main(
     private_key: str,
     state_db: str,
-):
+) -> int:
     """Console script for request_collector.
 
     Logging can be quickly set by specifying a global log level or in a

--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -1,5 +1,6 @@
 import sys
 import traceback
+from typing import Any
 
 import gevent
 import structlog
@@ -16,7 +17,7 @@ from raiden_libs.matrix import MatrixListener
 log = structlog.get_logger(__name__)
 
 
-def error_handler(_context, exc_info):
+def error_handler(_context: Any, exc_info: tuple) -> None:
     log.critical("Unhandled exception terminating the program")
     traceback.print_exception(
         etype=exc_info[0],
@@ -52,18 +53,18 @@ class RequestCollector(gevent.Greenlet):
             )
             sys.exit(1)
 
-    def listen_forever(self):
+    def listen_forever(self) -> None:
         self.matrix_listener.listen_forever()
 
-    def _run(self):
+    def _run(self) -> None:
         register_error_handler(error_handler)
         self.matrix_listener.start()
 
-    def stop(self):
+    def stop(self) -> None:
         self.matrix_listener.stop()
         self.matrix_listener.join()
 
-    def handle_message(self, message: SignedMessage):
+    def handle_message(self, message: SignedMessage) -> None:
         if isinstance(message, RequestMonitoring):
             self.on_monitor_request(message)
         else:
@@ -72,7 +73,7 @@ class RequestCollector(gevent.Greenlet):
     def on_monitor_request(
         self,
         request_monitoring: RequestMonitoring,
-    ):
+    ) -> None:
         assert isinstance(request_monitoring, RequestMonitoring)
 
         # Convert Raiden's RequestMonitoring object to a MonitorRequest


### PR DESCRIPTION
It's still allowed in tests. Tests don't need to be as strict as the
main code base.

Moving the mypy flags to `setup.cfg` makes IDE integration a bit easier.