### PR TITLE
Force adding the user to the known list

### DIFF
--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -208,7 +208,7 @@ class MatrixListener(gevent.Greenlet):
             self.user_manager.add_address(address)
 
             if refresh:
-                self.user_manager.populate_userids_for_address(address)
+                self.user_manager.populate_userids_for_address(address, force=True)
                 self.user_manager.refresh_address_presence(address)
 
             log.debug(


### PR DESCRIPTION
When a channel is created, the PFS service calls `follow_address_presence` with `refresh=True` to:
1. populate the user ID
2. refresh presence

However, populating the user ID would check if that address is known before the transport servers are queried for the user ID. On restart, that list of known addresses is empty so the check would fail and we would end up not registering the user ID. Therefore, this change forces the addition even though the address is unknown to the PFS when the channel is opened.