### PR TITLE
Add sentry-structlog processor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ requests==2.22.0
 marshmallow==3.0.0rc8
 marshmallow-dataclass==6.0.0rc4
 
-sentry-sdk[flask]==0.10.1
+sentry-sdk[flask]==0.10.2
+structlog-sentry==1.0.0

--- a/src/raiden_libs/logging.py
+++ b/src/raiden_libs/logging.py
@@ -1,10 +1,12 @@
 import logging
+import os
 import sys
 from dataclasses import asdict
 from typing import Any, Dict
 
 import structlog
 from eth_utils import to_checksum_address, to_hex
+from structlog_sentry import SentryProcessor
 
 from raiden.messages.abstract import Message
 from raiden_libs.events import Event
@@ -18,17 +20,22 @@ def setup_logging(log_level: str) -> None:
     logging.getLogger("web3").setLevel("INFO")
     logging.getLogger("urllib3").setLevel("INFO")
 
+    processors = [
+        format_to_hex,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+
+    sentry_dsn = os.environ.get("SENTRY_DSN")
+    if sentry_dsn is not None:
+        processors.append(SentryProcessor())  # requires structlog.stdlib.add_log_level before
+
     structlog.configure(
-        processors=[
-            format_to_hex,
-            structlog.stdlib.add_log_level,
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            structlog.dev.ConsoleRenderer(),
-        ],
+        processors=processors + [structlog.dev.ConsoleRenderer()],
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,


### PR DESCRIPTION
This add sentry-structlog to the strctlog processors, so that all logs
with level WARNING or higher get automatically reported to sentry.