### PR TITLE
Log to fluentd

### DIFF
--- a/deployment/.env.template
+++ b/deployment/.env.template
@@ -1,5 +1,11 @@
 # Make a copy called `.env` and replace all <PLACEHOLDERS>.
 
+# Use this to supply two compose files and override some options with the
+# settings from another compose file. Candidates are:
+# * docker-compose.latest.yml for using the latest dev version
+# * docker-compose.local.yml to run single services on a dev machine
+#COMPOSE_FILE=docker-compose.yml:docker-compose.latest.yml
+
 # Used as part of the hostnames: <service>.services-<DEPLOY_ENV>.raiden.network
 DEPLOY_ENV=dev
 # Prefix used for container names (default: current directory name)

--- a/deployment/.env.template
+++ b/deployment/.env.template
@@ -1,5 +1,8 @@
 # Make a copy called `.env` and replace all <PLACEHOLDERS>.
 
+# Used as part of the hostnames: <service>.services-<DEPLOY_ENV>.raiden.network
+DEPLOY_ENV=dev
+
 PFS_HOST=0.0.0.0
 PFS_KEYSTORE_FILE=/keystore/<FILENAME>
 PFS_PASSWORD=<PASSWORD>

--- a/deployment/.env.template
+++ b/deployment/.env.template
@@ -2,6 +2,8 @@
 
 # Used as part of the hostnames: <service>.services-<DEPLOY_ENV>.raiden.network
 DEPLOY_ENV=dev
+# Prefix used for container names (default: current directory name)
+COMPOSE_PROJECT_NAME=dev
 
 PFS_HOST=0.0.0.0
 PFS_KEYSTORE_FILE=/keystore/<FILENAME>

--- a/deployment/docker-compose.latest.yml
+++ b/deployment/docker-compose.latest.yml
@@ -47,6 +47,9 @@ services:
   ms-goerli:
     <<: *defaults
 
+  ms-goerli-backup:
+    <<: *defaults
+
   msrc-ropsten:
     << : *defaults
 
@@ -54,6 +57,9 @@ services:
     << : *defaults
 
   msrc-goerli:
+    <<: *defaults
+
+  msrc-goerli-backup:
     <<: *defaults
 
   registration-goerli:

--- a/deployment/docker-compose.latest.yml
+++ b/deployment/docker-compose.latest.yml
@@ -22,33 +22,21 @@ x-defaults: &defaults
 services:
   pfs-ropsten:
     << : *defaults
-    labels:
-      - "traefik.frontend.rule=Host: pfs-ropsten.services-dev.raiden.network"
 
   pfs-rinkeby:
     << : *defaults
-    labels:
-      - "traefik.frontend.rule=Host: pfs-rinkeby.services-dev.raiden.network"
 
   pfs-goerli:
     <<: *defaults
-    labels:
-      - "traefik.frontend.rule=Host: pfs-goerli.services-dev.raiden.network"
 
   pfs-ropsten-with-fee:
     << : *defaults
-    labels:
-      - "traefik.frontend.rule=Host: pfs-ropsten-with-fee.services-dev.raiden.network"
 
   pfs-rinkeby-with-fee:
     << : *defaults
-    labels:
-      - "traefik.frontend.rule=Host: pfs-rinkeby-with-fee.services-dev.raiden.network"
 
   pfs-goerli-with-fee:
     <<: *defaults
-    labels:
-      - "traefik.frontend.rule=Host: pfs-goerli-with-fee.services-dev.raiden.network"
 
   ms-ropsten:
     << : *defaults
@@ -70,11 +58,7 @@ services:
 
   registration-goerli:
     <<: *defaults
-    environment:
-      - RDN_REGISTRY_SERVICE_URL=https://pfs-goerli-with-fee.services-dev.raiden.network
 
   builder:
     environment:
       - HOSTNAME=services-dev
-    labels:
-      - "traefik.frontend.rule=Host: services-dev.raiden.network"

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -26,7 +26,10 @@ x-defaults: &defaults
     - /data/state:/state
     - /data/keystore:/keystore
   logging:
