### PR TITLE
Add profiling options to services and tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,27 @@ import gevent
 import pytest
 
 from raiden_contracts.tests.fixtures import *  # noqa
+from raiden_libs.cli import start_profiler
 
 from .libs.fixtures import *  # noqa
+
+
+def pytest_addoption(parser):
+    # Using this will create a stack profile for all selected tests. If you
+    # want to profile only a single test, use pytest to limit the test
+    # selection.
+    # Use https://github.com/brendangregg/FlameGraph to view the results.
+    parser.addoption("--flamegraph", default=None, help="Dir in which to save stack profile.")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def flamegraph_profiler(request):
+    profiler = start_profiler(request.config.option.flamegraph)
+
+    yield
+
+    if profiler is not None:
+        profiler.stop()
 
 
 def _get_running_greenlets():


### PR DESCRIPTION
This will create stack profiling data for use with https://github.com/brendangregg/FlameGraph.

Will only work reliably after https://github.com/raiden-network/raiden-services/pull/652 is merged.

Closes https://github.com/raiden-network/raiden-services/issues/643