### PR TITLE
Prevent acceptance of bad reward proof

### DIFF
--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -84,6 +84,8 @@ class RequestCollector(gevent.Greenlet):
         if monitor_request.chain_id != self.chain_id:
             log.debug("Bad chain_id", monitor_request=monitor_request, expected=self.chain_id)
             return
+        if monitor_request.non_closing_signer != monitor_request.reward_proof_signer:
+            log.debug("The two MR signatures don't match", monitor_request=monitor_request)
 
         # Check that received MR is newer by comparing nonces
         old_mr = self.state_db.get_monitor_request(


### PR DESCRIPTION
By checking that both MR signatures are done by the same key, attackers are prevented from adding a bad reward proof to an otherwise valid MR. This prevents https://github.com/raiden-network/raiden-services/issues/418 immediately.

After https://github.com/raiden-network/raiden-contracts/issues/1117 is done, this will be a much more useful check because it will not only fail when one of the proofs is tampered with, but also when they were not intended to be used in the same MR.

Closes https://github.com/raiden-network/raiden-services/issues/418.