### PR TITLE
Use clients default for confirmation blocks setting

### DIFF
--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -5,8 +5,8 @@ import structlog
 from web3 import Web3
 from web3.contract import Contract
 
-from monitoring_service.constants import DEFAULT_REQUIRED_CONFIRMATIONS
 from monitoring_service.service import MonitoringService
+from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
@@ -30,7 +30,7 @@ log = structlog.get_logger(__name__)
 )
 @click.option(
     "--confirmations",
-    default=DEFAULT_REQUIRED_CONFIRMATIONS,
+    default=DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
     type=click.IntRange(min=0),
     help="Number of block confirmations to wait for",
 )

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -10,11 +10,11 @@ from web3.middleware import construct_sign_and_send_raw_middleware
 from monitoring_service.constants import (
     DEFAULT_GAS_BUFFER_FACTOR,
     DEFAULT_GAS_CHECK_BLOCKS,
-    DEFAULT_REQUIRED_CONFIRMATIONS,
     MAX_FILTER_INTERVAL,
 )
 from monitoring_service.database import Database
 from monitoring_service.handlers import HANDLERS, Context
+from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.utils.typing import BlockNumber, ChainID
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
@@ -64,7 +64,7 @@ class MonitoringService:  # pylint: disable=too-few-public-methods
         db_filename: str,
         contracts: Dict[str, Contract],
         sync_start_block: BlockNumber = BlockNumber(0),
-        required_confirmations: int = DEFAULT_REQUIRED_CONFIRMATIONS,
+        required_confirmations: int = DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
         poll_interval: float = 1,
         min_reward: int = 0,
     ):

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -15,6 +15,7 @@ from web3.contract import Contract
 from pathfinding_service.api import ServiceApi
 from pathfinding_service.config import DEFAULT_API_HOST, DEFAULT_POLL_INTERVALL
 from pathfinding_service.service import PathfindingService
+from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.utils.typing import BlockNumber, TokenAmount
 from raiden_contracts.constants import (
     CONTRACT_ONE_TO_N,
@@ -24,8 +25,6 @@ from raiden_contracts.constants import (
 from raiden_libs.cli import blockchain_options, common_options
 
 log = structlog.get_logger(__name__)
-
-DEFAULT_REQUIRED_CONFIRMATIONS = 8  # ~2min with 15s blocks
 
 
 @blockchain_options(
@@ -43,7 +42,7 @@ DEFAULT_REQUIRED_CONFIRMATIONS = 8  # ~2min with 15s blocks
 )
 @click.option(
     "--confirmations",
-    default=DEFAULT_REQUIRED_CONFIRMATIONS,
+    default=DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
     type=click.IntRange(min=0),
     help="Number of block confirmations to wait for",
 )


### PR DESCRIPTION
This caused some mismatches which eventually led to failing scenarios.