### PR TITLE
Simplify builder

### DIFF
--- a/deployment/builder/app/main.py
+++ b/deployment/builder/app/main.py
@@ -2,56 +2,19 @@ import json
 import os
 import subprocess
 import sys
-from pprint import pprint
-from typing import List
 
 import requests
 from flask import Flask, request
 
-ALL_SERVICE_NAMES = [
-    "pfs-ropsten",
-    "pfs-rinkeby",
-    "pfs-kovan",
-    "pfs-goerli",
-    "pfs-ropsten-with-fee",
-    "pfs-rinkeby-with-fee",
-    "pfs-kovan-with-fee",
-    "pfs-goerli-with-fee",
-    "ms-ropsten",
-    "ms-rinkeby",
-    "ms-kovan",
-    "ms-goerli",
-    "ms-goerli-backup",
-    "msrc-ropsten",
-    "msrc-rinkeby",
-    "msrc-kovan",
-    "msrc-goerli",
-    "msrc-goerli-backup",
-    "builder",
-]
-
-REPOS = {
-    "latest": {
-        "master": {
-            "source": "/root/raiden-services",
-            "deployment": "/root/raiden-services/deployment",
-        }
-    }
-}
-
 app = Flask(__name__)
 
 
-class ImageUpdateError(Exception):
-    """Couldn't build/update our images."""
-
-
-def print_to_stderr(s):
+def print_to_stderr(s: str) -> None:
     print(s, file=sys.stderr)
 
 
 @app.route("/", methods=["get", "post"])
-def main():
+def main() -> str:
     data = request.json or {}
     print_to_stderr("Received request at '/'. Ignoring!")
     print_to_stderr(json.dumps(data))
@@ -61,77 +24,22 @@ def main():
 
 # See https://docs.docker.com/docker-hub/webhooks/
 @app.route("/dockerhub", methods=["get", "post"])
-def dockerhub():
-    data = request.json or {}
+def dockerhub() -> str:
     print_to_stderr("Received request at '/dockerhub'.")
+    data = request.json
     print_to_stderr(json.dumps(data))
+    callback_url = data["callback_url"]
+    state = "error"
 
-    callback_url = data.get("callback_url")
-    push_data = data.get("push_data", {})
-    tag = push_data.get("tag")
-
-    deploy_config = REPOS.get(tag)
-
-    if deploy_config:
-        try:
-            update(ALL_SERVICE_NAMES, **deploy_config["master"])
-
-            if callback_url:
-                requests.post(url=callback_url, json={"state": "success"})
-
-        except ImageUpdateError:
-            print_to_stderr("Error updating local images via docker registry!")
-            if callback_url:
-                requests.post(url=callback_url, json={"state": "error"})
-        except Exception as e:
-            print_to_stderr(
-                f"Fatal Error while updating images: Unhandled exception encountered: {e}"
-            )
-            if callback_url:
-                requests.post(url=callback_url, json={"state": "error"})
+    try:
+        tag = data["push_data"]["tag"]
+        os.chdir("/deployment")
+        subprocess.check_output(["./update.sh", tag])
+        state = "success"
+    except subprocess.CalledProcessError as ex:
+        print_to_stderr(ex.output)
+        raise
+    finally:
+        requests.post(url=callback_url, json={"state": state})
 
     return "OK"
-
-
-def update(container_names: List[str], source: str, deployment: str) -> None:
-    print_to_stderr(f"Changing working directory to {source}")
-    try:
-        os.chdir(source)
-    except FileNotFoundError as e:
-        print_to_stderr(f"Could not change to directory {source} - Not found!")
-        raise ImageUpdateError from e
-
-    print_to_stderr("Fetching latest changes: git fetch")
-    try:
-        subprocess.check_output(["git", "fetch", "--all"])
-    except subprocess.SubprocessError as e:
-        print_to_stderr(f"Fetching latest changes failed: {e}")
-        raise ImageUpdateError from e
-
-    print_to_stderr("Resetting branch: git reset")
-    try:
-        subprocess.check_output(["git", "reset", "--hard", "origin/master"])
-    except subprocess.SubprocessError as e:
-        print_to_stderr(f"Resetting branch failed: {e}")
-        raise ImageUpdateError from e
-
-    print_to_stderr(f"Changing working directory to {deployment}")
-    try:
-        os.chdir(deployment)
-    except FileNotFoundError as e:
-        print_to_stderr(f"Could not change to directory {deployment} - Not found!")
-        raise ImageUpdateError from e
-
-    print_to_stderr("Pulling containers containers: docker pull")
-    try:
-        subprocess.run(["docker-compose", "pull"], check=True)
-    except subprocess.SubprocessError as e:
-        print_to_stderr(f"Pulling new images from docker registry failed: {e}")
-        raise ImageUpdateError from e
-
-    print_to_stderr(f"Restarting containers: docker restart: {container_names}")
-    try:
-        subprocess.run(["docker-compose", "restart"] + container_names, check=True)
-    except subprocess.SubprocessError as e:
-        print_to_stderr(f"Restarting containers {container_names} failed: {e}")
-        raise ImageUpdateError from e

--- a/deployment/docker-compose.latest.yml
+++ b/deployment/docker-compose.latest.yml
@@ -85,5 +85,7 @@ services:
     <<: *defaults
 
   builder:
+    environment:
+      - HOSTNAME=services-dev
     labels:
       - "traefik.frontend.rule=Host: services-dev.raiden.network"

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -201,8 +201,9 @@ services:
     build: ./builder
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /root:/root
-      - /root/.ssh:/root/.ssh:ro
+      - /root/raiden-services/deployment/:/deployment
+    environment:
+      - HOSTNAME=services-stable
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host: services-test.raiden.network"

--- a/deployment/update.sh
+++ b/deployment/update.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
+# Called manually to update all services
+# Called from builder as `update.sh UPDATED_TAG` to update only when the relevant tag is passed
+# Builder and traefik are not restarted to allow the builder to properly finish the update and respond
 set -e
-case `hostname` in
+case $HOSTNAME in
 	services-stable)
 		COMPOSE_FILE="docker-compose.yml"
-		docker pull raidennetwork/raiden-services:stable
+                TAG=stable
 		;;
 	services-dev)
 		COMPOSE_FILE="docker-compose.yml -f docker-compose.latest.yml"
-		docker pull raidennetwork/raiden-services:latest
+                TAG=latest
 		;;
 esac
-[ -z $COMPOSE_FILE ] && { echo "Running on unknown host"; exit 1; }
-docker-compose down
-docker-compose -f $COMPOSE_FILE up -d
+[ -n "$COMPOSE_FILE" ] || { echo "Running on unknown host"; exit 1; }
+
+UPDATED_TAG=$1
+[ -n "$UPDATED_TAG" ] || UPDATED_TAG=$TAG
+[ $UPDATED_TAG = $TAG ] || { echo "Only listening on tag $TAG"; exit 0; }
+
+docker-compose -f $COMPOSE_FILE pull
+SERVICES=`docker-compose config --services | grep -v traefik | grep -v builder | xargs`  # exclude builder and traefik from restart
+docker-compose -f $COMPOSE_FILE up --no-deps -d $SERVICES


### PR DESCRIPTION
The builder will now only care about the services, not about updating
itself, the docker-compose-files or traefik. These changes are rare and
can be done manually.

The builder (or the `update.sh` to be more precise) is also now able to
understand the difference between the `dev` and `test` deployments.

Closes https://github.com/raiden-network/raiden-services/issues/80.