### PR TITLE
Bring Sentry configuration into a usable state

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,3 @@ marshmallow==3.0.0rc8
 marshmallow-dataclass==6.0.0rc4
 
 sentry-sdk[flask]==0.10.2
-structlog-sentry==1.0.0

--- a/src/raiden_libs/gevent_error_handler.py
+++ b/src/raiden_libs/gevent_error_handler.py
@@ -1,5 +1,4 @@
 import sys
-import traceback
 from typing import Any
 
 import structlog
@@ -9,7 +8,7 @@ log = structlog.get_logger(__name__)
 ORIGINAL_ERROR_HANDLER = Hub.handle_error
 
 
-def error_handler(_self: Any, _context: Any, etype: Any, value: Any, tb: Any) -> None:
+def error_handler(self: Any, _context: Any, etype: Any, value: Any, _tb: Any) -> None:
     if issubclass(etype, Hub.NOT_ERROR):
         return
     if issubclass(etype, KeyboardInterrupt):
@@ -21,8 +20,8 @@ def error_handler(_self: Any, _context: Any, etype: Any, value: Any, tb: Any) ->
         "Please report this issue at "
         "https://github.com/raiden-network/raiden-services/issues"
     )
-    traceback.print_exception(etype=etype, value=value, tb=tb)
-    sys.exit(1)
+    # This will properly raise the exception and stop the process
+    Hub.handle_system_error(self, etype, value)
 
 
 def register_error_handler() -> None:

--- a/src/raiden_libs/logging.py
+++ b/src/raiden_libs/logging.py
@@ -1,12 +1,10 @@
 import logging
-import os
 import sys
 from dataclasses import asdict
 from typing import Any, Dict
 
 import structlog
 from eth_utils import to_checksum_address, to_hex
-from structlog_sentry import SentryProcessor
 
 from raiden.messages.abstract import Message
 from raiden_libs.events import Event
@@ -29,10 +27,6 @@ def setup_logging(log_level: str) -> None:
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
     ]
-
-    sentry_dsn = os.environ.get("SENTRY_DSN")
-    if sentry_dsn is not None:
-        processors.append(SentryProcessor())  # requires structlog.stdlib.add_log_level before
 
     structlog.configure(
         processors=processors + [structlog.dev.ConsoleRenderer()],


### PR DESCRIPTION
We will still get garbled log messages like
```
[0m] [1mError log right before exception[0m [[34m[1mraiden_libs.matrix[0m] [36mvalue[0m=[35m2[0m
```
but at least the traceback will be clean and the error grouping works.