### PR TITLE
Iteration in fee approximation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@89b00a64878f536a2f2236eea6222378004fa14a
+git+https://github.com/raiden-network/raiden.git@90f9b42ce467a4e8a32680212a5398d797129737
 raiden-contracts==0.32.0
 
 structlog==19.1.0


### PR DESCRIPTION
Use `fee_receiver` and `fee_sender` from raiden to get the latest fee calculation. Those are currently in a test utils package and should be moved in a following PR.

Closes https://github.com/raiden-network/raiden-services/issues/563.