-    driver: journald
+    driver: "fluentd"
+    options:
+      fluentd-address: logs.raiden.network:24224
+      tag: raiden.{{.Name}}
 
 services:
   pfs-ropsten:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -34,7 +34,7 @@ x-defaults: &defaults
 services:
   pfs-ropsten:
     << : *defaults
-    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug"]
+    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug", "--log-json"]
     environment:
       - PFS_ETH_RPC=http://geth.ropsten.ethnodes.brainbot.com:8545
       - PFS_STATE_DB=/state/pfs-ropsten.db
@@ -44,7 +44,7 @@ services:
 
   pfs-ropsten-with-fee:
     << : *defaults
-    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug"]
+    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug", "--log-json"]
     environment:
       - PFS_ETH_RPC=http://geth.ropsten.ethnodes.brainbot.com:8545
       - PFS_STATE_DB=/state/pfs-ropsten-with-fee.db
@@ -57,7 +57,7 @@ services:
 
   pfs-rinkeby:
     << : *defaults
-    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug"]
+    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug", "--log-json"]
     environment:
       - PFS_ETH_RPC=http://geth.rinkeby.ethnodes.brainbot.com:8545
       - PFS_STATE_DB=/state/pfs-rinkeby.db
@@ -69,7 +69,7 @@ services:
 
   pfs-rinkeby-with-fee:
     << : *defaults
-    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug"]
+    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug", "--log-json"]
     environment:
       - PFS_ETH_RPC=http://geth.rinkeby.ethnodes.brainbot.com:8545
       - PFS_STATE_DB=/state/pfs-rinkeby-with-fee.db
@@ -82,7 +82,7 @@ services:
 
   pfs-goerli:
     <<: *defaults
-    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug"]
+    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug", "--log-json"]
     environment:
       - PFS_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
       - PFS_STATE_DB=/state/pfs-goerli.db
@@ -94,7 +94,7 @@ services:
 
   pfs-goerli-with-fee:
     <<: *defaults
-    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug"]
+    command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug", "--log-json"]
     environment:
       - PFS_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
       - PFS_STATE_DB=/state/pfs-goerli-with-fee.db
@@ -107,28 +107,28 @@ services:
 
   ms-ropsten:
     <<: *defaults
-    command: ["python3", "-m", "monitoring_service.cli"]
+    command: ["python3", "-m", "monitoring_service.cli", "--log-json"]
     environment:
       - MS_ETH_RPC=http://geth.ropsten.ethnodes.brainbot.com:8545
       - MS_STATE_DB=/state/ms-ropsten.db
 
   ms-rinkeby:
     <<: *defaults
-    command: ["python3", "-m", "monitoring_service.cli"]
+    command: ["python3", "-m", "monitoring_service.cli", "--log-json"]
     environment:
       - MS_ETH_RPC=http://geth.rinkeby.ethnodes.brainbot.com:8545
       - MS_STATE_DB=/state/ms-rinkeby.db
 
   ms-goerli:
     <<: *defaults
-    command: ["python3", "-m", "monitoring_service.cli"]
+    command: ["python3", "-m", "monitoring_service.cli", "--log-json"]
     environment:
       - MS_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
       - MS_STATE_DB=/state/ms-goerli.db
 
   ms-goerli-backup:
     <<: *defaults
-    command: ["python3", "-m", "monitoring_service.cli"]
+    command: ["python3", "-m", "monitoring_service.cli", "--log-json"]
     environment:
       - MS_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
       - MS_STATE_DB=/state/ms-goerli-backup.db
@@ -137,7 +137,7 @@ services:
 
   msrc-ropsten:
     <<: *defaults
-    command: ["python3", "-m", "request_collector.cli"]
+    command: ["python3", "-m", "request_collector.cli", "--log-json"]
     environment:
       - MSRC_CHAIN_ID=ropsten
       - MSRC_STATE_DB=/state/ms-ropsten.db
@@ -146,7 +146,7 @@ services:
 
   msrc-rinkeby:
     <<: *defaults
-    command: ["python3", "-m", "request_collector.cli"]
+    command: ["python3", "-m", "request_collector.cli", "--log-json"]
     environment:
       - MSRC_CHAIN_ID=rinkeby
       - MSRC_STATE_DB=/state/ms-rinkeby.db
