### PR TITLE
Add feedback API

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -161,7 +161,7 @@ class PathsResource(PathfinderResource):
             token_network_address=token_network.address,
         )
 
-        return {"result": {"paths": paths, "feedback_token": feedback_token.id.hex}}, 200
+        return {"result": paths, "feedback_token": feedback_token.id.hex}, 200
 
 
 def create_and_store_feedback_token(
@@ -301,11 +301,9 @@ class FeedbackResource(PathfinderResource):
         )
 
         # The client doesn't need to know whether the feedback was accepted or not,
-        # so in case the token is invalid we still return HTTP 200
-        if not feedback_token:
-            return {}, 200
-        if not feedback_token.is_valid():
-            return {}, 200
+        # so in case the token is invalid we return HTTP 400 without further infos
+        if not feedback_token or not feedback_token.is_valid():
+            return {}, 400
 
         log.info("Received feedback", feedback=feedback_request)
         token_network.feedback.append(

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -2,7 +2,7 @@ import collections
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, TypeVar, cast
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import marshmallow
 import pkg_resources
@@ -167,9 +167,7 @@ class PathsResource(PathfinderResource):
 def create_and_store_feedback_token(
     pathfinding_service: PathfindingService, token_network_address: TokenNetworkAddress
 ) -> FeedbackToken:
-    feedback_token = FeedbackToken(
-        id=uuid4(), creation_time=datetime.utcnow(), token_network_address=token_network_address
-    )
+    feedback_token = FeedbackToken(token_network_address=token_network_address)
     pathfinding_service.database.insert_feedback_token(feedback_token)
 
     return feedback_token

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -160,9 +160,8 @@ class PathsResource(PathfinderResource):
             pathfinding_service=self.pathfinding_service,
             token_network_address=token_network.address,
         )
-        assert feedback_token
 
