### PR TITLE
Include PFS' eth address in info endpoint

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -260,6 +260,7 @@ class InfoResource(PathfinderResource):
                 "version": self.version,
                 "operator": operator,
                 "message": message,
+                "payment_address": self.pathfinding_service.address,
             },
             200,
         )

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -266,6 +266,7 @@ def test_get_info(api_sut: ServiceApi, api_url: str, pathfinding_service_mock):
         "version": pkg_resources.require("raiden-services")[0].version,
         "operator": "PLACEHOLDER FOR PATHFINDER OPERATOR",
         "message": "PLACEHOLDER FOR ADDITIONAL MESSAGE BY THE PFS",
+        "payment_address": pathfinding_service_mock.address,
     }
 
 


### PR DESCRIPTION
Which allows running the Raiden client with a custom PFS without
manually passing the PFS' eth address to the client.