### PR TITLE
Use a global presence mapping

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -114,10 +114,10 @@ class PathsResource(PathfinderResource):
         token_network = self._validate_token_network_argument(token_network_address)
         path_req = self._parse_post(PathRequest)
         process_payment(
-            path_req.iou,
-            self.pathfinding_service,
-            self.service_api.service_fee,
-            self.service_api.one_to_n_address,
+            iou=path_req.iou,
+            pathfinding_service=self.pathfinding_service,
+            service_fee=self.service_api.service_fee,
+            one_to_n_address=self.service_api.one_to_n_address,
         )
 
         # only add optional args if not None, so we can use defaults
@@ -131,6 +131,7 @@ class PathsResource(PathfinderResource):
                 source=path_req.from_,
                 target=path_req.to,
                 value=path_req.value,
+                address_to_reachability=self.pathfinding_service.address_to_reachability,
                 max_paths=path_req.max_paths,
                 **optional_args,
             )

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -98,6 +98,7 @@ class PathfindingService(gevent.Greenlet):
             address_reachability_changed_callback=self.handle_reachability_change,
         )
 
+        self.address_to_reachability: Dict[Address, AddressReachability] = dict()
         self.token_networks = self._load_token_networks()
 
     def _load_token_networks(self) -> Dict[TokenNetworkAddress, TokenNetwork]:
@@ -167,9 +168,7 @@ class PathfindingService(gevent.Greenlet):
     def handle_reachability_change(
         self, address: Address, reachability: AddressReachability
     ) -> None:
