### PR TITLE
Enable more pylint checks

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -68,7 +68,6 @@ disable=
         unused-wildcard-import,
         len-as-condition,
         # good checks that could be enabled in the future
-        too-many-arguments,
         redefined-outer-name,
         broad-except,
 
@@ -481,7 +480,7 @@ valid-metaclass-classmethod-first-arg=cls
 [DESIGN]
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=7
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7

--- a/pylintrc
+++ b/pylintrc
@@ -71,7 +71,6 @@ disable=
         broad-except,
 
         # checks which have false positive that need to be excluded before enabling
-        invalid-name,
 
         # checks that are done with higher accuracy by mypy
         no-member,
@@ -245,7 +244,23 @@ good-names=i,
            k,
            ex,
            Run,
-           _
+           _,
+           log,
+           x,
+           n,
+           tb,  # traceback
+           cv,  # channel view
+           ms,  # monitoring service
+           mr,  # monitor request
+           rc,  # request collector
+           bp,  # balance proof
+           f,   # generic function or filehandle
+           c1,  # client 1
+           c2,
+           p1,  # participant 1
+           p2,
+           G,   # graph (networkx uses G for graph as mathematicians do)
+           T,   # generic TypeVar used by mypy
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/pylintrc
+++ b/pylintrc
@@ -67,10 +67,6 @@ disable=
         fixme,
         unused-wildcard-import,
         len-as-condition,
-        # good checks that could be enabled in the future
-        broad-except,
-
-        # checks which have false positive that need to be excluded before enabling
 
         # checks that are done with higher accuracy by mypy
         no-member,

--- a/pylintrc
+++ b/pylintrc
@@ -68,7 +68,6 @@ disable=
         unused-wildcard-import,
         len-as-condition,
         # good checks that could be enabled in the future
-        redefined-outer-name,
         broad-except,
 
         # checks which have false positive that need to be excluded before enabling

--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -417,7 +417,7 @@ def action_monitoring_triggered_event_handler(event: Event, context: Context) ->
 
                 channel.closing_tx_hash = tx_hash
                 context.db.upsert_channel(channel)
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-except
             log.error("Sending tx failed", exc_info=True, err=exc)
 
 
@@ -481,7 +481,7 @@ def action_claim_reward_triggered_event_handler(event: Event, context: Context) 
 
                 channel.claim_tx_hash = tx_hash
                 context.db.upsert_channel(channel)
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-except
             log.error("Sending tx failed", exc_info=True, err=exc)
 
 

--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -294,7 +294,7 @@ def monitor_new_balance_proof_event_handler(event: Event, context: Context) -> N
         trigger_block = BlockNumber(channel.closing_block + channel.settle_timeout)
 
         # trigger the claim reward action by an event
