### PR TITLE
Update raiden and marshmallow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@d348ba2256774daa25e866aaf219a44ebbd70c65
+git+https://github.com/raiden-network/raiden.git@d52a9e65b98af755c31de47c7a121c3172337219
 
 raiden-contracts==0.19.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@aab0172eaa2306e8aa6dc9f540eaf7b9c654f85f
+git+https://github.com/raiden-network/raiden.git@d348ba2256774daa25e866aaf219a44ebbd70c65
 
 raiden-contracts==0.19.1
 
@@ -22,5 +22,5 @@ gevent==1.3.6
 networkx==2.1
 requests==2.20.0
 
-marshmallow==2.15.4
-marshmallow-dataclass==0.5.5
+marshmallow==3.0.0rc6
+marshmallow-dataclass==6.0.0c2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from typing import List
 from setuptools import find_packages, setup
 
 REQ_REPLACE = {
-    "git+https://github.com/raiden-network/raiden.git@d348ba2256774daa25e866aaf219a44ebbd70c65": "raiden"  # noqa
+    "git+https://github.com/raiden-network/raiden.git@d52a9e65b98af755c31de47c7a121c3172337219": "raiden"  # noqa
 }
 
 DESCRIPTION = "Raiden Services contain additional tools for the Raiden Network."

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from typing import List
 from setuptools import find_packages, setup
 
 REQ_REPLACE = {
-    "git+https://github.com/raiden-network/raiden.git@aab0172eaa2306e8aa6dc9f540eaf7b9c654f85f": "raiden"  # noqa
+    "git+https://github.com/raiden-network/raiden.git@d348ba2256774daa25e866aaf219a44ebbd70c65": "raiden"  # noqa
 }
 
 DESCRIPTION = "Raiden Services contain additional tools for the Raiden Network."

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -4,6 +4,7 @@ from typing import Iterable, Optional
 from eth_utils import decode_hex, encode_hex
 from web3 import Web3
 
+from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages import RequestMonitoring, SignedBlindedBalanceProof
 from raiden.utils.signer import LocalSigner, recover
 from raiden.utils.signing import pack_data
@@ -131,7 +132,9 @@ class HashedBalanceProof:
             balance_hash=decode_hex(self.balance_hash),
         )
         request_monitoring = RequestMonitoring(
-            onchain_balance_proof=partner_signed_self, reward_amount=reward_amount
+            balance_proof=partner_signed_self,
+            reward_amount=reward_amount,
+            signature=EMPTY_SIGNATURE,
         )
         request_monitoring.sign(non_closing_signer)
         return request_monitoring

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -17,7 +17,6 @@ from raiden.utils.typing import (
     Signature,
     TokenAmount,
     TokenNetworkAddress,
-    TokenNetworkID,
     TransactionHash,
 )
 from raiden_contracts.constants import ChannelState, MessageTypeId