-        for token_network_model in self.token_networks.values():
-            if address in token_network_model.G.nodes:
-                token_network_model.address_to_reachability[address] = reachability
+        self.address_to_reachability[address] = reachability
 
     def get_token_network(
         self, token_network_address: TokenNetworkAddress

--- a/tests/pathfinding/fixtures/__init__.py
+++ b/tests/pathfinding/fixtures/__init__.py
@@ -1,7 +1,8 @@
 import pytest
 
 from pathfinding_service.model.token_network import TokenNetwork
-from raiden.utils.typing import TokenNetworkAddress
+from raiden.network.transport.matrix import AddressReachability
+from raiden.utils.typing import Address, Dict, TokenNetworkAddress
 
 from .accounts import *  # noqa
 from .api import *  # noqa
@@ -12,3 +13,8 @@ from .network_service import *  # noqa
 @pytest.fixture
 def token_network_model() -> TokenNetwork:
     return TokenNetwork(TokenNetworkAddress(bytes([1] * 20)))
+
+
+@pytest.fixture
+def address_to_reachability() -> Dict[Address, AddressReachability]:
+    return {}

--- a/tests/pathfinding/fixtures/api.py
+++ b/tests/pathfinding/fixtures/api.py
@@ -1,11 +1,12 @@
 # pylint: disable=redefined-outer-name
 import socket
-from typing import Iterator
+from typing import Dict, Iterator
 
 import pytest
 
 from pathfinding_service.api import ServiceApi
 from pathfinding_service.config import API_PATH
+from raiden.network.transport.matrix import AddressReachability
 from raiden.utils.typing import Address
 
 
@@ -26,9 +27,11 @@ def api_url(free_port: int) -> str:
 @pytest.fixture
 def api_sut(
     pathfinding_service_mock,
+    address_to_reachability: Dict[Address, AddressReachability],
     free_port: int,
     populate_token_network_case_1,  # pylint: disable=unused-argument
 ) -> Iterator[ServiceApi]:
+    pathfinding_service_mock.address_to_reachability = address_to_reachability
     api = ServiceApi(pathfinding_service_mock, one_to_n_address=Address(bytes([1] * 20)))
     api.run(port=free_port)
     yield api
@@ -38,9 +41,11 @@ def api_sut(
 @pytest.fixture
 def api_sut_with_debug(
     pathfinding_service_mock,
+    address_to_reachability: Dict[Address, AddressReachability],
     free_port: int,
     populate_token_network_case_1,  # pylint: disable=unused-argument
 ) -> Iterator[ServiceApi]:
+    pathfinding_service_mock.address_to_reachability = address_to_reachability
     api = ServiceApi(
         pathfinding_service_mock, one_to_n_address=Address(bytes([1] * 20)), debug_mode=True
     )

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -1,5 +1,5 @@
 # pylint: disable=redefined-outer-name
-from typing import Callable, Generator, List
+from typing import Callable, Dict, Generator, List
 from unittest.mock import Mock, patch
 
 import pytest
@@ -166,7 +166,10 @@ def channel_descriptions_case_3() -> List:
 def populate_token_network() -> Callable:
     # pylint: disable=too-many-locals
     def populate_token_network(
-        token_network: TokenNetwork, addresses: List[Address], channel_descriptions: List
+        token_network: TokenNetwork,
+        address_to_reachability: Dict[Address, AddressReachability],
+        addresses: List[Address],
+        channel_descriptions: List,
     ):
         for (
             channel_id,
@@ -246,8 +249,10 @@ def populate_token_network() -> Callable:
                 updating_capacity_partner=TokenAmount(p1_capacity),
                 other_capacity_partner=TokenAmount(p2_capacity),
             )
-            token_network.address_to_reachability[participant1] = p1_reachability
-            token_network.address_to_reachability[participant2] = p2_reachability
+
+            # Update presence state according to scenario
+            address_to_reachability[participant1] = p1_reachability
+            address_to_reachability[participant2] = p2_reachability
 
     return populate_token_network
 
@@ -256,30 +261,39 @@ def populate_token_network() -> Callable:
 def populate_token_network_case_1(
     populate_token_network: Callable,
     token_network_model: TokenNetwork,
+    address_to_reachability: Dict[Address, AddressReachability],
     addresses: List[Address],
     channel_descriptions_case_1: List,
 ):
-    populate_token_network(token_network_model, addresses, channel_descriptions_case_1)
+    populate_token_network(
+        token_network_model, address_to_reachability, addresses, channel_descriptions_case_1
+    )
 
 
 @pytest.fixture
 def populate_token_network_case_2(
     populate_token_network: Callable,
     token_network_model: TokenNetwork,
+    address_to_reachability: Dict[Address, AddressReachability],
     addresses: List[Address],
     channel_descriptions_case_2: List,
 ):
-    populate_token_network(token_network_model, addresses, channel_descriptions_case_2)
+    populate_token_network(
+        token_network_model, address_to_reachability, addresses, channel_descriptions_case_2
+    )
 
 
 @pytest.fixture
 def populate_token_network_case_3(
     populate_token_network: Callable,
     token_network_model: TokenNetwork,
+    address_to_reachability: Dict[Address, AddressReachability],
     addresses: List[Address],
     channel_descriptions_case_3: List,
 ):
-    populate_token_network(token_network_model, addresses, channel_descriptions_case_3)
+    populate_token_network(
+        token_network_model, address_to_reachability, addresses, channel_descriptions_case_3
+    )
 
 
 @pytest.fixture

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -246,36 +246,25 @@ def test_token_channel_closed(pathfinding_service_mock, token_network_model):
 def test_handle_reachability_change(pathfinding_service_mock, token_network_model):
     setup_channel(pathfinding_service_mock, token_network_model)
 
-    assert len(token_network_model.address_to_reachability) == 0
+    assert len(pathfinding_service_mock.address_to_reachability) == 0
     pathfinding_service_mock.handle_reachability_change(
         to_canonical_address(PARTICIPANT1), AddressReachability.REACHABLE
     )
-    assert len(token_network_model.channel_id_to_addresses) == 1
     assert (
-        token_network_model.address_to_reachability[PARTICIPANT1] == AddressReachability.REACHABLE
+        pathfinding_service_mock.address_to_reachability[PARTICIPANT1]
+        == AddressReachability.REACHABLE
     )
 
-    token_address = Address(b"8" * 20)
-    token_network_address = TokenNetworkAddress(b"9" * 20)
-    network_event = ReceiveTokenNetworkCreatedEvent(
-        token_address=token_address,
-        token_network_address=token_network_address,
-        block_number=BlockNumber(1),
-    )
-    pathfinding_service_mock.handle_event(network_event)
-    token_network_model2 = pathfinding_service_mock.token_networks[token_network_address]
-
-    assert len(token_network_model2.address_to_reachability) == 0
     pathfinding_service_mock.handle_reachability_change(
         to_canonical_address(PARTICIPANT2), AddressReachability.REACHABLE
     )
-    assert len(token_network_model.channel_id_to_addresses) == 1
-    assert len(token_network_model2.address_to_reachability) == 0
     assert (
-        token_network_model.address_to_reachability[PARTICIPANT1] == AddressReachability.REACHABLE
+        pathfinding_service_mock.address_to_reachability[PARTICIPANT1]
+        == AddressReachability.REACHABLE
     )
     assert (
-        token_network_model.address_to_reachability[PARTICIPANT2] == AddressReachability.REACHABLE
+        pathfinding_service_mock.address_to_reachability[PARTICIPANT2]
+        == AddressReachability.REACHABLE
     )
 
 


### PR DESCRIPTION
Keeping a per token network mapping of addresses to presences results in
more complicated code, bugs (#380) and inefficiencies (#350).

This commit changes the presence tracking to be handles in the service
itself.

Fixes #380
Fixes #350 