### PR TITLE
Update raiden and related deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/palango/raiden.git@fix0fee-update-datetime-type
+git+https://github.com/raiden-network/raiden.git@e7b75bc95e6c3d3b25e455bb4a84f6babff3fa8d
 raiden-contracts==0.33.3
 
 structlog==19.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@1cf335529e1b1edf790fe4e88bffad0460bcc56b
+git+https://github.com/palango/raiden.git@fix0fee-update-datetime-type
 raiden-contracts==0.33.3
 
 structlog==19.1.0
@@ -19,7 +19,7 @@ gevent==1.3.7
 networkx==2.3
 requests==2.22.0
 
-marshmallow==3.0.0rc8
-marshmallow-dataclass==6.0.0rc4
+marshmallow==3.2.2
+marshmallow-dataclass==6.0.0
 
 sentry-sdk[flask]==0.13.1

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -268,7 +268,7 @@ class IOURequest:
 
     sender: Address = field(metadata={"marshmallow_field": ChecksumAddress(required=True)})
     receiver: Address = field(metadata={"marshmallow_field": ChecksumAddress(required=True)})
-    timestamp: datetime
+    timestamp: datetime = field(metadata={"marshmallow_field": fields.NaiveDateTime()})
     timestamp_str: str = field(metadata=dict(data_key="timestamp", load_only=True))
     signature: Signature = field(metadata={"marshmallow_field": HexedBytes()})
     Schema: ClassVar[Type[marshmallow.Schema]]

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -88,7 +88,7 @@ class PathfinderResource(Resource):
         try:
             return req_class.Schema().load(json)  # type: ignore
         except marshmallow.ValidationError as ex:
-            raise exceptions.InvalidRequest(**ex.messages)
+            raise exceptions.InvalidRequest(**ex.normalized_messages())
 
 
 @add_schema
@@ -289,7 +289,7 @@ class IOUResource(PathfinderResource):
         try:
             iou_request = IOURequest.Schema().load(request.args)
         except marshmallow.ValidationError as ex:
-            raise exceptions.InvalidRequest(**ex.messages)
+            raise exceptions.InvalidRequest(**ex.normalized_messages())
         if not iou_request.is_signature_valid():
             raise exceptions.InvalidSignature
         if iou_request.timestamp < datetime.utcnow() - MAX_AGE_OF_IOU_REQUESTS:

--- a/src/pathfinding_service/model/channel.py
+++ b/src/pathfinding_service/model/channel.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import ClassVar, Tuple, Type
 
 import marshmallow
@@ -15,7 +15,7 @@ from raiden_libs.marshmallow import ChecksumAddress
 
 @dataclass
 class FeeSchedule(FeeScheduleRaiden):
-    timestamp: datetime = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    timestamp: datetime = datetime(2000, 1, 1)
 
     @classmethod
     def from_raiden(cls, fee_schedule: FeeScheduleRaiden, timestamp: datetime) -> "FeeSchedule":

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from copy import copy
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from itertools import islice
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -295,7 +295,7 @@ class TokenNetwork:
         return channel_view_to_partner.channel
 
     def handle_channel_fee_update(self, message: PFSFeeUpdate) -> Channel:
-        if message.timestamp > datetime.now(timezone.utc) + timedelta(hours=1):
+        if message.timestamp > datetime.utcnow() + timedelta(hours=1):
             # We don't really care about the time, but if we accept a time far
             # in the future, the client will have problems sending fee updates
             # with increasing time after fixing his clock.

--- a/tests/pathfinding/test_database.py
+++ b/tests/pathfinding/test_database.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List
 from uuid import uuid4
 
@@ -159,7 +159,7 @@ def test_waiting_messages(pathfinding_service_mock):
         ),
         updating_participant=participant1,
         fee_schedule=FeeScheduleState(),
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow(),
         signature=EMPTY_SIGNATURE,
     )
     fee_update.sign(LocalSigner(participant1_privkey))

--- a/tests/pathfinding/test_fee_schedule.py
+++ b/tests/pathfinding/test_fee_schedule.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, List
 
 import pytest
@@ -75,7 +75,7 @@ class TokenNetworkForTests(TokenNetwork):
                 updating_participant=a(node1),
                 fee_schedule=RaidenFeeSchedule(**fee_params),
                 signature=EMPTY_SIGNATURE,
-                timestamp=datetime.now(timezone.utc),
+                timestamp=datetime.utcnow(),
             )
         )
 

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List
 from unittest.mock import Mock, call, patch
 
@@ -277,7 +277,7 @@ def test_update_fee(order, pathfinding_service_mock, token_network_model):
         ),
         updating_participant=PARTICIPANT1,
         fee_schedule=fee_schedule,
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow(),
         signature=EMPTY_SIGNATURE,
     )
     fee_update.sign(LocalSigner(PARTICIPANT1_PRIVKEY))
@@ -302,7 +302,7 @@ def test_invalid_fee_update(pathfinding_service_mock, token_network_model):
         ),
         updating_participant=PARTICIPANT1,
         fee_schedule=FeeScheduleState(),
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow(),
         signature=EMPTY_SIGNATURE,
     )
 
@@ -356,7 +356,7 @@ def test_logging_processor():
         ),
         updating_participant=PARTICIPANT1,
         fee_schedule=FeeScheduleState(),
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.utcnow(),
         signature=EMPTY_SIGNATURE,
     )
     message_log = format_to_hex(


### PR DESCRIPTION
Fixes #619 

Relies on https://github.com/raiden-network/raiden/pull/5250

This makes the PFS expect non-timezones datetimes everywhere and adds validation for this.

This also updates raiden, updates marshmallow[-dataclass] and adapts some matrix code.