### PR TITLE
Use gas costs in gas.json

### DIFF
--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -19,7 +19,12 @@ log = structlog.get_logger(__name__)
 
 
 @blockchain_options(
-    contracts=[CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT, CONTRACT_MONITORING_SERVICE]
+    contracts=[
+        CONTRACT_TOKEN_NETWORK_REGISTRY,
+        CONTRACT_USER_DEPOSIT,
+        CONTRACT_MONITORING_SERVICE,
+    ],
+    with_gas_numbers=True,
 )
 @click.command()
 @click.option(
@@ -32,7 +37,7 @@ log = structlog.get_logger(__name__)
     "--confirmations",
     default=DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
     type=click.IntRange(min=0),
-    help="Number of block confirmations to wait for",
+    help="Number of block confirmations to wait for",  # pylint: disable=too-many-arguments
 )
 @common_options("raiden-monitoring-service")
 def main(
@@ -40,6 +45,7 @@ def main(
     state_db: str,
     web3: Web3,
     contracts: Dict[str, Contract],
+    gas_measurements: Dict[str, int],
     start_block: BlockNumber,
     confirmations: BlockNumber,
     min_reward: int,
@@ -51,6 +57,7 @@ def main(
         web3=web3,
         private_key=private_key,
         contracts=contracts,
+        gas_measurements=gas_measurements,
         sync_start_block=start_block,
         required_confirmations=confirmations,
         db_filename=state_db,

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -83,6 +83,7 @@ def monitoring_service(  # pylint: disable=too-many-arguments
             CONTRACT_MONITORING_SERVICE: monitoring_service_contract,
             CONTRACT_USER_DEPOSIT: user_deposit_contract,
         },
+        gas_measurements={"MonitoringService.monitor": 210000},
         required_confirmations=0,  # for faster tests
         poll_interval=0.01,  # for faster tests
         db_filename=":memory:",

--- a/tests/monitoring/monitoring_service/test_cli.py
+++ b/tests/monitoring/monitoring_service/test_cli.py
@@ -11,7 +11,7 @@ from monitoring_service.service import check_gas_reserve
 
 @pytest.fixture(autouse=True)
 def service_mock(monkeypatch):
-    connect_mock = Mock(return_value=(Mock(), MagicMock(), Mock()))
+    connect_mock = Mock(return_value=(Mock(), MagicMock(), MagicMock(), Mock()))
     monkeypatch.setattr("raiden_libs.cli.connect_to_blockchain", connect_mock)
     service_mock = Mock()
     monkeypatch.setattr("monitoring_service.cli.MonitoringService", service_mock)
@@ -20,7 +20,7 @@ def service_mock(monkeypatch):
 
 def test_account_check(web3, capsys):
     private_key = "0F951D6EAF7685D420AACCA3900127E669892FE5CA6C8E4C572A59B0609AAE6B"
-    check_gas_reserve(web3, private_key)
+    check_gas_reserve(web3, private_key, {"MonitoringService.monitor": 100})
     out = capsys.readouterr().out
     assert "Your account's balance is below the estimated gas reserve of" in out
 

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -84,11 +84,14 @@ def test_crash(
         CONTRACT_USER_DEPOSIT: ContractMock(),
     }
 
+    gas_measurements = {"MonitoringService.monitor": 210000}
+
     def new_ms(filename):
         ms = MonitoringService(
             web3=Web3Mock(),
             private_key=server_private_key,
             contracts=contracts,
+            gas_measurements=gas_measurements,
             db_filename=os.path.join(tmpdir, filename),
         )
         msc = Mock()

--- a/tests/pathfinding/test_claim_fees.py
+++ b/tests/pathfinding/test_claim_fees.py
@@ -91,7 +91,7 @@ def mock_connect_to_blockchain(monkeypatch):
     web3_mock = Mock()
     web3_mock.net.version = 1
     web3_mock.eth.blockNumber = 1
-    connect_mock = Mock(return_value=(web3_mock, MagicMock(), 0))
+    connect_mock = Mock(return_value=(web3_mock, MagicMock(), MagicMock(), 0))
     monkeypatch.setattr("raiden_libs.cli.connect_to_blockchain", connect_mock)
 
 


### PR DESCRIPTION
instead of GAS_REQUIRED_FOR_* from raiden_contracts.constants
because that number is deprecated.