### PR TITLE
Fix depoloyment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -eux; \
 WORKDIR /services
 ADD . /services
 
-USER services
-
 RUN python3 -m pip install -r requirements.txt
 RUN python3 -m pip install -e .
+
+USER services

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -5,8 +5,8 @@ x-defaults: &defaults
   image: raiden-services
   env_file: services.env
   volumes:
-    - /data/state:/state
-    - /data/keystore:/keystore
+    - ${DATA_DIR:-./data}/state:/state
+    - ${DATA_DIR:-./data}/keystore:/keystore
 
 services:
   pfs-ropsten:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -6,7 +6,7 @@ x-defaults: &defaults
   env_file: services.env
   volumes:
     - /data/state:/state
-    - ~/keystore:/keystore
+    - /data/keystore:/keystore
 
 services:
   pfs-ropsten:

--- a/deployment/services.env
+++ b/deployment/services.env
@@ -10,3 +10,6 @@ MS_LOG_LEVEL=DEBUG
 MSRC_KEYSTORE_FILE=/keystore/raiden-services-cd
 MSRC_PASSWORD=test
 MSRC_LOG_LEVEL=DEBUG
+
+## Data dir location. Optional, defaults to ./data in the checkout directory.
+DATA_DIR=/data


### PR DESCRIPTION
Before the services ran as root in the docker file. After the change to
a user, it cannot read the keyfile any more. Therefore the keyfile is
now put under `/data`.