### PR TITLE
Simplify gevent error handler

### DIFF
--- a/src/raiden_libs/gevent_error_handler.py
+++ b/src/raiden_libs/gevent_error_handler.py
@@ -4,22 +4,19 @@ from gevent.hub import Hub
 
 IGNORE_ERROR = Hub.SYSTEM_ERROR + Hub.NOT_ERROR
 
+_original_error_handler = Hub.handle_error
+
 
 def register_error_handler(error_handler: Callable) -> None:
-    Hub._origin_handle_error = Hub.handle_error
-
-    msg = 'registering the same error handler twice will result in a infinite loop'
-    assert error_handler != Hub._origin_handle_error, msg
+    """Sets the current error handler, overwriting the previous ones"""
 
     def custom_handle_error(self: Any, context: Any, type: Any, value: Any, tb: Any) -> None:
         if not issubclass(type, IGNORE_ERROR):
             error_handler(context, (type, value, tb))
 
-        self._origin_handle_error(context, type, value, tb)
-
     Hub.handle_error = custom_handle_error
 
 
 def unregister_error_handler() -> None:
-    if hasattr(Hub, '_origin_handle_error'):
-        Hub.handle_error = Hub._origin_handle_error
+    """Resets the error handler to the original gevent handler"""
+    Hub.handle_error = _original_error_handler

--- a/tests/pathfinding/conftest.py
+++ b/tests/pathfinding/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from raiden_libs import gevent_error_handler
+
 from tests.pathfinding.fixtures import *  # isort:skip # noqa
 
 
@@ -14,6 +16,5 @@ def pytest_addoption(parser):
 
 @pytest.fixture(autouse=True)
 def unregister_error_handler():
-    from raiden_libs.gevent_error_handler import unregister_error_handler
-
-    unregister_error_handler()
+    yield
+    gevent_error_handler.unregister_error_handler()


### PR DESCRIPTION
The error handler allowed nesting of multiple handlers, which often went
wrong for me causing `RecursionError`s. This in turn obscured the real
error which made debugging tests unnecessarily hard.

Since we don't actually need to nest error handlers, I simplified the
handling code which solves the debugging problems for me.