-        e = ActionClaimRewardTriggeredEvent(
+        event = ActionClaimRewardTriggeredEvent(
             token_network_address=channel.token_network_address,
             channel_identifier=channel.identifier,
             non_closing_participant=event.raiden_node_address,
@@ -304,7 +304,7 @@ def monitor_new_balance_proof_event_handler(event: Event, context: Context) -> N
         # If the event is already scheduled (e.g. after a restart) the DB takes care that
         # it is only stored once
         context.db.upsert_scheduled_event(
-            ScheduledEvent(trigger_block_number=trigger_block, event=cast(Event, e))
+            ScheduledEvent(trigger_block_number=trigger_block, event=cast(Event, event))
         )
 
 
@@ -417,8 +417,8 @@ def action_monitoring_triggered_event_handler(event: Event, context: Context) ->
 
                 channel.closing_tx_hash = tx_hash
                 context.db.upsert_channel(channel)
-        except Exception as e:
-            log.error("Sending tx failed", exc_info=True, err=e)
+        except Exception as exc:
+            log.error("Sending tx failed", exc_info=True, err=exc)
 
 
 def action_claim_reward_triggered_event_handler(event: Event, context: Context) -> None:
@@ -481,8 +481,8 @@ def action_claim_reward_triggered_event_handler(event: Event, context: Context) 
 
                 channel.claim_tx_hash = tx_hash
                 context.db.upsert_channel(channel)
-        except Exception as e:
-            log.error("Sending tx failed", exc_info=True, err=e)
+        except Exception as exc:
+            log.error("Sending tx failed", exc_info=True, err=exc)
 
 
 HANDLERS = {

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -56,7 +56,7 @@ def handle_event(event: Event, context: Context) -> None:
 
 
 class MonitoringService:  # pylint: disable=too-few-public-methods
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         web3: Web3,
         private_key: str,

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -55,7 +55,7 @@ class HashedBalanceProof:
     additional_hash: str
     signature: Signature
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         channel_identifier: ChannelID,
         token_network_address: TokenNetworkAddress,

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -284,17 +284,19 @@ class DebugEndpoint(PathfinderResource):
     ) -> Tuple[dict, int]:
         request_count = 0
         responses = []
-        for r in last_requests:
-            log.debug("Last Requests Values:", r=r)
+        for req in last_requests:
+            log.debug("Last Requests Values:", req=req)
             matches_params = is_same_address(
-                token_network_address, r["token_network_address"]
-            ) and is_same_address(source_address, r["source"])
+                token_network_address, req["token_network_address"]
+            ) and is_same_address(source_address, req["source"])
             if target_address is not None:
-                matches_params = matches_params and is_same_address(target_address, r["target"])
+                matches_params = matches_params and is_same_address(target_address, req["target"])
 
             if matches_params:
                 request_count += 1
-                responses.append(dict(source=r["source"], target=r["target"], routes=r["routes"]))
+                responses.append(
+                    dict(source=req["source"], target=req["target"], routes=req["routes"])
+                )
 
         return dict(request_count=request_count, responses=responses), 200
 

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -45,7 +45,7 @@ DEFAULT_REQUIRED_CONFIRMATIONS = 8  # ~2min with 15s blocks
 )
 @click.option("--enable-debug", default=False, is_flag=True, hidden=True)
 @common_options("raiden-pathfinding-service")
-def main(
+def main(  # pylint: disable-msg=too-many-arguments
     private_key: str,
     state_db: str,
     web3: Web3,

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -88,8 +88,8 @@ class TokenNetwork:
             ),
         ]
 
-        for v in views:
-            self.add_channel_view(v)
+        for cv in views:
+            self.add_channel_view(cv)
 
         return views
 

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -37,7 +37,7 @@ log = structlog.get_logger(__name__)
 
 class PathfindingService(gevent.Greenlet):
     # pylint: disable=too-many-instance-attributes
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         web3: Web3,
         contracts: Dict[str, Contract],

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -76,8 +76,8 @@ class PathfindingService(gevent.Greenlet):
                 callback=self.handle_message,
                 service_room_suffix=PATH_FINDING_BROADCASTING_ROOM,
             )
-        except ConnectionError as e:
-            log.critical("Could not connect to broadcasting system.", exc=e)
+        except ConnectionError as exc:
+            log.critical("Could not connect to broadcasting system.", exc=exc)
             sys.exit(1)
 
     def _load_token_networks(self) -> Dict[TokenNetworkAddress, TokenNetwork]:

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -125,15 +125,15 @@ def blockchain_options(contracts: List[str], contracts_version: str = None) -> C
     }
 
     param_for_contract: Dict[str, str] = {}
-    for c in contracts:
+    for con in contracts:
         option = click.Option(
-            ["--{}-address".format(arg_for_contract[c])],
+            ["--{}-address".format(arg_for_contract[con])],
             type=str,
-            help=f"Address of the {c} contract",
+            help=f"Address of the {con} contract",
             callback=validate_address,
         )
         options.append(option)
-        param_for_contract[c] = option.human_readable_name
+        param_for_contract[con] = option.human_readable_name
 
     def decorator(command: click.Command) -> click.Command:
         assert command.callback

--- a/src/raiden_libs/gevent_error_handler.py
+++ b/src/raiden_libs/gevent_error_handler.py
@@ -6,7 +6,7 @@ import structlog
 from gevent.hub import Hub
 
 log = structlog.get_logger(__name__)
