### PR TITLE
Don't require password confirmation in cli

### DIFF
--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -72,7 +72,11 @@ def common_options(app_name: str) -> Callable:
                     type=click.Path(exists=True, dir_okay=False, readable=True),
                     help='Path to a keystore file.',
                 ),
-                click.password_option('--password', help='Password to unlock the keystore file.'),
+                click.password_option(
+                    '--password',
+                    confirmation_prompt=False,
+                    help='Password to unlock the keystore file.',
+                ),
                 click.option(
                     '--state-db',
                     default=os.path.join(click.get_app_dir(app_name), 'state.db'),


### PR DESCRIPTION
I don't see any reason for a confirmation when opening the keystore. I assume this happened only due to a confirmation being the default.

Closes #257.