### PR TITLE
Fix 'MatrixListener' has no attr. 'rate_limiter'

### DIFF
--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -182,7 +182,7 @@ class MatrixListener(gevent.Greenlet):
             )
 
         self.startup_finished = Event()
-        self.rate_limiter(
+        self.rate_limiter = RateLimiter(
             allowed_bytes=MATRIX_RATE_LIMIT_ALLOWED_BYTES,
             reset_interval=MATRIX_RATE_LIMIT_RESET_INTERVAL,
         )


### PR DESCRIPTION
This uses far more mocking than I like, but I didn't see a simple way to
test this without having it do network stuff apart from using mocks.

Fixes https://github.com/raiden-network/raiden-services/issues/458.