### PR TITLE
Fix two reasons for flaky tests

### DIFF
--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -94,7 +94,7 @@ def common_options(app_name: str) -> Callable:
             func = option(func)
 
         @wraps(func)
-        def call_with_opened_keystore(**params: Any) -> Callable:
+        def call_with_common_options_initialized(**params: Any) -> Callable:
             params["private_key"] = _open_keystore(
                 params.pop("keystore_file"), params.pop("password")
             )
@@ -104,7 +104,7 @@ def common_options(app_name: str) -> Callable:
             finally:
                 structlog.reset_defaults()
 
-        return call_with_opened_keystore
+        return call_with_common_options_initialized
 
     return decorator
 

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -88,8 +88,6 @@ def common_options(app_name: str) -> Callable:
                     default="INFO",
                     type=click.Choice(["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]),
                     help="Print log messages of this level and more important ones",
-                    callback=lambda ctx, param, value: setup_logging(str(value)),
-                    expose_value=False,
                 ),
             ]
         ):
@@ -100,7 +98,11 @@ def common_options(app_name: str) -> Callable:
             params["private_key"] = _open_keystore(
                 params.pop("keystore_file"), params.pop("password")
             )
-            return func(**params)
+            try:
+                setup_logging(params.pop("log_level"))
+                return func(**params)
+            finally:
+                structlog.reset_defaults()
 
         return call_with_opened_keystore
 

--- a/tests/monitoring/monitoring_service/test_cli.py
+++ b/tests/monitoring/monitoring_service/test_cli.py
@@ -32,7 +32,7 @@ def test_success(keystore_file, default_cli_args_ms):
 
 
 def test_wrong_password(keystore_file, default_cli_args_ms):
-    """ Calling the monitoring_service with default args should succeed after heavy mocking """
+    """ Using the wrong password should fail, but not raise an exception """
     runner = CliRunner()
     result = runner.invoke(
         main, default_cli_args_ms + ["--password", "wrong"], catch_exceptions=False

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -162,7 +162,7 @@ def test_get_paths_validation(
 
     # bad signature
     bad_iou_dict = good_iou_dict.copy()
-    bad_iou_dict["signature"] = hex(int(bad_iou_dict["signature"], 16) + 1)
+    bad_iou_dict["signature"] = "0x" + "1" * 130
     response = request_path_with(iou=bad_iou_dict)
     assert response.json()["error_code"] == exceptions.InvalidSignature.error_code
 

--- a/tests/pathfinding/test_cli.py
+++ b/tests/pathfinding/test_cli.py
@@ -125,9 +125,14 @@ def test_shutdown(default_cli_args):
 def test_log_level(default_cli_args):
     """ Setting of log level via command line switch """
     runner = CliRunner()
-    with patch.multiple(**patch_args), patch("logging.basicConfig") as basicConfig:
+    with patch.multiple(**patch_args), patch.multiple(**patch_info_args), patch(
+        "logging.basicConfig"
+    ) as basicConfig:
         for log_level in ("CRITICAL", "WARNING"):
-            runner.invoke(main, default_cli_args + ["--log-level", log_level])
+            result = runner.invoke(
+                main, default_cli_args + ["--log-level", log_level], catch_exceptions=False
+            )
+            assert result.exit_code == 0
             # pytest already initializes logging, so basicConfig does not have
             # an effect. Use mocking to check that it's called properly.
             assert logging.getLevelName(basicConfig.call_args[1]["level"] == log_level)


### PR DESCRIPTION
Structlog messes up capturing with `capsys` in some cases when not properly reset. That was hard to find.