### PR TITLE
Don't treat `dist` dir as result of `dist` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,5 @@ clean-pyc:
 	find . -name '*.pyc' -delete
 	find . -name '*.pyo' -delete
 	find . -name '__pycache__' -delete
+
+.PHONY: dist


### PR DESCRIPTION
Otherwise `make dist` won't do anything when there is a `dist` directory.