### PR TITLE
Add option to send reports to sentry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ requests==2.22.0
 
 marshmallow==3.0.0rc8
 marshmallow-dataclass==6.0.0rc4
+
+sentry-sdk[flask]==0.10.1

--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -13,7 +13,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
-from raiden_libs.cli import blockchain_options, common_options, maybe_setup_sentry
+from raiden_libs.cli import blockchain_options, common_options, setup_sentry
 
 log = structlog.get_logger(__name__)
 
@@ -62,5 +62,5 @@ def main(
 
 
 if __name__ == "__main__":
-    maybe_setup_sentry()
+    setup_sentry()
     main(auto_envvar_prefix="MS")

--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -13,7 +13,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
-from raiden_libs.cli import blockchain_options, common_options
+from raiden_libs.cli import blockchain_options, common_options, maybe_setup_sentry
 
 log = structlog.get_logger(__name__)
 
@@ -62,4 +62,5 @@ def main(
 
 
 if __name__ == "__main__":
+    maybe_setup_sentry()
     main(auto_envvar_prefix="MS")

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -22,7 +22,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
-from raiden_libs.cli import blockchain_options, common_options, maybe_setup_sentry
+from raiden_libs.cli import blockchain_options, common_options, setup_sentry
 
 log = structlog.get_logger(__name__)
 
@@ -97,5 +97,5 @@ def main(  # pylint: disable-msg=too-many-arguments
 
 
 if __name__ == "__main__":
-    maybe_setup_sentry(enable_flask_integration=True)
+    setup_sentry(enable_flask_integration=True)
     main(auto_envvar_prefix="PFS")  # pragma: no cover

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -22,7 +22,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
-from raiden_libs.cli import blockchain_options, common_options
+from raiden_libs.cli import blockchain_options, common_options, maybe_setup_sentry
 
 log = structlog.get_logger(__name__)
 
@@ -97,4 +97,5 @@ def main(  # pylint: disable-msg=too-many-arguments
 
 
 if __name__ == "__main__":
+    maybe_setup_sentry(enable_flask_integration=True)
     main(auto_envvar_prefix="PFS")  # pragma: no cover

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import click
+import pkg_resources
 import requests.exceptions
 import sentry_sdk
 import structlog
@@ -211,9 +212,11 @@ def connect_to_blockchain(
     return web3, contracts, start_block
 
 
-def maybe_setup_sentry(enable_flask_integration: bool = False) -> None:
+def setup_sentry(enable_flask_integration: bool = False) -> None:
     sentry_dsn = os.environ.get("SENTRY_DSN")
     if sentry_dsn is not None:
         sentry_sdk.init(
-            dsn=sentry_dsn, integrations=[FlaskIntegration()] if enable_flask_integration else []
+            dsn=sentry_dsn,
+            integrations=[FlaskIntegration()] if enable_flask_integration else [],
+            release=pkg_resources.get_distribution("raiden-services").version,
         )

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -6,9 +6,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import click
 import requests.exceptions
+import sentry_sdk
 import structlog
 from eth_account import Account
 from eth_utils import decode_hex, is_checksum_address, to_checksum_address
+from sentry_sdk.integrations.flask import FlaskIntegration
 from web3 import HTTPProvider, Web3
 from web3.contract import Contract
 from web3.middleware import geth_poa_middleware
@@ -207,3 +209,11 @@ def connect_to_blockchain(
     hex_addresses = {key: to_checksum_address(value) for key, value in addresses.items()}
     log.info("Contract information", addresses=hex_addresses, start_block=start_block)
     return web3, contracts, start_block
+
+
+def maybe_setup_sentry(enable_flask_integration: bool = False) -> None:
+    sentry_dsn = os.environ.get("SENTRY_DSN")
+    if sentry_dsn is not None:
+        sentry_sdk.init(
+            dsn=sentry_dsn, integrations=[FlaskIntegration()] if enable_flask_integration else []
+        )

--- a/src/request_collector/cli.py
+++ b/src/request_collector/cli.py
@@ -11,7 +11,7 @@ from request_collector.server import RequestCollector
 
 from monitoring_service.database import SharedDatabase
 from raiden.utils.cli import NetworkChoiceType
-from raiden_libs.cli import common_options, maybe_setup_sentry
+from raiden_libs.cli import common_options, setup_sentry
 
 log = structlog.get_logger(__name__)
 
@@ -57,5 +57,5 @@ def main(private_key: str, state_db: str) -> int:
 
 
 if __name__ == "__main__":
-    maybe_setup_sentry()
+    setup_sentry()
     main(auto_envvar_prefix="MSRC")  # pragma: no cover

--- a/src/request_collector/cli.py
+++ b/src/request_collector/cli.py
@@ -11,7 +11,7 @@ from request_collector.server import RequestCollector
 
 from monitoring_service.database import SharedDatabase
 from raiden.utils.cli import NetworkChoiceType
-from raiden_libs.cli import common_options
+from raiden_libs.cli import common_options, maybe_setup_sentry
 
 log = structlog.get_logger(__name__)
 
@@ -57,4 +57,5 @@ def main(private_key: str, state_db: str) -> int:
 
 
 if __name__ == "__main__":
+    maybe_setup_sentry()
     main(auto_envvar_prefix="MSRC")  # pragma: no cover


### PR DESCRIPTION
This is done by setting the sentry dsn to the env varaible `SENTRY_DSN`

I didn't make this a CLI option because this way we can initialize sentry earlier, but it might me bore intuitive as an CLI arg.


Fixes #406