-        return {"result": paths}, 200
+        return {"result": {"paths": paths, "feedback_token": feedback_token.id.hex}}, 200
 
 
 def create_and_store_feedback_token(

--- a/src/pathfinding_service/config.py
+++ b/src/pathfinding_service/config.py
@@ -22,6 +22,7 @@ DEFAULT_POLL_INTERVALL = 10
 MIN_IOU_EXPIRY: int = 7 * 24 * 60 * 4
 
 MAX_AGE_OF_IOU_REQUESTS: timedelta = timedelta(hours=1)
+MAX_AGE_OF_FEEDBACK_REQUESTS: timedelta = timedelta(minutes=10)
 
 # Since the UDC deposits are not double spend safe, you want a higher deposit
 # than you're able to claim to reduce the possibility of double spends.

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -235,9 +235,9 @@ class PFSDatabase(BaseDatabase):
 
         if token:
             return FeedbackToken(
+                token_network_address=decode_hex(token["token_network_address"]),
                 id=UUID(token["token_id"]),
                 creation_time=token["creation_time"],
-                token_network_address=decode_hex(token["token_network_address"]),
             )
 
         return None

--- a/src/pathfinding_service/exceptions.py
+++ b/src/pathfinding_service/exceptions.py
@@ -35,17 +35,17 @@ class InvalidRequest(ApiException):
 
 class InvalidSignature(ApiException):
     error_code = 2001
-    msg = "The signature did not match the signed content"
+    msg = "The signature did not match the signed content."
 
 
 class RequestOutdated(ApiException):
     error_code = 2002
-    msg = "The request contains too old timestamps or nonces"
+    msg = "The request contains too old timestamps or nonces."
 
 
 class InvalidTokenNetwork(ApiException):
     error_code = 2003
-    msg = "Invalid token network"
+    msg = "Invalid token network."
 
 
 class UnsupportedTokenNetwork(ApiException):
@@ -62,22 +62,22 @@ class BadIOU(ApiException):
 
 class MissingIOU(BadIOU):
     error_code = 2101
-    msg = "No IOU for service fees has been provided"
+    msg = "No IOU for service fees has been provided."
 
 
 class WrongIOURecipient(BadIOU):
     error_code = 2102
-    msg = "IOU not addressed to the correct receiver"
+    msg = "IOU not addressed to the correct receiver."
 
 
 class IOUExpiredTooEarly(BadIOU):
     error_code = 2103
-    msg = "Please use a higher `expiration_block`"
+    msg = "Please use a higher `expiration_block`."
 
 
 class InsufficientServicePayment(BadIOU):
     error_code = 2104
-    msg = "The provided payment is lower than service fee"
+    msg = "The provided payment is lower than service fee."
 
 
 class IOUAlreadyClaimed(BadIOU):
@@ -101,4 +101,4 @@ class DepositTooLow(BadIOU):
 class NoRouteFound(ApiException):
     error_code = 2201
     http_code = 404
-    msg = "No route between nodes found"
+    msg = "No route between nodes found."

--- a/src/pathfinding_service/model/__init__.py
+++ b/src/pathfinding_service/model/__init__.py
@@ -1,6 +1,6 @@
 from .channel_view import ChannelView
-from .feedback import FeedbackToken, RouteFeedback
+from .feedback import FeedbackToken
 from .iou import IOU
 from .token_network import TokenNetwork
 
-__all__ = ["ChannelView", "TokenNetwork", "IOU", "FeedbackToken", "RouteFeedback"]
+__all__ = ["ChannelView", "TokenNetwork", "IOU", "FeedbackToken"]

--- a/src/pathfinding_service/model/__init__.py
+++ b/src/pathfinding_service/model/__init__.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
+from pathfinding_service.config import MAX_AGE_OF_FEEDBACK_REQUESTS
+
 from .channel_view import ChannelView
 from .iou import IOU
 from .token_network import TokenNetwork
@@ -13,3 +15,7 @@ __all__ = ["ChannelView", "TokenNetwork", "IOU", "FeedbackToken"]
 class FeedbackToken:
     id: UUID
     creation_time: datetime
+
+    def is_valid(self) -> bool:
+        """ Checks if the token is valid."""
+        return self.creation_time + MAX_AGE_OF_FEEDBACK_REQUESTS > datetime.utcnow()

--- a/src/pathfinding_service/model/__init__.py
+++ b/src/pathfinding_service/model/__init__.py
@@ -1,21 +1,6 @@
-from dataclasses import dataclass
-from datetime import datetime
-from uuid import UUID
-
-from pathfinding_service.config import MAX_AGE_OF_FEEDBACK_REQUESTS
-
 from .channel_view import ChannelView
+from .feedback import FeedbackToken, RouteFeedback
 from .iou import IOU
 from .token_network import TokenNetwork
 
-__all__ = ["ChannelView", "TokenNetwork", "IOU", "FeedbackToken"]
-
-
-@dataclass
-class FeedbackToken:
-    id: UUID
-    creation_time: datetime
-
-    def is_valid(self) -> bool:
-        """ Checks if the token is valid."""
-        return self.creation_time + MAX_AGE_OF_FEEDBACK_REQUESTS > datetime.utcnow()
+__all__ = ["ChannelView", "TokenNetwork", "IOU", "FeedbackToken", "RouteFeedback"]

--- a/src/pathfinding_service/model/feedback.py
+++ b/src/pathfinding_service/model/feedback.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from pathfinding_service.config import MAX_AGE_OF_FEEDBACK_REQUESTS
+from raiden.utils import Address, TokenNetworkAddress
+
+
+@dataclass
+class FeedbackToken:
+    id: UUID
+    creation_time: datetime
+    token_network_address: TokenNetworkAddress
+
+    def is_valid(self) -> bool:
+        """ Checks if the token is valid."""
+        return self.creation_time + MAX_AGE_OF_FEEDBACK_REQUESTS > datetime.utcnow()
+
+
+@dataclass
+class RouteFeedback:
+    status: str
+    received_time: datetime
+    path: List[Address]

--- a/src/pathfinding_service/model/feedback.py
+++ b/src/pathfinding_service/model/feedback.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import List
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from pathfinding_service.config import MAX_AGE_OF_FEEDBACK_REQUESTS
 from raiden.utils import Address, TokenNetworkAddress
@@ -9,9 +9,9 @@ from raiden.utils import Address, TokenNetworkAddress
 
 @dataclass
 class FeedbackToken:
-    id: UUID
-    creation_time: datetime
     token_network_address: TokenNetworkAddress
+    id: UUID = field(default_factory=uuid4)
+    creation_time: datetime = field(default_factory=datetime.utcnow)
 
     def is_valid(self) -> bool:
         """ Checks if the token is valid."""

--- a/src/pathfinding_service/model/feedback.py
+++ b/src/pathfinding_service/model/feedback.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List
 from uuid import UUID, uuid4
 
 from pathfinding_service.config import MAX_AGE_OF_FEEDBACK_REQUESTS
-from raiden.utils import Address, TokenNetworkAddress
+from raiden.utils import TokenNetworkAddress
 
 
 @dataclass
@@ -16,10 +15,3 @@ class FeedbackToken:
     def is_valid(self) -> bool:
         """ Checks if the token is valid."""
         return self.creation_time + MAX_AGE_OF_FEEDBACK_REQUESTS > datetime.utcnow()
-
-
-@dataclass
-class RouteFeedback:
-    status: str
-    received_time: datetime
-    path: List[Address]

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -12,7 +12,6 @@ from pathfinding_service.config import (
     FEE_PEN_DEFAULT,
 )
 from pathfinding_service.model.channel_view import ChannelView
-from pathfinding_service.model.feedback import RouteFeedback
 from raiden.messages import UpdatePFS
 from raiden.utils.typing import Address, ChannelID, TokenAmount, TokenNetworkAddress
 
@@ -44,7 +43,6 @@ class TokenNetwork:
         self.channel_id_to_addresses: Dict[ChannelID, Tuple[Address, Address]] = dict()
         self.G = DiGraph()
         self.max_relative_fee = 0
-        self.feedback: List[RouteFeedback] = []
 
     def __repr__(self) -> str:
         return (

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -12,6 +12,7 @@ from pathfinding_service.config import (
     FEE_PEN_DEFAULT,
 )
 from pathfinding_service.model.channel_view import ChannelView
+from pathfinding_service.model.feedback import RouteFeedback
 from raiden.messages import UpdatePFS
 from raiden.utils.typing import Address, ChannelID, TokenAmount, TokenNetworkAddress
 
@@ -43,6 +44,7 @@ class TokenNetwork:
         self.channel_id_to_addresses: Dict[ChannelID, Tuple[Address, Address]] = dict()
         self.G = DiGraph()
         self.max_relative_fee = 0
+        self.feedback: List[RouteFeedback] = []
 
     def __repr__(self) -> str:
         return (

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -52,5 +52,6 @@ CREATE TABLE capacity_update (
 CREATE TABLE feedback_token (
     token_id CHAR(32) NOT NULL,
     creation_time TIMESTAMP NOT NULL,
+    token_network_address CHAR(42) NOT NULL,
     PRIMARY KEY (token_id)
 );

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -49,9 +49,12 @@ CREATE TABLE capacity_update (
     PRIMARY KEY (updating_participant, token_network_address, channel_id)
 );
 
-CREATE TABLE feedback_token (
+CREATE TABLE feedback (
     token_id CHAR(32) NOT NULL,
     creation_time TIMESTAMP NOT NULL,
     token_network_address CHAR(42) NOT NULL,
-    PRIMARY KEY (token_id)
+    route TEXT NOT NULL,
+    successful BOOLEAN CHECK (successful IN (0,1)),
+    feedback_time TIMESTAMP,
+    PRIMARY KEY (token_id, token_network_address, route)
 );

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -6,6 +6,7 @@ import pkg_resources
 import pytest
 import requests
 from eth_utils import decode_hex, encode_hex, to_bytes, to_checksum_address, to_normalized_address
+from tests.pathfinding.test_database import db_has_feedback_for
 
 import pathfinding_service.exceptions as exceptions
 from pathfinding_service.api import DEFAULT_MAX_PATHS, ServiceApi
@@ -363,7 +364,7 @@ def test_feedback(api_sut: ServiceApi, api_url: str, token_network_model: TokenN
 
     response = make_request(token_id=token.id.hex)
     assert response.status_code == 400
-    assert not database.has_feedback_for(token, default_path)
+    assert not db_has_feedback_for(database, token, default_path)
 
     # Test expired token
     old_token = FeedbackToken(
@@ -374,7 +375,7 @@ def test_feedback(api_sut: ServiceApi, api_url: str, token_network_model: TokenN
 
     response = make_request(token_id=old_token.id.hex)
     assert response.status_code == 400
-    assert not database.has_feedback_for(token, default_path)
+    assert not db_has_feedback_for(database, token, default_path)
 
     # Test valid token
     token = FeedbackToken(token_network_address=token_network_model.address)
@@ -382,4 +383,4 @@ def test_feedback(api_sut: ServiceApi, api_url: str, token_network_model: TokenN
 
     response = make_request(token_id=token.id.hex)
     assert response.status_code == 200
-    assert database.has_feedback_for(token, default_path)
+    assert db_has_feedback_for(database, token, default_path)

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -61,7 +61,7 @@ def test_get_paths_via_debug_endpoint(
         },
     )
     assert response.status_code == 200
-    paths = response.json()["result"]
+    paths = response.json()["result"]["paths"]
     assert len(paths) == 1
     assert paths == [{"path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]], "estimated_fee": 0}]
 
@@ -227,14 +227,14 @@ def test_get_paths(api_url: str, addresses: List[Address], token_network_model: 
     data = {"from": hex_addrs[0], "to": hex_addrs[2], "value": 10, "max_paths": DEFAULT_MAX_PATHS}
     response = requests.post(url, json=data)
     assert response.status_code == 200
-    paths = response.json()["result"]
+    paths = response.json()["result"]["paths"]
     assert len(paths) == 1
     assert paths == [{"path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]], "estimated_fee": 0}]
 
     # check default value for num_path
     data = {"from": hex_addrs[0], "to": hex_addrs[2], "value": 10}
     default_response = requests.post(url, json=data)
-    assert default_response.json()["result"] == response.json()["result"]
+    assert default_response.json()["result"]["paths"] == response.json()["result"]["paths"]
 
     # impossible routes
     for source, dest in [

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -355,11 +355,7 @@ def test_feedback(api_sut: ServiceApi, api_url: str, token_network_model: TokenN
     assert response.json()["error_code"] == exceptions.InvalidRequest.error_code
 
     # Test valid IOU, but not in PFS DB
-    token = FeedbackToken(
-        id=uuid4(),
-        creation_time=datetime.utcnow(),
-        token_network_address=token_network_model.address,
-    )
+    token = FeedbackToken(token_network_address=token_network_model.address)
 
     response = make_request(token_id=token.id.hex)
     assert response.status_code == 200
@@ -367,7 +363,6 @@ def test_feedback(api_sut: ServiceApi, api_url: str, token_network_model: TokenN
 
     # Test old IOU
     old_token = FeedbackToken(
-        id=uuid4(),
         creation_time=datetime.utcnow() - timedelta(hours=1),
         token_network_address=token_network_model.address,
     )
@@ -378,11 +373,7 @@ def test_feedback(api_sut: ServiceApi, api_url: str, token_network_model: TokenN
     assert len(token_network_model.feedback) == 0
 
     # Test working IOU
-    token = FeedbackToken(
-        id=uuid4(),
-        creation_time=datetime.utcnow(),
-        token_network_address=token_network_model.address,
-    )
+    token = FeedbackToken(token_network_address=token_network_model.address)
     api_sut.pathfinding_service.database.insert_feedback_token(token)
 
     response = make_request(token_id=token.id.hex)

--- a/tests/pathfinding/test_database.py
+++ b/tests/pathfinding/test_database.py
@@ -1,15 +1,23 @@
 from datetime import datetime
 from uuid import uuid4
 
-from pathfinding_service.model import FeedbackToken
+from pathfinding_service.model.feedback import FeedbackToken
+from raiden.utils import TokenNetworkAddress
 
 
 def test_save_and_load_feedback_token(pathfinding_service_mock):
-    token = FeedbackToken(id=uuid4(), creation_time=datetime.utcnow())
+    token_network_address = TokenNetworkAddress(b"1" * 20)
+    token = FeedbackToken(
+        id=uuid4(), creation_time=datetime.utcnow(), token_network_address=token_network_address
+    )
     pathfinding_service_mock.database.insert_feedback_token(token)
 
-    stored = pathfinding_service_mock.database.get_feedback_token(token_id=token.id)
+    stored = pathfinding_service_mock.database.get_feedback_token(
+        token_id=token.id, token_network_address=token_network_address
+    )
     assert stored == token
 
-    stored = pathfinding_service_mock.database.get_feedback_token(token_id=uuid4())
+    stored = pathfinding_service_mock.database.get_feedback_token(
+        token_id=uuid4(), token_network_address=token_network_address
+    )
     assert stored is None

--- a/tests/pathfinding/test_database.py
+++ b/tests/pathfinding/test_database.py
@@ -1,20 +1,69 @@
 from uuid import uuid4
 
 from pathfinding_service.model.feedback import FeedbackToken
-from raiden.utils import TokenNetworkAddress
+from raiden.utils import Address, TokenNetworkAddress
 
 
-def test_save_and_load_feedback_token(pathfinding_service_mock):
+def test_insert_feedback_token(pathfinding_service_mock):
     token_network_address = TokenNetworkAddress(b"1" * 20)
-    token = FeedbackToken(token_network_address=token_network_address)
-    pathfinding_service_mock.database.insert_feedback_token(token)
+    route = [Address(b"2" * 20), Address(b"3" * 20)]
 
-    stored = pathfinding_service_mock.database.get_feedback_token(
-        token_id=token.id, token_network_address=token_network_address
+    token = FeedbackToken(token_network_address=token_network_address)
+    database = pathfinding_service_mock.database
+    database.prepare_feedback(token=token, route=route)
+
+    # Test round-trip
+    stored = database.get_feedback_token(
+        token_id=token.id, token_network_address=token_network_address, route=route
     )
     assert stored == token
 
-    stored = pathfinding_service_mock.database.get_feedback_token(
-        token_id=uuid4(), token_network_address=token_network_address
+    # Test different UUID
+    stored = database.get_feedback_token(
+        token_id=uuid4(), token_network_address=token_network_address, route=route
     )
     assert stored is None
+
+    # Test different token network address
+    token_network_address_wrong = TokenNetworkAddress(b"9" * 20)
+    stored = database.get_feedback_token(
+        token_id=uuid4(), token_network_address=token_network_address_wrong, route=route
+    )
+    assert stored is None
+
+    # Test different route
+    route_wrong = [Address(b"2" * 20), Address(b"3" * 20), Address(b"4" * 20)]
+    stored = database.get_feedback_token(
+        token_id=uuid4(), token_network_address=token_network_address, route=route_wrong
+    )
+    assert stored is None
+
+    # Test empty route
+    stored = database.get_feedback_token(
+        token_id=uuid4(), token_network_address=token_network_address, route=[]
+    )
+    assert stored is None
+
+
+def test_feedback(pathfinding_service_mock):
+    token_network_address = TokenNetworkAddress(b"1" * 20)
+    route = [Address(b"2" * 20), Address(b"3" * 20)]
+    other_route = [Address(b"2" * 20), Address(b"4" * 20)]
+
+    token = FeedbackToken(token_network_address=token_network_address)
+    other_token = FeedbackToken(token_network_address=token_network_address)
+
+    database = pathfinding_service_mock.database
+    assert not database.has_feedback_for(token=token, route=route)
+    assert not database.has_feedback_for(token=token, route=other_route)
+    assert not database.has_feedback_for(token=other_token, route=route)
+
+    database.prepare_feedback(token=token, route=route)
+    assert not database.has_feedback_for(token=token, route=route)
+    assert not database.has_feedback_for(token=other_token, route=route)
+    assert not database.has_feedback_for(token=token, route=other_route)
+
+    database.update_feedback(token=token, route=route, successful=True)
+    assert database.has_feedback_for(token=token, route=route)
+    assert not database.has_feedback_for(token=other_token, route=route)
+    assert not database.has_feedback_for(token=token, route=other_route)

--- a/tests/pathfinding/test_database.py
+++ b/tests/pathfinding/test_database.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from uuid import uuid4
 
 from pathfinding_service.model.feedback import FeedbackToken
@@ -7,9 +6,7 @@ from raiden.utils import TokenNetworkAddress
 
 def test_save_and_load_feedback_token(pathfinding_service_mock):
     token_network_address = TokenNetworkAddress(b"1" * 20)
-    token = FeedbackToken(
-        id=uuid4(), creation_time=datetime.utcnow(), token_network_address=token_network_address
-    )
+    token = FeedbackToken(token_network_address=token_network_address)
     pathfinding_service_mock.database.insert_feedback_token(token)
 
     stored = pathfinding_service_mock.database.get_feedback_token(

--- a/tests/pathfinding/test_model.py
+++ b/tests/pathfinding/test_model.py
@@ -7,9 +7,12 @@ from raiden.utils import TokenNetworkAddress
 
 def test_feedback_token_validity():
     token_network_address = TokenNetworkAddress(b"1" * 20)
+
+    # Newly created token is valid
     valid_token = FeedbackToken(token_network_address=token_network_address)
     assert valid_token.is_valid()
 
+    # Test expiry in is_valid
     invalid_token = FeedbackToken(
         creation_time=datetime.utcnow() - MAX_AGE_OF_FEEDBACK_REQUESTS - timedelta(seconds=1),
         token_network_address=token_network_address,

--- a/tests/pathfinding/test_model.py
+++ b/tests/pathfinding/test_model.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from uuid import uuid4
 
 from pathfinding_service.config import MAX_AGE_OF_FEEDBACK_REQUESTS
 from pathfinding_service.model.feedback import FeedbackToken
@@ -8,13 +7,10 @@ from raiden.utils import TokenNetworkAddress
 
 def test_feedback_token_validity():
     token_network_address = TokenNetworkAddress(b"1" * 20)
-    valid_token = FeedbackToken(
-        id=uuid4(), creation_time=datetime.utcnow(), token_network_address=token_network_address
-    )
+    valid_token = FeedbackToken(token_network_address=token_network_address)
     assert valid_token.is_valid()
 
     invalid_token = FeedbackToken(
-        id=uuid4(),
         creation_time=datetime.utcnow() - MAX_AGE_OF_FEEDBACK_REQUESTS - timedelta(seconds=1),
         token_network_address=token_network_address,
     )

--- a/tests/pathfinding/test_model.py
+++ b/tests/pathfinding/test_model.py
@@ -2,15 +2,20 @@ from datetime import datetime, timedelta
 from uuid import uuid4
 
 from pathfinding_service.config import MAX_AGE_OF_FEEDBACK_REQUESTS
-from pathfinding_service.model import FeedbackToken
+from pathfinding_service.model.feedback import FeedbackToken
+from raiden.utils import TokenNetworkAddress
 
 
 def test_feedback_token_validity():
-    valid_token = FeedbackToken(id=uuid4(), creation_time=datetime.utcnow())
+    token_network_address = TokenNetworkAddress(b"1" * 20)
+    valid_token = FeedbackToken(
+        id=uuid4(), creation_time=datetime.utcnow(), token_network_address=token_network_address
+    )
     assert valid_token.is_valid()
 
     invalid_token = FeedbackToken(
         id=uuid4(),
         creation_time=datetime.utcnow() - MAX_AGE_OF_FEEDBACK_REQUESTS - timedelta(seconds=1),
+        token_network_address=token_network_address,
     )
     assert not invalid_token.is_valid()

--- a/tests/pathfinding/test_model.py
+++ b/tests/pathfinding/test_model.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from pathfinding_service.config import MAX_AGE_OF_FEEDBACK_REQUESTS
+from pathfinding_service.model import FeedbackToken
+
+
+def test_feedback_token_validity():
+    valid_token = FeedbackToken(id=uuid4(), creation_time=datetime.utcnow())
+    assert valid_token.is_valid()
+
+    invalid_token = FeedbackToken(
+        id=uuid4(),
+        creation_time=datetime.utcnow() - MAX_AGE_OF_FEEDBACK_REQUESTS - timedelta(seconds=1),
+    )
+    assert not invalid_token.is_valid()


### PR DESCRIPTION
Part of #336 

This adds the feedback API to the PFS, I'd like to wait with merging this until I have the client changes done and tested.

Basically this PR adds a new ` /<token_network_address>/feedback` endpoint, which can be used to send feedback about routes to the PFS.

Some points for discussion:
- I don't store the sender of the feedback, as we can't be sure the person requesting a route is the actual source in the request. We'd need a signature in the request for that.
- I decided to return HTTP 200, even if the feedback was not accepted, the reasons for this are that the client's doesn't need to know and
- The time interval for feedback is currently set to 10mins
- Feedback is not yet persisted to the DB

