### PR TITLE
Rename `closing_tx_hash` to `monitor_tx_hash`

### DIFF
--- a/src/monitoring_service/database.py
+++ b/src/monitoring_service/database.py
@@ -106,7 +106,7 @@ class SharedDatabase(BaseDatabase):
             channel.state,
             hex256(channel.closing_block) if channel.closing_block else None,
             channel.closing_participant,
-            encode_hex(channel.closing_tx_hash) if channel.closing_tx_hash else None,
+            encode_hex(channel.monitor_tx_hash) if channel.monitor_tx_hash else None,
             encode_hex(channel.claim_tx_hash) if channel.claim_tx_hash else None,
         ]
         if channel.update_status:
@@ -141,8 +141,8 @@ class SharedDatabase(BaseDatabase):
         kwargs["token_network_address"] = decode_hex(kwargs["token_network_address"])
         kwargs["participant1"] = decode_hex(kwargs["participant1"])
         kwargs["participant2"] = decode_hex(kwargs["participant2"])
-        if kwargs["closing_tx_hash"] is not None:
-            kwargs["closing_tx_hash"] = decode_hex(kwargs["closing_tx_hash"])
+        if kwargs["monitor_tx_hash"] is not None:
+            kwargs["monitor_tx_hash"] = decode_hex(kwargs["monitor_tx_hash"])
         if kwargs["claim_tx_hash"] is not None:
             kwargs["claim_tx_hash"] = decode_hex(kwargs["claim_tx_hash"])
 

--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -446,7 +446,7 @@ def action_monitoring_triggered_event_handler(event: Event, context: Context) ->
         return
 
     assert (
-        channel.closing_tx_hash is None
+        channel.monitor_tx_hash is None
     ), "This MS already monitored this channel. Should be impossible."
 
     try:
@@ -484,7 +484,7 @@ def action_monitoring_triggered_event_handler(event: Event, context: Context) ->
             # Add tx hash to list of waiting transactions
             context.db.add_waiting_transaction(tx_hash)
 
-            channel.closing_tx_hash = tx_hash
+            channel.monitor_tx_hash = tx_hash
             context.db.upsert_channel(channel)
     except Exception as exc:  # pylint: disable=broad-except
         log.error("Sending tx failed", exc_info=True, err=exc)

--- a/src/monitoring_service/schema.sql
+++ b/src/monitoring_service/schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE channel (
     state                   INT NOT NULL CHECK (state >= 0 AND state <= 4),
     closing_block           HEX_INT,
     closing_participant     CHAR(42),
-    closing_tx_hash         CHAR(66),
+    monitor_tx_hash         CHAR(66),
     claim_tx_hash           CHAR(66),
     update_status_sender    CHAR(42),
     update_status_nonce     HEX_INT,

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -41,7 +41,7 @@ class Channel:
     closing_block: Optional[BlockNumber] = None
     closing_participant: Optional[Address] = None
 
-    closing_tx_hash: Optional[TransactionHash] = None
+    monitor_tx_hash: Optional[TransactionHash] = None
     claim_tx_hash: Optional[TransactionHash] = None
 
     update_status: Optional[OnChainUpdateStatus] = None

--- a/tests/monitoring/monitoring_service/factories.py
+++ b/tests/monitoring/monitoring_service/factories.py
@@ -69,7 +69,7 @@ def create_channel(update_status: OnChainUpdateStatus = None) -> Channel:
         state=random.choice(list(ChannelState)),
         closing_block=BlockNumber(random.randint(0, UINT256_MAX)),
         closing_participant=DEFAULT_PARTICIPANT1,
-        closing_tx_hash=make_transaction_hash(),
+        monitor_tx_hash=make_transaction_hash(),
         claim_tx_hash=make_transaction_hash(),
         update_status=update_status,
     )

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -125,8 +125,8 @@ def test_first_allowed_monitoring(
     assert [e.event for e in query()] == []
 
     # If our `monitor` call fails, we won't try again. Force a retry in this
-    # test by clearing closing_tx_hash.
-    channel.closing_tx_hash = None
+    # test by clearing monitor_tx_hash.
+    channel.monitor_tx_hash = None
     monitoring_service.database.upsert_channel(channel)
 
     # Now we can try again. The first try mined a new block, so now we're one

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -475,13 +475,13 @@ def test_action_monitoring_triggered_event_handler_does_not_trigger_monitor_call
     channel = context.db.get_channel(event4.token_network_address, event4.channel_identifier)
     assert channel
     assert channel.update_status is not None
-    assert channel.closing_tx_hash is None
+    assert channel.monitor_tx_hash is None
 
     action_monitoring_triggered_event_handler(event4, context)
 
     assert context.db.channel_count() == 1
     assert channel
-    assert channel.closing_tx_hash is None
+    assert channel.monitor_tx_hash is None
 
 
 def test_action_monitoring_rescheduling_when_user_lacks_funds(context: Context):
@@ -544,7 +544,7 @@ def test_action_monitoring_triggered_event_handler_with_sufficient_balance_does_
         trigger_event.token_network_address, trigger_event.channel_identifier
     )
     assert channel
-    assert channel.closing_tx_hash is None
+    assert channel.monitor_tx_hash is None
 
     context.user_deposit_contract.functions.effectiveBalance(
         DEFAULT_PARTICIPANT2
@@ -577,7 +577,7 @@ def test_action_monitoring_triggered_event_handler_with_insufficient_reward_amou
         trigger_event.token_network_address, trigger_event.channel_identifier
     )
     assert channel
-    assert channel.closing_tx_hash is None
+    assert channel.monitor_tx_hash is None
 
     context.user_deposit_contract.functions.effectiveBalance(
         DEFAULT_PARTICIPANT2
@@ -612,7 +612,7 @@ def test_action_monitoring_triggered_event_handler_without_sufficient_balance_do
         trigger_event.token_network_address, trigger_event.channel_identifier
     )
     assert channel
-    assert channel.closing_tx_hash is None
+    assert channel.monitor_tx_hash is None
 
     context.user_deposit_contract.functions.effectiveBalance(
         DEFAULT_PARTICIPANT2


### PR DESCRIPTION
The old name is misleading!

This change breaks the db compatibility.