### PR TITLE
 Receive and handle `FeeUpdate` generated by client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@f9409e2a7fe06e81af0d227ff3c1d6206c2e276d
+git+https://github.com/raiden-network/raiden.git@e2504fbd4c4527903c150fecbe17f06e76c4353d
 
 raiden-contracts==0.22.0
 

--- a/src/pathfinding_service/exceptions.py
+++ b/src/pathfinding_service/exceptions.py
@@ -1,8 +1,16 @@
 from typing import Any, Dict, Optional
 
 
-class InvalidCapacityUpdate(Exception):
-    """Exception for incoming messages"""
+class InvalidGlobalMessage(Exception):
+    """A global message received via matrix is invalid and must be discarded"""
+
+
+class InvalidCapacityUpdate(InvalidGlobalMessage):
+    pass
+
+
+class InvalidFeeUpdate(InvalidGlobalMessage):
+    pass
 
 
 class UndefinedFee(Exception):

--- a/src/pathfinding_service/model/channel_view.py
+++ b/src/pathfinding_service/model/channel_view.py
@@ -47,7 +47,7 @@ class FeeSchedule:
     flat: FeeAmount = FeeAmount(0)
     proportional: float = 0
     imbalance_penalty: Optional[List[Tuple[TokenAmount, FeeAmount]]] = None
-    _penalty_func: Interpolate = field(init=False, repr=False)
+    _penalty_func: Optional[Interpolate] = field(init=False, repr=False, default=None)
 
     def __post_init__(self) -> None:
         if self.imbalance_penalty:
@@ -56,7 +56,7 @@ class FeeSchedule:
             self._penalty_func = Interpolate(x_list, y_list)
 
     def fee(self, amount: TokenAmount, capacity: TokenAmount) -> FeeAmount:
-        if self.imbalance_penalty:
+        if self._penalty_func:
             # Total channel capacity - node capacity = balance (used as x-axis for the penalty)
             balance = self._penalty_func.x_list[-1] - capacity
             try:

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -62,3 +62,15 @@ CREATE TABLE feedback (
 
 CREATE INDEX feedback_successful
     ON feedback(successful);
+
+-- Messages which can't be processed yet because the ChannelOpened event has
+-- not been confirmed at the time of receiving will be stored here. The
+-- messages are processed when the corresponding ChannelOpened is confirmed.
+CREATE TABLE waiting_message (
+    token_network_address   CHAR(42) NOT NULL,
+    channel_id              HEX_INT NOT NULL,
+    message                 JSON NOT NULL,
+    added_at                TIMESTAMP DEFAULT current_timestamp,
+    FOREIGN KEY (token_network_address)
+        REFERENCES token_network(address)
+)

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -10,7 +10,7 @@ from matrix_client.user import User
 
 from raiden.constants import Environment
 from raiden.exceptions import InvalidProtocolMessage, TransportError
-from raiden.messages import Message, RequestMonitoring, SignedMessage, UpdatePFS
+from raiden.messages import FeeUpdate, Message, RequestMonitoring, SignedMessage, UpdatePFS
 from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import (
     AddressReachability,
@@ -35,7 +35,7 @@ from raiden.utils.typing import Address, ChainID
 log = structlog.get_logger(__name__)
 
 
-SERVICE_MESSAGES: Tuple = (UpdatePFS, RequestMonitoring)
+SERVICE_MESSAGES: Tuple = (UpdatePFS, RequestMonitoring, FeeUpdate)
 VALID_MESSAGE_TYPES = set(klass.__module__ + "." + klass.__name__ for klass in SERVICE_MESSAGES)
 
 


### PR DESCRIPTION
The messages have to be stored until a ChannelOpened event has been
received, if that is no the case yet when receive the `FeeUpdate`. Still missing:
- Nonce handling
- Scenario to test the client/PFS integration