### PR TITLE
Update to latest Raiden and contracts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-raiden==0.100.5a0
-
-raiden-contracts==0.29.0
+git+https://github.com/raiden-network/raiden.git@0f6ddc4bfa81911b43d04ea81c9c966d681d7e89
+raiden-contracts==0.30.0
 
 structlog==19.1.0
 colorama==0.4.1

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -164,9 +164,7 @@ class HashedBalanceProof:
         Useful for `closing_signature` of `TokenNetwork.closeChannel`
         """
         signer = LocalSigner(decode_hex(privkey))
-        # TODO: use default message type id once
-        #       https://github.com/raiden-network/raiden-contracts/issues/1149 is fixed
-        return signer.sign(self.serialize_bin(MessageTypeId.BALANCE_PROOF_UPDATE) + self.signature)
+        return signer.sign(self.serialize_bin() + self.signature)
 
 
 @dataclass

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -191,6 +191,7 @@ class MatrixListener(gevent.Greenlet):
         self._start_client()
 
         self.client.start_listener_thread()
+        assert self.client.sync_thread
         self.client.sync_thread.get()
 
     def stop(self) -> None:

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -195,10 +195,15 @@ class MatrixListener(gevent.Greenlet):
         self.client.sync_thread.get()
 
     def stop(self) -> None:
+        if self.user_manager:
+            self.user_manager.stop()
         self.client.stop_listener_thread()
 
     def _start_client(self) -> None:
         try:
+            if self.user_manager:
+                self.user_manager.start()
+
             login_or_register(
                 self.client, signer=LocalSigner(private_key=decode_hex(self.private_key))
             )

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -24,8 +24,8 @@ TEST_POLL_INTERVAL = 0.001
 
 
 @pytest.fixture(scope="session")
-def ms_address(create_account) -> Address:
-    return to_canonical_address(create_account())
+def ms_address(create_service_account) -> Address:
+    return to_canonical_address(create_service_account())
 
 
 @pytest.fixture
@@ -52,19 +52,6 @@ def ms_database():
 
 
 @pytest.fixture
-def register_service(custom_token, service_registry):
-    def f(address):
-        deposit = service_registry.functions.currentPrice().call()
-        custom_token.functions.mint(deposit).transact({"from": address})
-        custom_token.functions.approve(service_registry.address, deposit).transact(
-            {"from": address}
-        )
-        service_registry.functions.deposit(deposit).transact({"from": address})
-
-    return f
-
-
-@pytest.fixture
 def monitoring_service(  # pylint: disable=too-many-arguments
     ms_address,
     web3: Web3,
@@ -73,9 +60,7 @@ def monitoring_service(  # pylint: disable=too-many-arguments
     token_network_registry_contract,
     ms_database,
     get_private_key,
-    register_service,
 ):
-    register_service(ms_address)
     ms = MonitoringService(
         web3=web3,
         private_key=get_private_key(ms_address),

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, Generator, List
 from unittest.mock import Mock, patch
 
 import pytest
+from eth_utils import to_canonical_address
 from web3 import Web3
 from web3.contract import Contract
 
@@ -23,6 +24,11 @@ from raiden.utils.typing import (
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_libs.utils import private_key_to_address
+
+
+@pytest.fixture(scope="session")
+def pfs_address(create_service_account) -> Address:
+    return to_canonical_address(create_service_account())
 
 
 @pytest.fixture(scope="session")
@@ -314,7 +320,7 @@ def pathfinding_service_mock(
 
 @pytest.fixture
 def pathfinding_service_web3_mock(
-    web3: Web3, user_deposit_contract: Contract
+    web3: Web3, user_deposit_contract: Contract, get_private_key: Callable, pfs_address: Address
 ) -> Generator[PathfindingService, None, None]:
     with patch("pathfinding_service.service.MatrixListener", new=Mock):
         pathfinding_service = PathfindingService(
@@ -323,7 +329,7 @@ def pathfinding_service_web3_mock(
                 CONTRACT_TOKEN_NETWORK_REGISTRY: Mock(address="0x" + "9" * 40),
                 CONTRACT_USER_DEPOSIT: user_deposit_contract,
             },
-            private_key="3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266",
+            private_key=get_private_key(pfs_address),
             db_filename=":memory:",
             required_confirmations=1,
         )

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -27,11 +27,6 @@ from raiden_libs.utils import private_key_to_address
 
 
 @pytest.fixture(scope="session")
-def pfs_address(create_service_account) -> Address:
-    return to_canonical_address(create_service_account())
-
-
-@pytest.fixture(scope="session")
 def channel_descriptions_case_1() -> List:
     """ Creates a network with some edge cases.
 
@@ -320,8 +315,12 @@ def pathfinding_service_mock(
 
 @pytest.fixture
 def pathfinding_service_web3_mock(
-    web3: Web3, user_deposit_contract: Contract, get_private_key: Callable, pfs_address: Address
+    web3: Web3,
+    user_deposit_contract: Contract,
+    get_private_key: Callable,
+    create_service_account: Callable,
 ) -> Generator[PathfindingService, None, None]:
+    pfs_address = to_canonical_address(create_service_account())
     with patch("pathfinding_service.service.MatrixListener", new=Mock):
         pathfinding_service = PathfindingService(
             web3=web3,


### PR DESCRIPTION
Update client and contracts deps

### TODO:
- [ ] The UserAddressManager now has `.start()` and `.stop()` methods that need to be called to `start` / `stop` the event listener. 
  -  `start` should be called just before login is performed on the client. Stop somewhere before the client it disconnected

⚠️ Don't merge before the hackathon, as we don't want to deploy this yet.