-_original_error_handler = Hub.handle_error
+ORIGINAL_ERROR_HANDLER = Hub.handle_error
 
 
 def error_handler(_self: Any, _context: Any, etype: Any, value: Any, tb: Any) -> None:
@@ -32,4 +32,4 @@ def register_error_handler() -> None:
 
 def unregister_error_handler() -> None:
     """Resets the error handler to the original gevent handler"""
-    Hub.handle_error = _original_error_handler
+    Hub.handle_error = ORIGINAL_ERROR_HANDLER

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -94,8 +94,8 @@ class MatrixListener(gevent.Greenlet):
         try:
             self.client, self.monitoring_room = self.setup_matrix(service_room_suffix)
             self.monitoring_room.add_listener(self._handle_message, "m.room.message")
-        except ConnectionError as e:
-            log.critical("Could not connect to broadcasting system.", exc=e)
+        except ConnectionError as exc:
+            log.critical("Could not connect to broadcasting system.", exc=exc)
             sys.exit(1)
 
     def listen_forever(self) -> None:

--- a/src/raiden_libs/types.py
+++ b/src/raiden_libs/types.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 from typing import NewType
 
 T_Address = str

--- a/src/raiden_libs/utils.py
+++ b/src/raiden_libs/utils.py
@@ -20,5 +20,5 @@ def private_key_to_address(private_key: Union[str, bytes]) -> Address:
         private_key = to_bytes(hexstr=private_key)
 
     assert isinstance(private_key, bytes)
-    pk = PrivateKey(private_key)
-    return public_key_to_address(pk.public_key)
+    privkey = PrivateKey(private_key)
+    return public_key_to_address(privkey.public_key)

--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -31,8 +31,8 @@ class RequestCollector(gevent.Greenlet):
                 callback=self.handle_message,
                 service_room_suffix=MONITORING_BROADCASTING_ROOM,
             )
-        except ConnectionError as e:
-            log.critical("Could not connect to broadcasting system.", exc=e)
+        except ConnectionError as exc:
+            log.critical("Could not connect to broadcasting system.", exc=exc)
             sys.exit(1)
 
     def listen_forever(self) -> None:

--- a/tests/libs/fixtures/web3.py
+++ b/tests/libs/fixtures/web3.py
@@ -17,11 +17,11 @@ log = logging.getLogger(__name__)
 def wait_for_blocks(web3):
     """Returns a function that blocks until n blocks are mined"""
 
-    def wait_for_blocks(n):
+    def f(n):
         web3.testing.mine(n)
         gevent.sleep()
 
-    return wait_for_blocks
+    return f
 
 
 @pytest.fixture(scope="session")
@@ -32,14 +32,14 @@ def contracts_manager():
 
 @pytest.fixture
 def keystore_file(tmp_path) -> str:
-    keystore_file = tmp_path / KEYSTORE_FILE_NAME
+    filename = tmp_path / KEYSTORE_FILE_NAME
 
     account = Account.create()
     keystore_json = Account.encrypt(private_key=account.privateKey, password=KEYSTORE_PASSWORD)
-    with open(keystore_file, "w") as fp:
+    with open(filename, "w") as fp:
         json.dump(keystore_json, fp)
 
-    return keystore_file
+    return filename
 
 
 @pytest.fixture

--- a/tests/libs/fixtures/web3.py
+++ b/tests/libs/fixtures/web3.py
@@ -36,8 +36,8 @@ def keystore_file(tmp_path) -> str:
 
     account = Account.create()
     keystore_json = Account.encrypt(private_key=account.privateKey, password=KEYSTORE_PASSWORD)
-    with open(filename, "w") as fp:
-        json.dump(keystore_json, fp)
+    with open(filename, "w") as f:
+        json.dump(keystore_json, f)
 
     return filename
 

--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import json
 from unittest.mock import Mock, patch
 

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import logging
 from typing import List
 from unittest.mock import patch

--- a/tests/monitoring/monitoring_service/test_cli.py
+++ b/tests/monitoring/monitoring_service/test_cli.py
@@ -52,11 +52,11 @@ def test_shutdown(default_cli_args_ms, service_mock):
 def test_log_level(default_cli_args_ms):
     """ Setting of log level via command line switch """
     runner = CliRunner()