@@ -155,7 +155,7 @@ services:
 
   msrc-goerli:
     <<: *defaults
-    command: ["python3", "-m", "request_collector.cli"]
+    command: ["python3", "-m", "request_collector.cli", "--log-json"]
     environment:
       - MSRC_CHAIN_ID=goerli
       - MSRC_STATE_DB=/state/ms-goerli.db
@@ -164,7 +164,7 @@ services:
 
   msrc-goerli-backup:
     <<: *defaults
-    command: ["python3", "-m", "request_collector.cli"]
+    command: ["python3", "-m", "request_collector.cli", "--log-json"]
     environment:
       - MSRC_CHAIN_ID=goerli
       - MSRC_STATE_DB=/state/ms-goerli-backup.db

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -31,14 +31,13 @@ x-defaults: &defaults
 services:
   pfs-ropsten:
     << : *defaults
-    build: ../
     command: ["python3", "-m", "pathfinding_service.cli", "--enable-debug"]
     environment:
       - PFS_ETH_RPC=http://geth.ropsten.ethnodes.brainbot.com:8545
       - PFS_STATE_DB=/state/pfs-ropsten.db
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-ropsten.services-test.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-ropsten.services-${DEPLOY_ENV}.raiden.network"
 
   pfs-ropsten-with-fee:
     << : *defaults
@@ -49,7 +48,7 @@ services:
       - PFS_SERVICE_FEE=100
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-ropsten-with-fee.services-test.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-ropsten-with-fee.services-${DEPLOY_ENV}.raiden.network"
     depends_on:
       - pfs-ropsten
 
@@ -61,7 +60,7 @@ services:
       - PFS_STATE_DB=/state/pfs-rinkeby.db
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-rinkeby.services-test.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-rinkeby.services-${DEPLOY_ENV}.raiden.network"
     depends_on:
       - pfs-ropsten-with-fee
 
@@ -74,7 +73,7 @@ services:
       - PFS_SERVICE_FEE=100
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-rinkeby-with-fee.services-test.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-rinkeby-with-fee.services-${DEPLOY_ENV}.raiden.network"
     depends_on:
       - pfs-rinkeby
 
@@ -86,7 +85,7 @@ services:
       - PFS_STATE_DB=/state/pfs-goerli.db
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-goerli.services-test.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-goerli.services-${DEPLOY_ENV}.raiden.network"
     depends_on:
       - pfs-rinkeby-with-fee
 
@@ -99,7 +98,7 @@ services:
       - PFS_SERVICE_FEE=100
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: pfs-goerli-with-fee.services-test.raiden.network"
+      - "traefik.frontend.rule=Host: pfs-goerli-with-fee.services-${DEPLOY_ENV}.raiden.network"
     depends_on:
       - pfs-goerli
 
@@ -181,7 +180,7 @@ services:
       - HOSTNAME=services-stable
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host: services-test.raiden.network"
+      - "traefik.frontend.rule=Host: services-${DEPLOY_ENV}.raiden.network"
 
   traefik:
     image: traefik:1.7
@@ -219,7 +218,7 @@ services:
       - RDN_REGISTRY_LOG_LEVEL=DEBUG
       - RDN_REGISTRY_KEYSTORE_FILE=${MS_KEYSTORE_FILE}
       - RDN_REGISTRY_PASSWORD=${MS_PASSWORD}
-      - RDN_REGISTRY_SERVICE_URL=https://pfs-goerli-with-fee.services-test.raiden.network
+      - RDN_REGISTRY_SERVICE_URL=https://pfs-goerli-with-fee.services-${DEPLOY_ENV}.raiden.network
       - RDN_REGISTRY_ETH_RPC=http://parity.goerli.ethnodes.brainbot.com:8545
     depends_on:
       - traefik


### PR DESCRIPTION
I deviated from the planned tag scheme to keep the configuration simple and the naming consistent. Now the container name will be used as part of the tag, resulting in tags like `raiden.dev_pfs-rinkeby-with-fee_1`.

Results are visible on [Kibana](http://logs.raiden.network/app/kibana#/discover/18d7f580-06f2-11ea-98a2-67045732bdf3?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-5m%2Cto%3Anow))).

Closes https://github.com/raiden-network/raiden-services/issues/602