### PR TITLE
[FEAT-#80] Update docker setup to use docker registry

### DIFF
--- a/deployment/docker-compose.latest.yml
+++ b/deployment/docker-compose.latest.yml
@@ -1,0 +1,89 @@
+# Development Setup.
+# Uses the latest commit of the `master` branch to run each service.
+# Start individual services using the following command::
+#
+#   docker-compose up <service_1> <service_2> [..]
+#
+# Add the `-d` flag to daemonize the container.
+#
+# Updating the images is as easy as this:
+#
+#   docker-compose pull && docker-compose restart
+#
+# ..Note::
+#
+#   The above commands assume you're already in the directory where
+#   where this docker-compose file is located.
+version: '3.4'
+
+x-defaults: &defaults
+  restart: "no"
+  image: raidennetwork/raiden-services:latest
+  env_file: services.env
+    - ./state:/state
+    - ~/.ethereum/keystore:/keystore
+
+services:
+  pfs-ropsten:
+    << : *defaults
+    ports:
+      - 6001:6000
+
+  pfs-rinkeby:
+    << : *defaults
+    ports:
+      - 6002:6000
+
+  pfs-kovan:
+    << : *defaults
+    ports:
+      - 6003:6000
+
+  pfs-goerli:
+    <<: *defaults
+    ports:
+      - 6004:6000
+
+  pfs-ropsten-with-fee:
+    << : *defaults
+    ports:
+      - 6005:6000
+
+  pfs-rinkeby-with-fee:
+    << : *defaults
+    ports:
+      - 6006:6000
+
+  pfs-kovan-with-fee:
+    << : *defaults
+    ports:
+      - 6007:6000
+
+  pfs-goerli-with-fee:
+    <<: *defaults
+    ports:
+      - 6008:6000
+
+  ms-ropsten:
+    << : *defaults
+
+  ms-rinkeby:
+    << : *defaults
+
+  ms-kovan:
+    << : *defaults
+
+  ms-goerli:
+    <<: *defaults
+
+  msrc-ropsten:
+    << : *defaults
+
+  msrc-rinkeby:
+    << : *defaults
+
+  msrc-kovan:
+    << : *defaults
+
+  msrc-goerli:
+    <<: *defaults

--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -1,5 +1,12 @@
-# For development. Start the desired services with
-# docker-compose up service1 service2
+# Local-changes setup.
+# Uses the development code on the local disc.
+#
+# Start the desired services with::
+#
+#   docker-compose up service1 service2
+#
+# Daemonize with the `-d` flag.
+#
 version: '3.4'
 
 x-defaults: &defaults

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,8 +1,26 @@
+# Production-ready setup.
+# Uses the newest `stable` image of the `master` branch.
+# a traefik instance handles exposition of service instances.
+# All services are expected to be started, hence the following command
+# must be run to start the docker setup:
+#
+#   docker-compose up
+#
+# Add the `-d` flag to daemonize the containers.
+#
+# Updating the images is as easy as this:
+#
+#   docker-compose pull && docker-compose restart
+#
+# ..Note::
+#
+#   The above commands assume you're already in the directory where
+#   where this docker-compose file is located.
 version: '3.4'
 
 x-defaults: &defaults
   restart: always
-  image: raiden-services
+  image: raidennetwork/raiden-services:stable
   env_file: services.env
   volumes:
     - /data/state:/state

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - PFS_STATE_DB=/state/pfs-ropsten.db
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-ropsten.services-dev.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-ropsten-stable.services-dev.raiden.network"
 
   pfs-ropsten-with-fee:
     << : *defaults
@@ -47,7 +47,7 @@ services:
       - PFS_SERVICE_FEE=100
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-ropsten-with-fee.services-dev.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-ropsten-with-fee-stable.services-dev.raiden.network"
 
   pfs-rinkeby:
     << : *defaults
@@ -57,7 +57,7 @@ services:
       - PFS_STATE_DB=/state/pfs-rinkeby.db
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-rinkeby.services-dev.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-rinkeby-stable.services-dev.raiden.network"
 
   pfs-rinkeby-with-fee:
     << : *defaults
@@ -68,7 +68,7 @@ services:
       - PFS_SERVICE_FEE=100
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-rinkeby-with-fee.services-dev.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-rinkeby-with-fee-stable.services-dev.raiden.network"
 
   pfs-kovan:
     << : *defaults
@@ -78,7 +78,7 @@ services:
       - PFS_STATE_DB=/state/pfs-kovan.db
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-kovan.services-dev.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-kovan-stable.services-dev.raiden.network"
 
   pfs-kovan-with-fee:
     << : *defaults
@@ -89,7 +89,7 @@ services:
       - PFS_SERVICE_FEE=100
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-kovan-with-fee.services-dev.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-kovan-with-fee-stable.services-dev.raiden.network"
 
   pfs-goerli:
     <<: *defaults
@@ -99,7 +99,7 @@ services:
       - PFS_STATE_DB=/state/pfs-goerli.db
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-goerli.services-dev.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-goerli-stable.services-dev.raiden.network"
 
   pfs-goerli-with-fee:
     <<: *defaults
@@ -110,7 +110,7 @@ services:
       - PFS_SERVICE_FEE=100
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-goerli-with-fee.services-dev.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-goerli-with-fee-stable.services-dev.raiden.network"
 
   ms-ropsten:
     << : *defaults


### PR DESCRIPTION
The docker-compose files provided now use the hub.docker.com
registry to pull built images.

This replaces the builder's build functionality with an
update functionality - images are no longer built
directly from the repo - instead, we let hub.docker.com
handle the build process. Images are updated using
`docker-compose pull && docker-compose restart` to
download the newest images for the configured tag.

Additionally, a docker-compose.latest.yml has been added
as a drop-in replacement for docker-compose.override.yml,
which is a more explicit name for the file imo.

Doc strings have been added to the compose yamls.

Exception handling was slightly refacored in the builder app.