### PR TITLE
Split udc_margin_default for MS and PFS,

### DIFF
--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -21,7 +21,7 @@ from monitoring_service.states import (
 from raiden.utils.typing import BlockNumber, TokenNetworkAddress, TransactionHash
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelState
 from raiden_libs.blockchain import get_pessimistic_udc_balance
-from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR
+from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR_MS
 from raiden_libs.contract_info import CONTRACT_MANAGER
 from raiden_libs.events import (
     Event,
@@ -442,7 +442,7 @@ def action_monitoring_triggered_event_handler(event: Event, context: Context) ->
         )
         return
 
-    if user_deposit < monitor_request.reward_amount * UDC_SECURITY_MARGIN_FACTOR:
+    if user_deposit < monitor_request.reward_amount * UDC_SECURITY_MARGIN_FACTOR_MS:
         log.debug(
             "User deposit is insufficient -> try monitoring again later",
             monitor_request=monitor_request,

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -39,7 +39,7 @@ from raiden.exceptions import InvalidSignature
 from raiden.utils.signer import recover
 from raiden.utils.typing import Address, PaymentAmount, Signature, TokenAmount, TokenNetworkAddress
 from raiden_libs.blockchain import get_pessimistic_udc_balance
-from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR
+from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR_PFS
 from raiden_libs.marshmallow import ChecksumAddress, HexedBytes
 
 log = structlog.get_logger(__name__)
@@ -244,7 +244,7 @@ def process_payment(  # pylint: disable=too-many-branches
         from_block=latest_block - pathfinding_service.required_confirmations,
         to_block=latest_block,
     )
-    required_deposit = round(expected_amount * UDC_SECURITY_MARGIN_FACTOR)
+    required_deposit = round(expected_amount * UDC_SECURITY_MARGIN_FACTOR_PFS)
     if udc_balance < required_deposit:
         raise exceptions.DepositTooLow(required_deposit=required_deposit)
 

--- a/src/raiden_libs/constants.py
+++ b/src/raiden_libs/constants.py
@@ -1,3 +1,4 @@
 # Since the UDC deposits are not double spend safe, you want a higher deposit
 # than you're able to claim to reduce the possibility of double spends.
-UDC_SECURITY_MARGIN_FACTOR: float = 2
+UDC_SECURITY_MARGIN_FACTOR_MS: float = 1.1
+UDC_SECURITY_MARGIN_FACTOR_PFS: float = 2

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -34,7 +34,7 @@ from monitoring_service.states import OnChainUpdateStatus
 from raiden.utils.typing import Address, BlockNumber, ChannelID, Nonce, TokenAmount
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.tests.utils import get_random_privkey
-from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR
+from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR_MS
 from raiden_libs.events import (
     Event,
     ReceiveChannelClosedEvent,
@@ -514,7 +514,7 @@ def test_action_monitoring_rescheduling_when_user_lacks_funds(context: Context):
     # With sufficient funds it must succeed
     with patch(
         "monitoring_service.handlers.get_pessimistic_udc_balance",
-        Mock(return_value=reward_amount * UDC_SECURITY_MARGIN_FACTOR),
+        Mock(return_value=reward_amount * UDC_SECURITY_MARGIN_FACTOR_MS),
     ):
         action_monitoring_triggered_event_handler(event, context)
     assert context.monitoring_service_contract.functions.monitor.called

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -5,7 +5,7 @@ import pathfinding_service.exceptions as exceptions
 from pathfinding_service.api import process_payment
 from raiden.utils.typing import Address, TokenAmount
 from raiden_contracts.tests.utils import get_random_privkey
-from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR
+from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR_PFS
 
 
 def test_save_and_load_iou(pathfinding_service_mock, make_iou):
@@ -90,7 +90,7 @@ def test_process_payment(
     service_fee = TokenAmount(1)
     sender = create_account()
     privkey = get_private_key(sender)
-    deposit_to_udc(sender, round(1 * UDC_SECURITY_MARGIN_FACTOR))
+    deposit_to_udc(sender, round(1 * UDC_SECURITY_MARGIN_FACTOR_PFS))
     web3.testing.mine(pathfinding_service_web3_mock.required_confirmations)
     one_to_n_address = to_canonical_address(one_to_n_contract.address)
 
@@ -104,13 +104,13 @@ def test_process_payment(
 
     # Increasing the amount would make the payment work again, if we had enough
     # deposit. But we set the deposit one token too low.
-    deposit_to_udc(sender, round(2 * UDC_SECURITY_MARGIN_FACTOR) - 1)
+    deposit_to_udc(sender, round(2 * UDC_SECURITY_MARGIN_FACTOR_PFS) - 1)
     iou = make_iou(privkey, pfs.address, amount=2)
     with pytest.raises(exceptions.DepositTooLow):
         process_payment(iou, pfs, service_fee, one_to_n_address)
 
     # With the higher amount and enough deposit, it works again!
-    deposit_to_udc(sender, round(2 * UDC_SECURITY_MARGIN_FACTOR))
+    deposit_to_udc(sender, round(2 * UDC_SECURITY_MARGIN_FACTOR_PFS))
     web3.testing.mine(pathfinding_service_web3_mock.required_confirmations)
     iou = make_iou(privkey, pfs.address, amount=2)
     process_payment(iou, pfs, service_fee, one_to_n_address)


### PR DESCRIPTION
2 was too high for pfs and we have pessimistic assertion function
2 seems good for the pfs risk margin
fixes https://github.com/raiden-network/raiden/issues/4825