### PR TITLE
Revert join all rooms

### DIFF
--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -142,7 +142,7 @@ def test_matrix_lister_smoke_test(get_accounts, get_private_key):
     client_mock.api.base_url = url
     client_mock.user_id = "1"
     with patch.multiple(
-        "raiden_libs.matrix", make_client=Mock(return_value=client_mock), join_global_room=Mock()
+        "raiden_libs.matrix", make_client=Mock(return_value=client_mock),
     ):
         listener = MatrixListener(
             private_key=get_private_key(c1),

--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -141,7 +141,9 @@ def test_matrix_lister_smoke_test(get_accounts, get_private_key):
     client_mock = Mock()
     client_mock.api.base_url = url
     client_mock.user_id = "1"
-    with patch.multiple("raiden_libs.matrix", make_client=Mock(return_value=client_mock)):
+    with patch.multiple(
+        "raiden_libs.matrix", make_client=Mock(return_value=client_mock), join_global_room=Mock()
+    ):
         listener = MatrixListener(
             private_key=get_private_key(c1),
             chain_id=ChainID(1),


### PR DESCRIPTION
Fixes #634, https://github.com/raiden-network/raiden-services/issues/630

This reverts https://github.com/raiden-network/raiden-services/pull/609 as we now have one alias for the same broadcast room on all servers.