### PR TITLE
Remove unnecessary log in matrix

### DIFF
--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -269,9 +269,6 @@ class MatrixListener(gevent.Greenlet):
 
         for message in messages:
             assert message.sender, "Message has no sender"
-            log.debug(
-                "Message received", message=message, sender=to_checksum_address(message.sender)
-            )
             self.message_received_callback(message)
 
         return True


### PR DESCRIPTION
Incoming messages are already logged by the services, so we don't need
to do that at the matrix client level.