### PR TITLE
Provide nice error when settings in db don't match

### DIFF
--- a/src/raiden_libs/database.py
+++ b/src/raiden_libs/database.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import sys
 from typing import Any, Dict, Union
 
 import structlog
@@ -100,7 +101,14 @@ class BaseDatabase:
         ).fetchone()
         for key, val in new_settings.items():
             old = old_settings[key]
-            assert old == val, f"DB was created with {key}={old}, got {val}!"
+            if old != val:
+                log.error(
+                    "Mismatch between current settings and settings saved in db: "
+                    f"DB was created with {key}='{old}', current_value is '{val}'! "
+                    "Either fix your settings or start with a fresh db. "
+                    "WARNING: If you delete your db, you will lose earned fees!"
+                )
+                sys.exit(1)
 
     def insert(
         self, table_name: str, fields_by_colname: Dict[str, Any], keyword: str = "INSERT"


### PR DESCRIPTION
Example output:
```
2019-07-02 12:47:41.831588 [info     ] Starting Raiden Pathfinding Service [__main__]
2019-07-02 12:47:41.863405 [info     ] PFS payment address            [pathfinding_service.service] address=0x062C12c01D0f17fC9eAa33940D994594d91a0182
2019-07-02 12:47:41.863770 [info     ] Opening database               [raiden_libs.database] filename=state/pfs-rinkeby.db
2019-07-02 12:47:41.865866 [error    ] Mismatch between current settings and settings saved in db: DB was created with token_network_registry_address='0xd353c140CB3B2B994672784B7363928B8191B884', current_value is '0xCBee035Df4E3f2b40506c4cCc7be4D76407F7FF7'! Either fix your settings or start with a fresh db. WARNING: If you delete your db, you will lose earned fees! [raiden_libs.database]
Exiting...
2019-07-02 12:47:41.866374 [info     ] Stopping Pathfinding Service... [__main__]
```

Closes https://github.com/raiden-network/raiden-services/issues/409.