### PR TITLE
Configure CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,52 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements-dev.txt
+            pip install -e .
+            pip install codecov
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+
+      - run:
+          name: make lint
+          command: |
+            . venv/bin/activate
+            make lint
+
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            pytest -v tests/ -n 3 --cov=src --cov-report=xml --junitxml=test-reports/junit.xml
+            codecov
+
+      - store_test_results:
+          path: test-reports
+
+      - store_artifacts:
+          path: test-reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ script:
   - pip install -e .
   - make lint
   - pytest -v --cov=./ tests/ -n auto
-  - codecov


### PR DESCRIPTION

In the raiden client we already use CircleCI and are happier with it than with Travis. The change seems simple enough and even with this basic configuration, we are faster than Travis (~2:45 vs ~3:45).
    
I'll keep both Travis and CircleCI on for a while to see if things run as intended. We can remove Travis when we're confident enough. I just disabled the codecov upload by Travis to avoid duplicate uploads.
