### PR TITLE
Upgrade raiden version to the current develop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@f155d030aca6d6ffc5cb6025718374a90d96a9c1
+git+https://github.com/raiden-network/raiden.git@c15867186e93c00490cb9407c120208e137a4b9e
 raiden-contracts==0.33.1
 
 structlog==19.1.0


### PR DESCRIPTION
After doing this, it's easier to integrate the new `raiden-contracts`. `raiden-contracts` first gets integrated to raiden:develop.