### PR TITLE
Wait for matrix to completetely start

### DIFF
--- a/src/pathfinding_service/constants.py
+++ b/src/pathfinding_service/constants.py
@@ -18,6 +18,8 @@ DEFAULT_SETTLE_TO_REVEAL_TIMEOUT_RATIO = 2
 DEFAULT_POLL_INTERVALL = 2
 DEFAULT_INFO_MESSAGE = "This is your favorite pfs for token network registry "
 
+MATRIX_START_TIMEOUT = 10
+
 # When a new IOU session is started, this is the minimum number of blocks
 # between the current block and `expiration_block`.
 MIN_IOU_EXPIRY: int = 7 * 24 * 60 * 4


### PR DESCRIPTION
Until now we only started matrix but didn't wait for completions of the
initialization.
This could lead to problems when a blockchain event was processed before
the sync token was set.