### PR TITLE
Enable auto restart for builder

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -155,6 +155,7 @@ services:
       - ms-goerli
 
   builder:
+    restart: always
     build: ./builder
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
The builder sometimes crashes and didn't have `restart: always` enabled.