### PR TITLE
Remove handling of ChannelNewDeposit event

### DIFF
--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -144,14 +144,7 @@ class PFSDatabase(BaseDatabase):
 
     def upsert_channel_view(self, channel_view: ChannelView) -> None:
         cv_dict = ChannelView.Schema().dump(channel_view)
-        for key in (
-            "channel_id",
-            "settle_timeout",
-            "capacity",
-            "reveal_timeout",
-            "deposit",
-            "update_nonce",
-        ):
+        for key in ("channel_id", "settle_timeout", "capacity", "reveal_timeout", "update_nonce"):
             cv_dict[key] = hex256(cv_dict[key])
         cv_dict["fee_schedule_sender"] = json.dumps(cv_dict["fee_schedule_sender"])
         cv_dict["fee_schedule_receiver"] = json.dumps(cv_dict["fee_schedule_receiver"])

--- a/src/pathfinding_service/model/channel_view.py
+++ b/src/pathfinding_service/model/channel_view.py
@@ -47,22 +47,12 @@ class ChannelView:
     token_network_address: TokenNetworkAddress = field(
         metadata={"marshmallow_field": ChecksumAddress(required=True)}
     )
-    capacity: TokenAmount = None  # type: ignore
+    capacity: TokenAmount = TokenAmount(0)
     reveal_timeout: int = DEFAULT_REVEAL_TIMEOUT
-    deposit: TokenAmount = TokenAmount(0)
     update_nonce: Nonce = Nonce(0)
     fee_schedule_sender: FeeSchedule = field(default_factory=FeeSchedule)
     fee_schedule_receiver: FeeSchedule = field(default_factory=FeeSchedule)
     Schema: ClassVar[Type[marshmallow.Schema]]
-
-    def __post_init__(self) -> None:
-        if self.capacity is None:
-            self.capacity = self.deposit
-
-    def update_deposit(self, total_deposit: TokenAmount) -> None:
-        if total_deposit > self.deposit:
-            self.capacity = TokenAmount(self.capacity + total_deposit - self.deposit)
-            self.deposit = TokenAmount(total_deposit)
 
     def update_capacity(
         self, capacity: TokenAmount, nonce: Nonce = Nonce(0), reveal_timeout: int = None

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -179,7 +179,6 @@ class TokenNetwork:
                 participant1=participant1,
                 participant2=participant2,
                 settle_timeout=settle_timeout,
-                deposit=TokenAmount(0),
             ),
             ChannelView(
                 token_network_address=self.address,
@@ -187,7 +186,6 @@ class TokenNetwork:
                 participant1=participant2,
                 participant2=participant1,
                 settle_timeout=settle_timeout,
-                deposit=TokenAmount(0),
             ),
         ]
 
@@ -207,32 +205,6 @@ class TokenNetwork:
                 channel_view.participant2,
             )
         self.G.add_edge(channel_view.participant1, channel_view.participant2, view=channel_view)
