### PR TITLE
Use `sync_start_block` in monitoring service

### DIFF
--- a/src/monitoring_service/database.py
+++ b/src/monitoring_service/database.py
@@ -251,12 +251,18 @@ class Database(SharedDatabase):
         msc_address: Address,
         registry_address: Address,
         receiver: str,
+        sync_start_block: BlockNumber = BlockNumber(0),
     ) -> None:
         super(Database, self).__init__(filename, allow_create=True)
-        self._setup(chain_id, msc_address, registry_address, receiver)
+        self._setup(chain_id, msc_address, registry_address, receiver, sync_start_block)
 
     def _setup(
-        self, chain_id: int, msc_address: str, registry_address: str, receiver: str
+        self,
+        chain_id: int,
+        msc_address: str,
+        registry_address: str,
+        receiver: str,
+        sync_start_block: BlockNumber,
     ) -> None:
         """ Make sure that the db is initialized an matches the given settings """
         assert chain_id >= 0
@@ -291,9 +297,10 @@ class Database(SharedDatabase):
                 SET chain_id = ?,
                     monitor_contract_address = ?,
                     token_network_registry_address = ?,
-                    receiver = ?;
+                    receiver = ?,
+                    latest_known_block = ?
             """,
-                settings,
+                settings + [sync_start_block],
             )
 
     def update_state(self, state: MonitoringServiceState) -> None:

--- a/src/monitoring_service/schema.sql
+++ b/src/monitoring_service/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE blockchain (
     receiver                        CHAR(42),
     token_network_registry_address  CHAR(42),
     monitor_contract_address        CHAR(42),
-    latest_known_block              INT NOT NULL DEFAULT -1
+    latest_known_block              INT
 );
 INSERT INTO blockchain DEFAULT VALUES;
 

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -94,6 +94,7 @@ class MonitoringService:
             registry_address=registry_address,
             receiver=self.address,
             msc_address=monitor_contract_address,
+            sync_start_block=sync_start_block,
         )
         ms_state = self.database.load_state()
 


### PR DESCRIPTION
When running the MS for the first time, this will skip all blocks before
Raiden contracts have been deployed.