### PR TITLE
Add some logging to Flask requests

### DIFF
--- a/src/raiden_libs/logging.py
+++ b/src/raiden_libs/logging.py
@@ -11,20 +11,17 @@ def setup_logging(log_level: str) -> None:
 
     logging.getLogger("web3").setLevel("INFO")
     logging.getLogger("urllib3").setLevel("INFO")
-    # don't show urllib3.connectionpoool errors
-    logging.getLogger("urllib3.connectionpool").setLevel("ERROR")
 
-    chain = [
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.dev.ConsoleRenderer(),
-    ]
-    structlog.configure_once(
-        processors=chain,
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.dev.ConsoleRenderer(),
+        ],
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,


### PR DESCRIPTION
For some reason Flask still logs on it's own, and structlog doesn't pick up that.