### PR TITLE
Return early in case of unknown message type

### DIFF
--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -241,6 +241,7 @@ class PathfindingService(gevent.Greenlet):
                 changed_cvs = self.on_fee_update(message)
             else:
                 log.debug("Ignoring message", message=message)
+                return
 
             for cv in changed_cvs:
                 self.database.upsert_channel_view(cv)

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -240,7 +240,7 @@ class PathfindingService(gevent.Greenlet):
             elif isinstance(message, PFSFeeUpdate):
                 changed_cvs = self.on_fee_update(message)
             else:
-                log.debug("Ignoring message", message=message)
+                log.debug("Ignoring message", unknown_message=message)
                 return
 
             for cv in changed_cvs:

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -31,8 +31,8 @@ def test_process_payment_errors(
 
     def test_payment(iou, service_fee=TokenAmount(1)):
         process_payment(
-            iou,
-            pfs,
+            iou=iou,
+            pathfinding_service=pfs,
             service_fee=service_fee,
             one_to_n_address=decode_hex(one_to_n_contract.address),
         )

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -10,6 +10,7 @@ from pathfinding_service import exceptions
 from pathfinding_service.model.token_network import PFSFeeUpdate
 from pathfinding_service.service import PathfindingService
 from raiden.constants import EMPTY_SIGNATURE
+from raiden.messages.synchronization import Processed
 from raiden.network.transport.matrix import AddressReachability
 from raiden.tests.utils.factories import make_privkey_address
 from raiden.transfer.identifiers import CanonicalIdentifier
@@ -21,6 +22,7 @@ from raiden.utils.typing import (
     ChainID,
     ChannelID,
     FeeAmount,
+    MessageID,
     TokenAmount,
     TokenNetworkAddress,
 )
@@ -306,6 +308,14 @@ def test_invalid_fee_update(pathfinding_service_mock, token_network_model):
     # bad/missing signature
     with pytest.raises(exceptions.InvalidPFSFeeUpdate):
         pathfinding_service_mock.on_fee_update(fee_update)
+
+
+def test_unhandled_message(pathfinding_service_mock, log):
+    unknown_message = Processed(MessageID(123), signature=EMPTY_SIGNATURE)
+    unknown_message.sign(LocalSigner(PARTICIPANT1_PRIVKEY))
+
+    pathfinding_service_mock.handle_message(unknown_message)
+    assert log.has("Ignoring message", unknown_message=unknown_message)
 
 
 def test_logging_processor():


### PR DESCRIPTION
Otherwise `changed_cvs` will not be initialized.

Closes #500 