-    with patch("logging.basicConfig") as basicConfig:
+    with patch("logging.basicConfig") as basic_config:
         for log_level in ("CRITICAL", "WARNING"):
             runner.invoke(
                 main, default_cli_args_ms + ["--log-level", log_level], catch_exceptions=False
             )
             # pytest already initializes logging, so basicConfig does not have
             # an effect. Use mocking to check that it's called properly.
-            assert logging.getLevelName(basicConfig.call_args[1]["level"] == log_level)
+            assert logging.getLevelName(basic_config.call_args[1]["level"] == log_level)

--- a/tests/monitoring/monitoring_service/test_cli.py
+++ b/tests/monitoring/monitoring_service/test_cli.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import logging
 from unittest.mock import MagicMock, Mock, patch
 

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -30,7 +30,7 @@ def create_ms_contract_events_query(
     return f
 
 
-def test_e2e(  # pylint: disable=too-many-locals
+def test_e2e(  # pylint: disable=too-many-arguments,too-many-locals
     web3,
     monitoring_service_contract,
     user_deposit_contract,

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 from unittest.mock import Mock
 
 import pytest

--- a/tests/monitoring/monitoring_service/test_states.py
+++ b/tests/monitoring/monitoring_service/test_states.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import random
 from typing import Callable
 

--- a/tests/monitoring/request_collector/test_cli.py
+++ b/tests/monitoring/request_collector/test_cli.py
@@ -4,13 +4,13 @@ from unittest.mock import DEFAULT, patch
 from click.testing import CliRunner
 from request_collector.cli import main
 
-patch_args = dict(target="request_collector.cli", RequestCollector=DEFAULT)
+PATCH_ARGS = dict(target="request_collector.cli", RequestCollector=DEFAULT)
 
 
 def test_success(default_cli_args):
     """ Calling the request_collector with default args should succeed after heavy mocking """
     runner = CliRunner()
-    with patch.multiple(**patch_args):
+    with patch.multiple(**PATCH_ARGS):
         result = runner.invoke(main, default_cli_args, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -18,7 +18,7 @@ def test_success(default_cli_args):
 def test_wrong_password(default_cli_args):
     """ Calling the request_collector with default args should succeed after heavy mocking """
     runner = CliRunner()
-    with patch.multiple(**patch_args):
+    with patch.multiple(**PATCH_ARGS):
         result = runner.invoke(
             main, default_cli_args + ["--password", "wrong"], catch_exceptions=False
         )
@@ -28,7 +28,7 @@ def test_wrong_password(default_cli_args):
 def test_shutdown(default_cli_args):
     """ Clean shutdown after KeyboardInterrupt """
     runner = CliRunner()
-    with patch.multiple(**patch_args) as mocks:
+    with patch.multiple(**PATCH_ARGS) as mocks:
         mocks["RequestCollector"].return_value.run.side_effect = KeyboardInterrupt
         result = runner.invoke(main, default_cli_args, catch_exceptions=False)
         assert result.exit_code == 0
@@ -39,11 +39,11 @@ def test_shutdown(default_cli_args):
 def test_log_level(default_cli_args):
     """ Setting of log level via command line switch """
     runner = CliRunner()
-    with patch.multiple(**patch_args), patch("logging.basicConfig") as basicConfig:
+    with patch.multiple(**PATCH_ARGS), patch("logging.basicConfig") as basic_config:
         for log_level in ("CRITICAL", "WARNING"):
             runner.invoke(
                 main, default_cli_args + ["--log-level", log_level], catch_exceptions=False
             )
             # pytest already initializes logging, so basicConfig does not have
             # an effect. Use mocking to check that it's called properly.
-            assert logging.getLevelName(basicConfig.call_args[1]["level"] == log_level)
+            assert logging.getLevelName(basic_config.call_args[1]["level"] == log_level)

--- a/tests/monitoring/request_collector/test_server.py
+++ b/tests/monitoring/request_collector/test_server.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import pytest
 from eth_utils import decode_hex, to_checksum_address
 

--- a/tests/pathfinding/fixtures/accounts.py
+++ b/tests/pathfinding/fixtures/accounts.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 from typing import List
 
 import pytest

--- a/tests/pathfinding/fixtures/api.py
+++ b/tests/pathfinding/fixtures/api.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 from itertools import count
 from typing import Iterator
 

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -3,13 +3,23 @@ from typing import Callable, Generator, List
 from unittest.mock import Mock, patch
 
 import pytest
+from eth_utils import decode_hex
 from tests.pathfinding.config import NUMBER_OF_CHANNELS
 from web3 import Web3
 from web3.contract import Contract
 
 from pathfinding_service.model.token_network import TokenNetwork
 from pathfinding_service.service import PathfindingService
-from raiden.utils.typing import ChannelID, FeeAmount, Nonce, TokenAmount
+from raiden.messages import UpdatePFS
+from raiden.utils import CanonicalIdentifier
+from raiden.utils.typing import (
+    ChainID,
+    ChannelID,
+    FeeAmount,
+    Nonce,
+    TokenAmount,
+    TokenNetworkAddress as TokenNetworkAddressBytes,
+)
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_libs.types import Address
 from raiden_libs.utils import private_key_to_address
@@ -166,26 +176,42 @@ def populate_token_network_random(
         token_network_model.handle_channel_new_deposit_event(channel_id, address1, deposit1)
         token_network_model.handle_channel_new_deposit_event(channel_id, address2, deposit2)
         token_network_model.handle_channel_balance_update_message(
-            channel_identifier=channel_id,
-            updating_participant=address1,
-            other_participant=address2,
-            updating_nonce=Nonce(1),
-            other_nonce=Nonce(1),
-            updating_capacity=deposit1,
-            other_capacity=deposit2,
-            reveal_timeout=2,
-            mediation_fee=FeeAmount(0),
+            UpdatePFS(
+                canonical_identifier=CanonicalIdentifier(
+                    chain_identifier=ChainID(1),
+                    channel_identifier=channel_id,
+                    token_network_address=TokenNetworkAddressBytes(
+                        decode_hex(token_network_model.address)
+                    ),
+                ),
+                updating_participant=decode_hex(address1),
+                other_participant=decode_hex(address2),
+                updating_nonce=Nonce(1),
+                other_nonce=Nonce(1),
+                updating_capacity=deposit1,
+                other_capacity=deposit2,
+                reveal_timeout=2,
+                mediation_fee=FeeAmount(0),
+            )
         )
         token_network_model.handle_channel_balance_update_message(
-            channel_identifier=channel_id,
-            updating_participant=address2,
-            other_participant=address1,
-            updating_nonce=Nonce(2),
-            other_nonce=Nonce(1),
-            updating_capacity=deposit1,
-            other_capacity=deposit2,
-            reveal_timeout=2,
-            mediation_fee=FeeAmount(0),
+            UpdatePFS(
+                canonical_identifier=CanonicalIdentifier(
+                    chain_identifier=ChainID(1),
+                    channel_identifier=channel_id,
+                    token_network_address=TokenNetworkAddressBytes(
+                        decode_hex(token_network_model.address)
+                    ),
+                ),
+                updating_participant=decode_hex(address2),
+                other_participant=decode_hex(address1),
+                updating_nonce=Nonce(2),
+                other_nonce=Nonce(1),
+                updating_capacity=deposit2,
+                other_capacity=deposit1,
+                reveal_timeout=2,
+                mediation_fee=FeeAmount(0),
+            )
         )
 
 
@@ -225,26 +251,42 @@ def populate_token_network() -> Callable:
             )
 
             token_network.handle_channel_balance_update_message(
-                channel_identifier=ChannelID(channel_id),
-                updating_participant=addresses[p1_index],
-                other_participant=addresses[p2_index],
-                updating_nonce=Nonce(1),
-                other_nonce=Nonce(1),
-                updating_capacity=p1_capacity,
-                other_capacity=p2_capacity,
-                reveal_timeout=p1_reveal_timeout,
-                mediation_fee=FeeAmount(0),
+                UpdatePFS(
+                    canonical_identifier=CanonicalIdentifier(
+                        chain_identifier=ChainID(1),
+                        channel_identifier=ChannelID(channel_id),
+                        token_network_address=TokenNetworkAddressBytes(
+                            decode_hex(token_network.address)
+                        ),
+                    ),
+                    updating_participant=decode_hex(addresses[p1_index]),
+                    other_participant=decode_hex(addresses[p2_index]),
+                    updating_nonce=Nonce(1),
+                    other_nonce=Nonce(1),
+                    updating_capacity=p1_capacity,
+                    other_capacity=p2_capacity,
+                    reveal_timeout=p1_reveal_timeout,
+                    mediation_fee=FeeAmount(0),
+                )
             )
             token_network.handle_channel_balance_update_message(
-                channel_identifier=ChannelID(channel_id),
-                updating_participant=addresses[p2_index],
-                other_participant=addresses[p1_index],
-                updating_nonce=Nonce(2),
-                other_nonce=Nonce(1),
-                updating_capacity=p2_capacity,
-                other_capacity=p1_capacity,
-                reveal_timeout=p2_reveal_timeout,
-                mediation_fee=FeeAmount(0),
+                UpdatePFS(
+                    canonical_identifier=CanonicalIdentifier(
+                        chain_identifier=ChainID(1),
+                        channel_identifier=ChannelID(channel_id),
+                        token_network_address=TokenNetworkAddressBytes(
+                            decode_hex(token_network.address)
+                        ),
+                    ),
+                    updating_participant=decode_hex(addresses[p2_index]),
+                    other_participant=decode_hex(addresses[p1_index]),
+                    updating_nonce=Nonce(2),
+                    other_nonce=Nonce(1),
+                    updating_capacity=p2_capacity,
+                    other_capacity=p1_capacity,
+                    reveal_timeout=p2_reveal_timeout,
+                    mediation_fee=FeeAmount(0),
+                )
             )
 
     return populate_token_network

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import random
 from typing import Callable, Generator, List
 from unittest.mock import Mock, patch

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -23,7 +23,7 @@ from raiden_contracts.constants import (
 from raiden_contracts.tests.utils.constants import EMPTY_LOCKSROOT
 
 
-def test_pfs_with_mocked_client(
+def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
     web3,
     token_network_registry_contract,
     channel_descriptions_case_1: List,

--- a/tests/pathfinding/test_capacity_updates.py
+++ b/tests/pathfinding/test_capacity_updates.py
@@ -74,7 +74,7 @@ def setup_channel_with_deposits(service: PathfindingService) -> TokenNetwork:
     return token_network
 
 
-def get_updatepfs_message(
+def get_updatepfs_message(  # pylint: disable=too-many-arguments
     updating_participant: Address,
     other_participant: Address,
     chain_identifier=ChainID(1),

--- a/tests/pathfinding/test_cli.py
+++ b/tests/pathfinding/test_cli.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import logging
 from unittest.mock import DEFAULT, MagicMock, Mock, patch
 

--- a/tests/pathfinding/test_cli.py
+++ b/tests/pathfinding/test_cli.py
@@ -12,13 +12,13 @@ from raiden_contracts.constants import (
     CONTRACT_USER_DEPOSIT,
 )
 
-patch_args = {
+PATCH_ARGS = {
     "target": "pathfinding_service.cli",
     "PathfindingService": DEFAULT,
     "ServiceApi": DEFAULT,
 }
 
-patch_info_args = {
+PATCH_INFO_ARGS = {
     "target": "raiden_libs.cli",
     "get_contract_addresses_and_start_block": MagicMock(
         return_value=(
@@ -64,7 +64,7 @@ def test_bad_eth_client(log, default_cli_args):
 def test_success(default_cli_args):
     """ Calling the pathfinding_service with default args should succeed after heavy mocking """
     runner = CliRunner()
-    with patch.multiple(**patch_args), patch.multiple(**patch_info_args):
+    with patch.multiple(**PATCH_ARGS), patch.multiple(**PATCH_INFO_ARGS):
         result = runner.invoke(main, default_cli_args, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -100,7 +100,7 @@ def test_registry_address(default_cli_args):
 def test_confirmations(default_cli_args):
     """ The `confirmations` parameter must reach the `PathfindingService` """
     runner = CliRunner()
-    with patch.multiple(**patch_args) as mocks, patch.multiple(**patch_info_args):
+    with patch.multiple(**PATCH_ARGS) as mocks, patch.multiple(**PATCH_INFO_ARGS):
         confirmations = 77
         result = runner.invoke(
             main,
@@ -115,7 +115,7 @@ def test_confirmations(default_cli_args):
 def test_shutdown(default_cli_args):
     """ Clean shutdown after KeyboardInterrupt """
     runner = CliRunner()
-    with patch.multiple(**patch_args) as mocks, patch.multiple(**patch_info_args):
+    with patch.multiple(**PATCH_ARGS) as mocks, patch.multiple(**PATCH_INFO_ARGS):
         mocks["PathfindingService"].return_value.run.side_effect = KeyboardInterrupt
         result = runner.invoke(main, default_cli_args, catch_exceptions=False)
         assert result.exit_code == 0
@@ -128,9 +128,9 @@ def test_shutdown(default_cli_args):
 def test_log_level(default_cli_args):
     """ Setting of log level via command line switch """
     runner = CliRunner()
-    with patch.multiple(**patch_args), patch.multiple(**patch_info_args), patch(
+    with patch.multiple(**PATCH_ARGS), patch.multiple(**PATCH_INFO_ARGS), patch(
         "logging.basicConfig"
-    ) as basicConfig:
+    ) as basic_config:
         for log_level in ("CRITICAL", "WARNING"):
             result = runner.invoke(
                 main, default_cli_args + ["--log-level", log_level], catch_exceptions=False
@@ -138,4 +138,4 @@ def test_log_level(default_cli_args):
             assert result.exit_code == 0
             # pytest already initializes logging, so basicConfig does not have
             # an effect. Use mocking to check that it's called properly.
-            assert logging.getLevelName(basicConfig.call_args[1]["level"] == log_level)
+            assert logging.getLevelName(basic_config.call_args[1]["level"] == log_level)

--- a/tests/pathfinding/test_middleware.py
+++ b/tests/pathfinding/test_middleware.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 import requests.exceptions
-import web3
+from web3 import Web3
 from web3.providers import HTTPProvider
 
 from pathfinding_service.middleware import http_retry_with_backoff_middleware
@@ -20,7 +20,7 @@ def test_retries(make_post_request_mock):
 
     provider = HTTPProvider()
     provider.middlewares.replace("http_retry_request", quick_retry_middleware)
-    w3 = web3.Web3(provider)
+    w3 = Web3(provider)
 
     # log the time since start each time the mock is called
     start_time = time()

--- a/tests/pathfinding/test_middleware.py
+++ b/tests/pathfinding/test_middleware.py
@@ -20,7 +20,7 @@ def test_retries(make_post_request_mock):
 
     provider = HTTPProvider()
     provider.middlewares.replace("http_retry_request", quick_retry_middleware)
-    w3 = Web3(provider)
+    web3 = Web3(provider)
 
     # log the time since start each time the mock is called
     start_time = time()
@@ -34,7 +34,7 @@ def test_retries(make_post_request_mock):
 
     # the call must fail after the number of retries is exceeded
     with pytest.raises(requests.exceptions.ConnectionError):
-        w3.eth.blockNumber()
+        web3.eth.blockNumber()
 
     # check timings
     assert make_post_request_mock.call_count == 5
@@ -45,5 +45,5 @@ def test_retries(make_post_request_mock):
     start_time = time()
     retry_times = []
     with pytest.raises(requests.exceptions.ConnectionError):
-        w3.eth.blockNumber()
+        web3.eth.blockNumber()
     assert retry_times == pytest.approx(expected_times, abs=0.002, rel=0.3)


### PR DESCRIPTION
I've reduced the strictness of some checks and added a lot of `disable` comments, but now we can start eliminating those when touching the respective parts of the code and we won't accidentally add new code that violates one of these checks.

Relates to https://github.com/raiden-network/raiden-services/issues/280.