### PR TITLE
Start RequestCollector greenlet

### DIFF
--- a/src/request_collector/cli.py
+++ b/src/request_collector/cli.py
@@ -20,7 +20,10 @@ def main(private_key: str, state_db: str) -> int:
 
     database = SharedDatabase(state_db)
 
-    RequestCollector(private_key=private_key, state_db=database).listen_forever()
+    service = RequestCollector(private_key=private_key, state_db=database)
+
+    service.start()
+    service.listen_forever()
 
     print("Exiting...")
     return 0


### PR DESCRIPTION
Currently the RequestCollector doesn't start, as the RC greenlet is not started and thus the MatrixListener doesn't log in properly.

~This is not a nice solution yet, but I haven't found a nice way to wait until the startup process is finished properly. @ulope any hints? Probably some event that is set once the startup is finished would help?~