### PR TITLE
add initial pfs happy path scenario

### DIFF
--- a/scenarios/simple_pfs_integration_without_reward.yml
+++ b/scenarios/simple_pfs_integration_without_reward.yml
@@ -1,0 +1,84 @@
+version: 2
+
+settings:
+  gas_price: "fast"
+  chain: kovan
+  services:
+    pfs:
+      url: https://pfs-kovan.services-dev.raiden.network
+    udc:
+      enable: true
+      token:
+        deposit: true
+
+token:
+
+nodes:
+  mode: managed
+  count: 4
+  ## add path to Raiden virtual env
+  raiden_version: /home/pirate/raiden/venv/RaidenClient/bin/raiden
+
+  default_options:
+    gas-price: fast
+    environment-type: development
+    routing-mode: pfs
+    pathfinding-max-paths: 5
+
+
+scenario:
+  serial:
+    tasks:
+      - parallel:
+          name: "Open channels"
+          tasks:
+            - open_channel: {from: 0, to: 1, total_deposit: 1000}
+            - open_channel: {from: 0, to: 2, total_deposit: 1000}
+            - open_channel: {from: 3, to: 1, total_deposit: 1000}
+            - open_channel: {from: 3, to: 2, total_deposit: 1000}
+            - open_channel: {from: 1, to: 3, total_deposit: 1000}
+            - open_channel: {from: 2, to: 3, total_deposit: 1000}
+      - serial:
+          name: "Test providing routes"
+          tasks:
+            # node 3 cannot send tokens to node 0 due to imbalanced channels
+            # now we expect the pfs not to send any route
+            - transfer: {from: 3, to: 0, amount: 10, expected_http_status: 409}
+            - assert_pfs_routes: {from: 3, to: 0, amount: 10, expected_paths: 0}
+
+            # node0 two possible routes to node3
+            - assert_pfs_routes: {from: 0, to: 3, amount: 10, expected_paths: 2}
+            - assert_pfs_history: {source: 0, request_count: 1}
+            - assert_pfs_history: {source: 3, request_count: 1}
+            - wait: 60
+            - parallel:
+                name: "Balancing channel 0 <-> 1 <-> 3"
+                tasks:
+                  - transfer: {from: 3, to: 1, amount: 500, expected_http_status: 200}
+                  - transfer: {from: 0, to: 1, amount: 500, expected_http_status: 200}
+            - wait: 60
+            # now we expect the pfs to provide one path
+            - transfer: {from: 3, to: 0, amount: 10, expected_http_status: 200}
+            - assert_pfs_routes: {from: 3, to: 0, amount: 10, expected_paths: 1}
+            - parallel:
+                name: "Balancing channel 0 <-> 2 <-> 3"
+                tasks:
+                  - transfer: {from: 3, to: 2, amount: 500, expected_http_status: 200}
+                  - transfer: {from: 0, to: 2, amount: 500, expected_http_status: 200}
+            - wait: 60
+
+            # now we expect the pfs to provide two paths
+            - transfer: {from: 3, to: 0, amount: 10, expected_http_status: 200}
+            - assert_pfs_routes: {from: 3, to: 0, amount: 10, expected_paths: 2}
+
+            ## 4 requests where made from source node 3 to target node 0 and the specified number of
+            ## routes have been returned
+            - assert_pfs_history: {source: 3, target: 0, request_count: 3, routes_count: [0, 0, 1, 1, 2, 2]}
+
+            ## The listed routes have been returned for requests from source node 0 to target node 3
+            - assert_pfs_history:
+                source: 0
+                target: 3
+                expected_routes:
+                  - [0, 1, 3]
+                  - [0, 2, 3]


### PR DESCRIPTION
This PR add a minimal viable happy path scenario for the PFS. 

Once this scenario passes, I think we have a some working version of the PFS.

Currently it doesn't work since the `assert_pfs_history` task doesn't work yet.