### PR TITLE
Graph pruning

### DIFF
--- a/src/raiden_libs/utils.py
+++ b/src/raiden_libs/utils.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from coincurve import PrivateKey, PublicKey
-from eth_utils import keccak, to_bytes
+from eth_utils import decode_hex, keccak
 
 from raiden.utils.typing import Address
 
@@ -15,7 +15,7 @@ def public_key_to_address(public_key: PublicKey) -> Address:
 def private_key_to_address(private_key: Union[str, bytes]) -> Address:
     """ Converts a private key to an Ethereum address. """
     if isinstance(private_key, str):
-        private_key = to_bytes(hexstr=private_key)
+        private_key = decode_hex(private_key)
 
     assert isinstance(private_key, bytes)
     privkey = PrivateKey(private_key)

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-outer-name
+import random
 from typing import Callable, Dict, Generator, List
 from unittest.mock import Mock, patch
 
@@ -21,6 +22,7 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
+from raiden_libs.utils import private_key_to_address
 
 
 @pytest.fixture(scope="session")
@@ -327,3 +329,66 @@ def pathfinding_service_web3_mock(
         )
 
         yield pathfinding_service
+
+
+@pytest.fixture
+def populate_token_network_random(
+    token_network_model: TokenNetwork, private_keys: List[str]
+) -> None:
+    number_of_channels = 300
+    # seed for pseudo-randomness from config constant, that changes from time to time
+    random.seed(number_of_channels)
+
+    for channel_id_int in range(number_of_channels):
+        channel_id = ChannelID(channel_id_int)
+
+        private_key1, private_key2 = random.sample(private_keys, 2)
+        address1 = private_key_to_address(private_key1)
+        address2 = private_key_to_address(private_key2)
+        settle_timeout = 15
+        token_network_model.handle_channel_opened_event(
+            channel_id, address1, address2, settle_timeout
+        )
+
+        # deposit to channels
+        deposit1 = TokenAmount(random.randint(0, 1000))
+        deposit2 = TokenAmount(random.randint(0, 1000))
+        address1, address2 = token_network_model.channel_id_to_addresses[channel_id]
+        token_network_model.handle_channel_balance_update_message(
+            PFSCapacityUpdate(
+                canonical_identifier=CanonicalIdentifier(
+                    chain_identifier=ChainID(1),
+                    channel_identifier=channel_id,
+                    token_network_address=TokenNetworkAddress(token_network_model.address),
+                ),
+                updating_participant=address1,
+                other_participant=address2,
+                updating_nonce=Nonce(1),
+                other_nonce=Nonce(1),
+                updating_capacity=deposit1,
+                other_capacity=deposit2,
+                reveal_timeout=2,
+                signature=EMPTY_SIGNATURE,
+            ),
+            updating_capacity_partner=TokenAmount(0),
+            other_capacity_partner=TokenAmount(0),
+        )
+        token_network_model.handle_channel_balance_update_message(
+            PFSCapacityUpdate(
+                canonical_identifier=CanonicalIdentifier(
+                    chain_identifier=ChainID(1),
+                    channel_identifier=channel_id,
+                    token_network_address=TokenNetworkAddress(token_network_model.address),
+                ),
+                updating_participant=address2,
+                other_participant=address1,
+                updating_nonce=Nonce(2),
+                other_nonce=Nonce(1),
+                updating_capacity=deposit2,
+                other_capacity=deposit1,
+                reveal_timeout=2,
+                signature=EMPTY_SIGNATURE,
+            ),
+            updating_capacity_partner=TokenAmount(deposit1),
+            other_capacity_partner=TokenAmount(deposit2),
+        )

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -3,7 +3,6 @@ import time
 from copy import deepcopy
 from typing import Dict, List
 
-import networkx
 import pytest
 from eth_utils import decode_hex, to_canonical_address, to_checksum_address
 
@@ -120,14 +119,14 @@ def test_routing_simple(
     }
 
     # Not connected.
-    with pytest.raises(NetworkXNoPath):
-        token_network_model.get_paths(
-            source=addresses[0],
-            target=addresses[5],
-            value=PaymentAmount(10),
-            max_paths=1,
-            address_to_reachability=address_to_reachability,
-        )
+    no_paths = token_network_model.get_paths(
+        source=addresses[0],
+        target=addresses[5],
+        value=PaymentAmount(10),
+        max_paths=1,
+        address_to_reachability=address_to_reachability,
+    )
+    assert [] == no_paths
 
 
 @pytest.mark.usefixtures("populate_token_network_case_1")
@@ -139,8 +138,8 @@ def test_capacity_check(
     """ Test that the mediation fees are included in the capacity check """
     # First get a path without mediation fees. This must return the shortest path: 4->1->0
     paths = token_network_model.get_paths(
-        addresses[4],
-        addresses[0],
+        source=addresses[4],
+        target=addresses[0],
         value=PaymentAmount(35),
         max_paths=1,
         address_to_reachability=address_to_reachability,
@@ -156,8 +155,8 @@ def test_capacity_check(
     # value of 35. But 35 + 1 exceeds the capacity for channel 4->1, which is
     # 35. So we should now get the next best route instead.
     paths = model_with_fees.get_paths(
-        addresses[4],
-        addresses[0],
+        source=addresses[4],
+        target=addresses[0],
         value=PaymentAmount(35),
         max_paths=1,
         address_to_reachability=address_to_reachability,
@@ -175,8 +174,8 @@ def test_routing_result_order(
 ):
     hex_addrs = [to_checksum_address(addr) for addr in addresses]
     paths = token_network_model.get_paths(
-        addresses[0],
-        addresses[2],
+        source=addresses[0],
+        target=addresses[2],
         value=PaymentAmount(10),
         max_paths=5,
         address_to_reachability=address_to_reachability,
@@ -342,7 +341,7 @@ def test_reachability_target(
     )
 
 
-@pytest.mark.skip('Just run it locally for now')
+@pytest.mark.skip("Just run it locally for now")
 @pytest.mark.usefixtures("populate_token_network_random")
 def test_routing_benchmark(token_network_model: TokenNetwork):  # pylint: disable=too-many-locals
     value = PaymentAmount(100)


### PR DESCRIPTION
It showed in #520 that in bigger token networks the search was blocking
the PFS for longer intervals. The main reason for that was that the path
finding was trying many routes where participants were offline.

This can easily be improved by pruning the graph on unreachable nodes
before the routing, so that the graph on which the search is done
consists only of reachable nodes.

This can be improved further in the future by also pruning channels with
to little capacity, etc.

Fixes #520