@@ -124,7 +123,7 @@ class HashedBalanceProof:
         non_closing_signer = LocalSigner(decode_hex(privkey))
         partner_signed_self = SignedBlindedBalanceProof(
             channel_identifier=self.channel_identifier,
-            token_network_address=TokenNetworkID(self.token_network_address),
+            token_network_address=self.token_network_address,
             nonce=self.nonce,
             additional_hash=decode_hex(self.additional_hash),
             chain_id=self.chain_id,

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -91,7 +91,7 @@ class PFSDatabase(BaseDatabase):
         self.conn.execute("UPDATE blockchain SET latest_known_block = ?", [latest_known_block])
 
     def upsert_iou(self, iou: IOU) -> None:
-        iou_dict = IOU.Schema(strict=True, exclude=["receiver", "chain_id"]).dump(iou)[0]
+        iou_dict = IOU.Schema(exclude=["receiver", "chain_id"]).dump(iou)
         iou_dict["one_to_n_address"] = to_checksum_address(iou_dict["one_to_n_address"])
         for key in ("amount", "expiration_block"):
             iou_dict[key] = hex256(iou_dict[key])
@@ -130,7 +130,7 @@ class PFSDatabase(BaseDatabase):
         for row in self.conn.execute(query, args):
             iou_dict = dict(zip(row.keys(), row))
             iou_dict["receiver"] = to_checksum_address(self.pfs_address)
-            yield IOU.Schema(strict=True).load(iou_dict)[0]
+            yield IOU.Schema().load(iou_dict)
 
     def get_iou(
         self, sender: Address, expiration_block: BlockNumber = None, claimed: bool = None
@@ -141,7 +141,7 @@ class PFSDatabase(BaseDatabase):
             return None
 
     def upsert_channel_view(self, channel_view: ChannelView) -> None:
-        cv_dict = ChannelView.Schema(strict=True, exclude=["state"]).dump(channel_view)[0]
+        cv_dict = ChannelView.Schema().dump(channel_view)
         for key in (
             "channel_id",
             "settle_timeout",
@@ -161,7 +161,7 @@ class PFSDatabase(BaseDatabase):
             cv_dict = dict(zip(row.keys(), row))
             cv_dict["fee_schedule_sender"] = json.loads(cv_dict["fee_schedule_sender"])
             cv_dict["fee_schedule_receiver"] = json.loads(cv_dict["fee_schedule_receiver"])
-            yield ChannelView.Schema(strict=True).load(cv_dict)[0]
+            yield ChannelView.Schema().load(cv_dict)
 
     def delete_channel_views(self, channel_id: ChannelID) -> None:
         self.conn.execute("DELETE FROM channel_view WHERE channel_id = ?", [channel_id])

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -247,7 +247,7 @@ class PathfindingService(gevent.Greenlet):
             try:
                 self.on_pfs_update(message)
             except InvalidCapacityUpdate as x:
-                log.info(str(x), **message.to_dict())
+                log.info(str(x), **asdict(message))
         else:
             log.info("Ignoring unknown message type")
 
@@ -300,7 +300,7 @@ class PathfindingService(gevent.Greenlet):
     def on_pfs_update(self, message: UpdatePFS) -> None:
         token_network = self._validate_pfs_update(message)
 
-        log.info("Received Capacity Update", **message.to_dict())
+        log.info("Received Capacity Update", **asdict(message))
         self.database.upsert_capacity_update(message)
 
         # Follow presence for the channel participants

--- a/src/raiden_libs/database.py
+++ b/src/raiden_libs/database.py
@@ -1,6 +1,6 @@
 import os
 import sqlite3
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import structlog
 from eth_utils import to_checksum_address
@@ -18,13 +18,15 @@ def convert_hex(raw: bytes) -> int:
 sqlite3.register_converter("HEX_INT", convert_hex)
 
 
-def hex256(x: int) -> str:
+def hex256(x: Union[int, str]) -> str:
     """Hex encodes values up to 256 bits into a fixed length
 
     By including this amount of leading zeros in the hex string, lexicographic
     and numeric ordering are identical. This facilitates working with these
     numbers in the database without native uint256 support.
     """
+    if isinstance(x, str):
+        x = int(x)
     return "0x{:064x}".format(x)
 
 

--- a/src/raiden_libs/marshmallow.py
+++ b/src/raiden_libs/marshmallow.py
@@ -7,20 +7,20 @@ from eth_utils import decode_hex, encode_hex, is_checksum_address, to_checksum_a
 class HexedBytes(marshmallow.fields.Field):
     """ Use `bytes` in the dataclass, serialize to hex encoding"""
 
-    def _serialize(self, value: bytes, attr: Any, obj: Any) -> str:
+    def _serialize(self, value: bytes, attr: Any, obj: Any, **kwargs: Any) -> str:
         return encode_hex(value)
 
-    def _deserialize(self, value: str, attr: Any, data: Any) -> bytes:
+    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> bytes:
         return decode_hex(value)
 
 
 class ChecksumAddress(marshmallow.fields.Field):
     """ Use `bytes` in the dataclass, serialize to checksum address"""
 
-    def _serialize(self, value: bytes, attr: Any, obj: Any) -> str:
+    def _serialize(self, value: bytes, attr: Any, obj: Any, **kwargs: Any) -> str:
         return to_checksum_address(value)
 
-    def _deserialize(self, value: str, attr: Any, data: Any) -> bytes:
+    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> bytes:
         if not is_checksum_address(value):
             raise marshmallow.ValidationError(f"Not a checksummed address: {value}")
         return decode_hex(value)

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -21,7 +21,7 @@ from raiden.network.transport.matrix.utils import (
     make_room_alias,
     validate_userid_signature,
 )
-from raiden.network.transport.udp import udp_utils
+from raiden.network.transport.utils import timeout_exponential_backoff
 from raiden.settings import (
     DEFAULT_MATRIX_KNOWN_SERVERS,
     DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL,
@@ -83,7 +83,7 @@ def deserialize_messages(data: str, peer_address: Address) -> List[SignedMessage
 
 
 def matrix_http_retry_delay() -> Iterable[float]:
-    return udp_utils.timeout_exponential_backoff(
+    return timeout_exponential_backoff(
         DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
         int(DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL / 5),
         int(DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL),

--- a/tests/monitoring/request_collector/test_server.py
+++ b/tests/monitoring/request_collector/test_server.py
@@ -4,6 +4,7 @@ from eth_utils import encode_hex, to_checksum_address
 
 from monitoring_service.states import HashedBalanceProof
 from raiden.messages import RequestMonitoring
+from raiden.storage.serialization.serializer import DictSerializer
 from raiden.utils.typing import ChainID, ChannelID, Nonce, TokenAmount, TokenNetworkAddress
 from raiden_contracts.tests.utils import get_random_privkey
 from raiden_libs.utils import private_key_to_address
@@ -44,10 +45,10 @@ def build_request_monitoring():
 def test_invalid_request(ms_database, build_request_monitoring, request_collector):
     def store_successful(reward_proof_signature=None, **kwargs):
         request_monitoring = build_request_monitoring(**kwargs)
-        rm_dict = request_monitoring.to_dict()
+        rm_dict = DictSerializer.serialize(request_monitoring)
         if reward_proof_signature:
-            rm_dict["reward_proof_signature"] = reward_proof_signature
-        request_collector.on_monitor_request(RequestMonitoring.from_dict(rm_dict))
+            rm_dict["signature"] = reward_proof_signature
+        request_collector.on_monitor_request(DictSerializer.deserialize(rm_dict))
         return ms_database.monitor_request_count() == 1
 
     # bad signature

--- a/tests/pathfinding/fixtures/iou.py
+++ b/tests/pathfinding/fixtures/iou.py
@@ -30,7 +30,7 @@ def make_iou(one_to_n_contract):
         iou_dict["signature"] = encode_hex(
             sign_one_to_n_iou(privatekey=sender_priv_key, **iou_dict)
         )
-        iou = IOU.Schema(strict=True).load(iou_dict)[0]
+        iou = IOU.Schema().load(iou_dict)
         iou.claimed = False
         return iou
 

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -8,6 +8,7 @@ from web3.contract import Contract
 
 from pathfinding_service.model.token_network import TokenNetwork
 from pathfinding_service.service import PathfindingService
+from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages import UpdatePFS
 from raiden.network.transport.matrix import AddressReachability
 from raiden.transfer.identifiers import CanonicalIdentifier
@@ -220,6 +221,7 @@ def populate_token_network() -> Callable:
                     other_capacity=p2_capacity,
                     reveal_timeout=p1_reveal_timeout,
                     mediation_fee=FeeAmount(0),
+                    signature=EMPTY_SIGNATURE,
                 ),
                 updating_capacity_partner=TokenAmount(0),
                 other_capacity_partner=TokenAmount(0),
@@ -239,6 +241,7 @@ def populate_token_network() -> Callable:
                     other_capacity=p1_capacity,
                     reveal_timeout=p2_reveal_timeout,
                     mediation_fee=FeeAmount(0),
+                    signature=EMPTY_SIGNATURE,
                 ),
                 updating_capacity_partner=TokenAmount(p1_capacity),
                 other_capacity_partner=TokenAmount(p2_capacity),

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -193,7 +193,7 @@ def test_get_paths_validation(
         api_sut.pathfinding_service.address,
         one_to_n_address=api_sut.one_to_n_address,
     )
-    good_iou_dict = iou.Schema().dump(iou)[0]
+    good_iou_dict = iou.Schema().dump(iou)
 
     # malformed iou
     bad_iou_dict = good_iou_dict.copy()
@@ -321,7 +321,7 @@ def test_get_iou(api_sut: ServiceApi, api_url: str, token_network_model: TokenNe
     # Is returned IOU the one save into the db?
     response = requests.get(url, params=params)
     assert response.status_code == 200, response.json()
-    iou_dict = IOU.Schema(exclude=["claimed"]).dump(iou)[0]
+    iou_dict = IOU.Schema(exclude=["claimed"]).dump(iou)
     assert response.json()["last_iou"] == iou_dict
 
     # Invalid signatures must fail

--- a/tests/pathfinding/test_capacity_updates.py
+++ b/tests/pathfinding/test_capacity_updates.py
@@ -11,7 +11,7 @@ from eth_utils import decode_hex
 from pathfinding_service.exceptions import InvalidCapacityUpdate
 from pathfinding_service.model import TokenNetwork
 from pathfinding_service.service import PathfindingService
-from raiden.constants import UINT256_MAX
+from raiden.constants import EMPTY_SIGNATURE, UINT256_MAX
 from raiden.messages import UpdatePFS
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.utils.signer import LocalSigner
@@ -102,6 +102,7 @@ def get_updatepfs_message(  # pylint: disable=too-many-arguments
         other_capacity=other_capacity,
         reveal_timeout=reveal_timeout,
         mediation_fee=mediation_fee,
+        signature=EMPTY_SIGNATURE,
     )
 
     updatepfs_message.sign(LocalSigner(privkey_signer))

--- a/tests/pathfinding/test_middleware.py
+++ b/tests/pathfinding/test_middleware.py
@@ -39,11 +39,11 @@ def test_retries(make_post_request_mock):
     # check timings
     assert make_post_request_mock.call_count == 5
     expected_times = [0, 0.01, 0.01 + 0.02, 0.01 + 0.02 + 0.04, 0.01 + 0.02 + 0.04 + 0.08]
-    assert retry_times == pytest.approx(expected_times, abs=0.002, rel=0.3)
+    assert retry_times == pytest.approx(expected_times, abs=0.003, rel=0.3)
 
     # try again to make sure that each request starts with a clean backoff
     start_time = time()
     retry_times = []
     with pytest.raises(requests.exceptions.ConnectionError):
         web3.eth.blockNumber()
-    assert retry_times == pytest.approx(expected_times, abs=0.002, rel=0.3)
+    assert retry_times == pytest.approx(expected_times, abs=0.003, rel=0.3)


### PR DESCRIPTION
* raiden switched it's message implementation to dataclasses
* update from marshmallow 2 to 3, which has API changes

This still needs https://github.com/raiden-network/raiden/pull/4127 before passing CI.