### PR TITLE
Rename `--registry-address` CLI flag

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,7 @@ The services share a number of options. These are:
 
     Defaults to ``http://localhost:8545``.
 
-``--registry-address``
+``--token-network-registry-address``
     Defines the address of the token network registry to be used.
 
     Defaults to the contract address that the Raiden client uses for the given

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -116,7 +116,7 @@ def blockchain_options(contracts: List[str], contracts_version: str = None) -> C
     ]
 
     arg_for_contract = {
-        CONTRACT_TOKEN_NETWORK_REGISTRY: "registry",
+        CONTRACT_TOKEN_NETWORK_REGISTRY: "token-network-registry",
         CONTRACT_USER_DEPOSIT: "user-deposit-contract",
         CONTRACT_MONITORING_SERVICE: "monitor-contract",
         CONTRACT_ONE_TO_N: "one-to-n-contract",

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -33,7 +33,7 @@ def server_private_key(ethereum_tester):
 @pytest.fixture
 def default_cli_args_ms(default_cli_args) -> List[str]:
     return default_cli_args + [
-        "--registry-address",
+        "--token-network-registry-address",
         "0x" + "1" * 40,
         "--monitor-contract-address",
         "0x" + "2" * 40,

--- a/tests/pathfinding/test_cli.py
+++ b/tests/pathfinding/test_cli.py
@@ -83,7 +83,9 @@ def test_registry_address(default_cli_args):
     # check validation of address format
     def fails_on_registry_check(address):
         result = runner.invoke(
-            main, default_cli_args + ["--registry-address", address], catch_exceptions=False
+            main,
+            default_cli_args + ["--token-network-registry-address", address],
+            catch_exceptions=False,
         )
         assert result.exit_code != 0
         assert "EIP-55" in result.output


### PR DESCRIPTION
This was ambiguous between token network registry and service registry.