-
-    def handle_channel_new_deposit_event(
-        self, channel_identifier: ChannelID, receiver: Address, total_deposit: TokenAmount
-    ) -> Optional[ChannelView]:
-        """ Register a new balance for the beneficiary.
-
-        Corresponds to the ChannelNewDeposit event. Called by the contract event listener. """
-
-        try:
-            participant1, participant2 = self.channel_id_to_addresses[channel_identifier]
-            if receiver == participant1:
-                channel_view = self.G[participant1][participant2]["view"]
-            elif receiver == participant2:
-                channel_view = self.G[participant2][participant1]["view"]
-            else:
-                log.error("Receiver in ChannelNewDeposit does not fit the internal channel")
-                return None
-        except KeyError:
-            log.error(
-                "Received ChannelNewDeposit event for unknown channel",
-                channel_identifier=channel_identifier,
-            )
-            return None
-
-        channel_view.update_deposit(total_deposit=total_deposit)
-        return channel_view
 
     def handle_channel_closed_event(self, channel_identifier: ChannelID) -> None:
         """ Close a channel. This doesn't mean that the channel is settled yet, but it cannot

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -19,7 +19,6 @@ CREATE TABLE channel_view (
     settle_timeout  HEX_INT NOT NULL,
     capacity        HEX_INT NOT NULL,
     reveal_timeout  HEX_INT NOT NULL,
-    deposit         HEX_INT NOT NULL,
     update_nonce    HEX_INT,
     fee_schedule_sender    JSON,
     fee_schedule_receiver  JSON,

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -28,7 +28,6 @@ from raiden_libs.contract_info import CONTRACT_MANAGER
 from raiden_libs.events import (
     Event,
     ReceiveChannelClosedEvent,
-    ReceiveChannelNewDepositEvent,
     ReceiveChannelOpenedEvent,
     ReceiveTokenNetworkCreatedEvent,
     UpdatedHeadBlockEvent,
@@ -183,8 +182,6 @@ class PathfindingService(gevent.Greenlet):
             self.handle_token_network_created(event)
         elif isinstance(event, ReceiveChannelOpenedEvent):
             self.handle_channel_opened(event)
-        elif isinstance(event, ReceiveChannelNewDepositEvent):
-            self.handle_channel_new_deposit(event)
         elif isinstance(event, ReceiveChannelClosedEvent):
             self.handle_channel_closed(event)
         elif isinstance(event, UpdatedHeadBlockEvent):
@@ -225,21 +222,6 @@ class PathfindingService(gevent.Greenlet):
                 token_network_address=token_network.address, channel_id=event.channel_identifier
             ):
                 self.handle_message(message)
-
-    def handle_channel_new_deposit(self, event: ReceiveChannelNewDepositEvent) -> None:
-        token_network = self.get_token_network(event.token_network_address)
-        if token_network is None:
-            return
-
-        log.info("Received ChannelNewDeposit event", event_=event)
-
-        channel_view = token_network.handle_channel_new_deposit_event(
-            channel_identifier=event.channel_identifier,
-            receiver=event.participant_address,
-            total_deposit=event.total_deposit,
-        )
-        if channel_view:
-            self.database.upsert_channel_view(channel_view)
 
     def handle_channel_closed(self, event: ReceiveChannelClosedEvent) -> None:
         token_network = self.get_token_network(event.token_network_address)

--- a/src/raiden_libs/blockchain.py
+++ b/src/raiden_libs/blockchain.py
@@ -21,7 +21,6 @@ from raiden_contracts.contract_manager import ContractManager
 from raiden_libs.events import (
     Event,
     ReceiveChannelClosedEvent,
-    ReceiveChannelNewDepositEvent,
     ReceiveChannelOpenedEvent,
     ReceiveChannelSettledEvent,
     ReceiveMonitoringNewBalanceProofEvent,
@@ -101,12 +100,6 @@ def parse_token_network_event(event: dict) -> Optional[Event]:
             participant1=decode_hex(event["args"]["participant1"]),
             participant2=decode_hex(event["args"]["participant2"]),
             settle_timeout=event["args"]["settle_timeout"],
-            **common_infos,
-        )
-    if event_name == ChannelEvent.DEPOSIT:
-        return ReceiveChannelNewDepositEvent(
-            participant_address=decode_hex(event["args"]["participant"]),
-            total_deposit=event["args"]["total_deposit"],
             **common_infos,
         )
     if event_name == ChannelEvent.CLOSED:

--- a/src/raiden_libs/events.py
+++ b/src/raiden_libs/events.py
@@ -33,15 +33,6 @@ class ReceiveChannelOpenedEvent(Event):
 
 
 @dataclass
-class ReceiveChannelNewDepositEvent(Event):
-    token_network_address: TokenNetworkAddress
-    channel_identifier: ChannelID
-    participant_address: Address
-    total_deposit: TokenAmount
-    block_number: BlockNumber
-
-
-@dataclass
 class ReceiveChannelClosedEvent(Event):
     token_network_address: TokenNetworkAddress
     channel_identifier: ChannelID

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -34,13 +34,11 @@ def channel_descriptions_case_1() -> List:
     # The tuples in channel_descriptions define the following:
     # (
     #     p1_index,
-    #     p1_deposit,
     #     p1_capacity,
     #     p1_fee,
     #     p1_reveal_timeout,
     #     p1_reachability,
     #     p2_index,
-    #     p2_deposit,
     #     p2_capacity,
     #     p2_fee,
     #     p2_reveal_timeout,
@@ -55,13 +53,13 @@ def channel_descriptions_case_1() -> List:
     reach = AddressReachability.REACHABLE
 
     channel_descriptions = [
-        (0, 100, 90, 10, 2, reach, 1, 50, 60, 15, 2, reach, 14),  # capacities  90 --  60
-        (1, 40, 130, 8, 2, reach, 2, 130, 40, 12, 2, reach, 14),  # capacities 130 --  40
-        (2, 90, 80, 7, 2, reach, 3, 10, 20, 10, 2, reach, 3),  # capacities  80 --  20
-        (3, 50, 50, 11, 2, reach, 4, 50, 50, 11, 2, reach, 14),  # capacities  50 --  50
-        (0, 40, 0, 15, 2, reach, 2, 80, 120, 25, 2, reach, 14),  # capacities   0 -- 120
-        (1, 30, 35, 100, 2, reach, 4, 40, 35, 18, 2, reach, 14),  # capacities  35 --  35
-        (5, 500, 550, 30, 2, reach, 6, 750, 700, 40, 2, reach, 14),  # capacities 550 -- 700
+        (0, 90, 10, 2, reach, 1, 60, 15, 2, reach, 14),  # capacities  90 --  60
+        (1, 130, 8, 2, reach, 2, 40, 12, 2, reach, 14),  # capacities 130 --  40
+        (2, 80, 7, 2, reach, 3, 20, 10, 2, reach, 3),  # capacities  80 --  20
+        (3, 50, 11, 2, reach, 4, 50, 11, 2, reach, 14),  # capacities  50 --  50
+        (0, 0, 15, 2, reach, 2, 120, 25, 2, reach, 14),  # capacities   0 -- 120
+        (1, 35, 100, 2, reach, 4, 35, 18, 2, reach, 14),  # capacities  35 --  35
+        (5, 550, 30, 2, reach, 6, 700, 40, 2, reach, 14),  # capacities 550 -- 700
     ]
     return channel_descriptions
 
@@ -77,13 +75,11 @@ def channel_descriptions_case_2() -> List:
     # The tuples in channel_descriptions define the following:
     # (
     #     p1_index,
-    #     p1_deposit,
     #     p1_capacity,
     #     p1_fee,
     #     p1_reveal_timeout,
     #     p1_reachability,
     #     p2_index,
-    #     p2_deposit,
     #     p2_capacity,
     #     p2_fee,
     #     p2_reveal_timeout,
@@ -98,13 +94,13 @@ def channel_descriptions_case_2() -> List:
     reach = AddressReachability.REACHABLE
 
     channel_descriptions = [
-        (0, 100, 90, 3000, 2, reach, 1, 50, 60, 3000, 2, reach, 15),  # capacities  90 --  60
-        (1, 40, 130, 2000, 2, reach, 4, 130, 40, 2000, 2, reach, 15),  # capacities 130 --  40
-        (0, 90, 80, 1000, 2, reach, 2, 10, 10, 1000, 2, reach, 15),  # capacities  80 --  10
-        (2, 50, 50, 1500, 2, reach, 3, 50, 50, 1500, 2, reach, 15),  # capacities  50 --  50
-        (3, 100, 60, 1000, 2, reach, 4, 80, 120, 1000, 2, reach, 15),  # capacities  60 -- 120
-        (2, 30, 35, 1000, 2, reach, 5, 40, 35, 1000, 2, reach, 15),  # capacities  35 --  35
-        (5, 500, 550, 1000, 2, reach, 4, 750, 700, 1000, 2, reach, 15),  # capacities 550 -- 700
+        (0, 90, 3000, 2, reach, 1, 60, 3000, 2, reach, 15),  # capacities  90 --  60
+        (1, 130, 2000, 2, reach, 4, 40, 2000, 2, reach, 15),  # capacities 130 --  40
+        (0, 80, 1000, 2, reach, 2, 10, 1000, 2, reach, 15),  # capacities  80 --  10
+        (2, 50, 1500, 2, reach, 3, 50, 1500, 2, reach, 15),  # capacities  50 --  50
+        (3, 60, 1000, 2, reach, 4, 120, 1000, 2, reach, 15),  # capacities  60 -- 120
+        (2, 35, 1000, 2, reach, 5, 35, 1000, 2, reach, 15),  # capacities  35 --  35
+        (5, 550, 1000, 2, reach, 4, 700, 1000, 2, reach, 15),  # capacities 550 -- 700
     ]
     return channel_descriptions
 
@@ -117,13 +113,11 @@ def channel_descriptions_case_3() -> List:
     # The tuples in channel_descriptions define the following:
     # (
     #     p1_index,
-    #     p1_deposit,
     #     p1_capacity,
     #     p1_fee,
     #     p1_reveal_timeout,
     #     p1_reachability,
     #     p2_index,
-    #     p2_deposit,
     #     p2_capacity,
     #     p2_fee,
     #     p2_reveal_timeout,
@@ -140,7 +134,7 @@ def channel_descriptions_case_3() -> List:
     reach = AddressReachability.REACHABLE
 
     channel_descriptions = [
-        (a, 100, 100, 0, 2, reach, b, 100, 100, 0, 2, reach, 15)
+        (a, 100, 0, 2, reach, b, 100, 0, 2, reach, 15)
         for a, b in [
             (0, 1),
             (1, 2),
@@ -174,13 +168,11 @@ def populate_token_network() -> Callable:
             channel_id,
             (
                 p1_index,
-                p1_deposit,
                 p1_capacity,
                 _p1_fee,
                 p1_reveal_timeout,
                 p1_reachability,
                 p2_index,
-                p2_deposit,
                 p2_capacity,
                 _p2_fee,
                 p2_reveal_timeout,
@@ -195,17 +187,6 @@ def populate_token_network() -> Callable:
                 participant1=participant1,
                 participant2=participant2,
                 settle_timeout=settle_timeout,
-            )
-
-            token_network.handle_channel_new_deposit_event(
-                channel_identifier=ChannelID(channel_id),
-                receiver=participant1,
-                total_deposit=p1_deposit,
-            )
-            token_network.handle_channel_new_deposit_event(
-                channel_identifier=ChannelID(channel_id),
-                receiver=participant2,
-                total_deposit=p2_deposit,
             )
 
             token_network.handle_channel_balance_update_message(

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -106,7 +106,7 @@ def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
     )
 
     # check that deposits, settle_timeout and transfers got registered
-    for index, _ in enumerate(channel_descriptions_case_1):
+    for index in range(len(channel_descriptions_case_1)):
         channel_identifier = channel_identifiers[index]
         p1_address, p2_address = token_network_model.channel_id_to_addresses[channel_identifier]
         view1: ChannelView = graph[p1_address][p2_address]["view"]

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -70,14 +70,12 @@ def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
     channel_identifiers = []
     for (
         p1_index,
-        p1_deposit,
-        _p1_capacity,
+        p1_capacity,
         _p1_fee,
         _p1_reveal_timeout,
         _p1_reachability,
         p2_index,
-        p2_deposit,
-        _p2_capacity,
+        p2_capacity,
         _p2_fee,
         _p2_reveal_timeout,
         _p2_reachability,
@@ -88,8 +86,8 @@ def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
         channel_identifiers.append(channel_id)
 
         for address, partner_address, amount in [
-            (clients[p1_index], clients[p2_index], p1_deposit),
-            (clients[p2_index], clients[p1_index], p2_deposit),
+            (clients[p1_index], clients[p2_index], p1_capacity),
+            (clients[p2_index], clients[p1_index], p2_capacity),
         ]:
             custom_token.functions.mint(amount).transact({"from": address})
             custom_token.functions.approve(token_network.address, amount).transact(
@@ -108,30 +106,11 @@ def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
     )
 
     # check that deposits, settle_timeout and transfers got registered
-    for (
-        index,
-        (
-            _p1_index,
-            p1_deposit,
-            _p1_capacity,
-            _p1_fee,
-            _p1_reveal_timeout,
-            _p1_reachability,
-            _p2_index,
-            p2_deposit,
-            _p2_capacity,
-            _p2_fee,
-            _p2_reveal_timeout,
-            _p2_reachability,
-            _settle_timeout,
-        ),
-    ) in enumerate(channel_descriptions_case_1):
+    for index, _ in enumerate(channel_descriptions_case_1):
         channel_identifier = channel_identifiers[index]
         p1_address, p2_address = token_network_model.channel_id_to_addresses[channel_identifier]
         view1: ChannelView = graph[p1_address][p2_address]["view"]
         view2: ChannelView = graph[p2_address][p1_address]["view"]
-        assert view1.deposit == p1_deposit
-        assert view2.deposit == p2_deposit
         assert view1.settle_timeout == TEST_SETTLE_TIMEOUT_MIN
         assert view2.settle_timeout == TEST_SETTLE_TIMEOUT_MIN
         assert view1.reveal_timeout == DEFAULT_REVEAL_TIMEOUT
@@ -142,13 +121,11 @@ def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
         index,
         (
             p1_index,
-            _p1_deposit,
             _p1_capacity,
             _p1_fee,
             _p1_reveal_timeout,
             _p1_reachability,
             p2_index,
-            _p2_deposit,
             _p2_capacity,
             _p2_fee,
             _p2_reveal_timeout,

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -99,7 +99,6 @@ def test_routing_simple(
     view01: ChannelView = token_network_model.G[addresses[0]][addresses[1]]["view"]
     view10: ChannelView = token_network_model.G[addresses[1]][addresses[0]]["view"]
 
-    # assert view01.deposit == 100
     assert view01.fee_schedule_sender.flat == 0
     assert view01.capacity == 90
     assert view10.capacity == 60

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -99,7 +99,7 @@ def test_routing_simple(
     view01: ChannelView = token_network_model.G[addresses[0]][addresses[1]]["view"]
     view10: ChannelView = token_network_model.G[addresses[1]][addresses[0]]["view"]
 
-    assert view01.deposit == 100
+    # assert view01.deposit == 100
     assert view01.fee_schedule_sender.flat == 0
     assert view01.capacity == 90
     assert view10.capacity == 60

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -28,7 +28,6 @@ from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT
 from raiden_contracts.tests.utils import get_random_privkey, to_canonical_address
 from raiden_libs.events import (
     ReceiveChannelClosedEvent,
-    ReceiveChannelNewDepositEvent,
     ReceiveChannelOpenedEvent,
     ReceiveTokenNetworkCreatedEvent,
     UpdatedHeadBlockEvent,
@@ -204,29 +203,6 @@ def test_token_channel_opened(pathfinding_service_mock, token_network_model):
     pathfinding_service_mock.matrix_listener.follow_address_presence.assert_has_calls(
         [call(PARTICIPANT1, refresh=True), call(PARTICIPANT2, refresh=True)]
     )
-
-
-def test_token_channel_new_deposit(pathfinding_service_mock, token_network_model):
-    setup_channel(pathfinding_service_mock, token_network_model)
-
-    deposit_event = ReceiveChannelNewDepositEvent(
-        token_network_address=token_network_model.address,
-        channel_identifier=ChannelID(1),
-        participant_address=PARTICIPANT1,
-        total_deposit=TokenAmount(123),
-        block_number=BlockNumber(2),
-    )
-
-    pathfinding_service_mock.handle_event(deposit_event)
-    assert len(pathfinding_service_mock.token_networks) == 1
-    assert len(token_network_model.channel_id_to_addresses) == 1
-
-    # Test invalid token network address
-    deposit_event.token_network_address = TokenNetworkAddress(bytes([0] * 20))
-
-    pathfinding_service_mock.handle_event(deposit_event)
-    assert len(pathfinding_service_mock.token_networks) == 1
-    assert len(token_network_model.channel_id_to_addresses) == 1
 
 
 def test_token_channel_closed(pathfinding_service_mock, token_network_model):


### PR DESCRIPTION
Handling the event turned out to be a source of issues. Besides, it
doesn't provide any advantages over just using the capacity updates from
the nodes.

This commit removes all internal handling of the deposit event.

Fixes https://github.com/raiden-network/raiden-services/issues/494