### PR TITLE
Fix BlockchainListener crash

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,9 +19,9 @@ pytest-cov
 pytest-structlog==0.1
 coverage>=4.5.2
 
-ipython
+ipython==4.2.1
 pdbpp
-psutil
+psutil==5.4.7
 
 eth-tester[py-evm]==0.1.0b33
 attrs==18.2.0  # needed for travis

--- a/src/pathfinding_service/blockchain.py
+++ b/src/pathfinding_service/blockchain.py
@@ -178,8 +178,7 @@ class BlockchainListener(gevent.Greenlet):
         new_unconfirmed_head_number = self.unconfirmed_head_number + self.sync_chunk_size
         new_unconfirmed_head_number = min(new_unconfirmed_head_number, current_block)
         new_confirmed_head_number = max(
-            new_unconfirmed_head_number - self.required_confirmations,
-            self.confirmed_head_number + 1,
+            new_unconfirmed_head_number - self.required_confirmations, self.confirmed_head_number
         )
 
         # return if blocks have already been processed

--- a/tests/pathfinding/test_mocked_integration.py
+++ b/tests/pathfinding/test_mocked_integration.py
@@ -68,6 +68,7 @@ def test_pfs_with_mocked_events(
             dict(
                 address=token_network_address,
                 event='ChannelOpened',
+                blockNumber=13,
                 args=dict(
                     channel_identifier=index,
                     participant1=addresses[p1_index],
@@ -81,6 +82,7 @@ def test_pfs_with_mocked_events(
             dict(
                 address=token_network_address,
                 event='ChannelNewDeposit',
+                blockNumber=14,
                 args=dict(
                     channel_identifier=index,
                     participant=addresses[p1_index],
@@ -93,6 +95,7 @@ def test_pfs_with_mocked_events(
             dict(
                 address=token_network_address,
                 event='ChannelNewDeposit',
+                blockNumber=15,
                 args=dict(
                     channel_identifier=index,
                     participant=addresses[p2_index],
@@ -185,6 +188,7 @@ def test_pfs_with_mocked_events(
             dict(
                 address=token_network_address,
                 event='ChannelClosed',
+                blockNumber=99,
                 args=dict(channel_identifier=index, closing_participant=addresses[p1_index]),
             )
         )
@@ -231,6 +235,7 @@ def test_pfs_idempotency_of_channel_openings(
             dict(
                 address=token_network_address,
                 event='ChannelOpened',
+                blockNumber=13,
                 args=dict(
                     channel_identifier=decode_hex('0x%064x' % 1),
                     participant1=addresses[0],
@@ -248,6 +253,7 @@ def test_pfs_idempotency_of_channel_openings(
         dict(
             address=token_network_address,
             event='ChannelClosed',
+            blockNumber=99,
             args=dict(
                 channel_identifier=decode_hex('0x%064x' % 1), closing_participant=addresses[0]
             ),
@@ -295,6 +301,7 @@ def test_pfs_multiple_channels_for_two_participants_opened(
         dict(
             address=token_network_address,
             event='ChannelOpened',
+            blockNumber=13,
             args=dict(
                 channel_identifier=decode_hex('0x%064x' % 1),
                 participant1=addresses[0],
@@ -309,6 +316,7 @@ def test_pfs_multiple_channels_for_two_participants_opened(
         dict(
             address=token_network_address,
             event='ChannelOpened',
+            blockNumber=14,
             args=dict(
                 channel_identifier=decode_hex('0x%064x' % 2),
                 participant1=addresses[1],
@@ -326,6 +334,7 @@ def test_pfs_multiple_channels_for_two_participants_opened(
         dict(
             address=token_network_address,
             event='ChannelClosed',
+            blockNumber=99,
             args=dict(
                 channel_identifier=decode_hex('0x%064x' % 1), closing_participant=addresses[0]
             ),


### PR DESCRIPTION
In #217 I incorrectly changed the calculation of the `new_confirmed_head_number`.
This change made the number increase by 1 every call, which eventually resulted in asking for a not yet existing block. 

With the default settings this happened after roughly 8 * 10 seconds.

Fixes #223 