### PR TITLE
Remove import from __init__.py (fix monkeypatch)

### DIFF
--- a/src/pathfinding_service/__init__.py
+++ b/src/pathfinding_service/__init__.py
@@ -1,3 +1,0 @@
-from .service import PathfindingService
-
-__all__ = ['PathfindingService']

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -14,7 +14,6 @@ from networkx.exception import NetworkXNoPath, NodeNotFound
 from web3 import Web3
 
 import pathfinding_service.exceptions as exceptions
-from pathfinding_service import PathfindingService
 from pathfinding_service.config import (
     API_PATH,
     DEFAULT_API_HOST,
@@ -26,6 +25,7 @@ from pathfinding_service.config import (
     UDC_SECURITY_MARGIN_FACTOR,
 )
 from pathfinding_service.model import IOU
+from pathfinding_service.service import PathfindingService
 from raiden.exceptions import InvalidSignature
 from raiden.utils.signer import recover
 from raiden.utils.typing import Signature, TokenAmount

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -12,9 +12,9 @@ import structlog
 from web3 import Web3
 from web3.contract import Contract
 
-from pathfinding_service import PathfindingService
 from pathfinding_service.api import ServiceApi
 from pathfinding_service.config import DEFAULT_API_HOST, DEFAULT_POLL_INTERVALL
+from pathfinding_service.service import PathfindingService
 from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_libs.cli import blockchain_options, common_options

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -8,8 +8,8 @@ from tests.pathfinding.config import NUMBER_OF_CHANNELS
 from web3 import Web3
 from web3.contract import Contract
 
-from pathfinding_service import PathfindingService
 from pathfinding_service.model.token_network import TokenNetwork
+from pathfinding_service.service import PathfindingService
 from raiden.utils.typing import ChannelID, FeeAmount, Nonce, TokenAmount
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_contracts.contract_manager import ContractManager

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -9,9 +9,9 @@ from unittest.mock import Mock, patch
 
 import gevent
 
-from pathfinding_service import PathfindingService
 from pathfinding_service.config import DEFAULT_REVEAL_TIMEOUT
 from pathfinding_service.model import ChannelView
+from pathfinding_service.service import PathfindingService
 from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_contracts.contract_manager import ContractManager


### PR DESCRIPTION
The import in `__init__.py` was executed first when the PFS is executed
via `python -m pathfinding_service.cli` or the setuptools entry point.
This causes the gevent monkeypatching to be executed after SSL imports,
which in turn led to `RecursionError`s.

Closes https://github.com/raiden-network/raiden-services/issues/93.