### PR TITLE
Remove contract manager from `Context`

### DIFF
--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -21,7 +21,6 @@ from monitoring_service.states import (
 )
 from raiden.utils.typing import BlockNumber, TokenNetworkAddress, TransactionHash
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelState
-from raiden_contracts.contract_manager import ContractManager
 from raiden_libs.contract_info import CONTRACT_MANAGER
 from raiden_libs.events import (
     Event,
@@ -42,7 +41,6 @@ class Context:
     ms_state: MonitoringServiceState
     db: Database
     w3: Web3
-    contract_manager: ContractManager
     last_known_block: int
     monitoring_service_contract: Contract
     user_deposit_contract: Contract

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -93,7 +93,6 @@ class MonitoringService:  # pylint: disable=too-few-public-methods
             ms_state=ms_state,
             db=self.database,
             w3=self.web3,
-            contract_manager=CONTRACT_MANAGER,
             last_known_block=0,
             monitoring_service_contract=monitoring_contract,
             user_deposit_contract=user_deposit_contract,

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -97,7 +97,6 @@ def context(ms_database: Database):
         ms_state=ms_database.load_state(),
         db=ms_database,
         w3=Mock(),
-        contract_manager=Mock(),
         last_known_block=0,
         monitoring_service_contract=Mock(),
         user_deposit_contract=Mock(),


### PR DESCRIPTION
We have a global contract manager now, so that one is not needed,
anymore.