### PR TITLE
Cleaup synced

### DIFF
--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -179,7 +179,6 @@ class MatrixListener(gevent.Greenlet):
 
         self._client.start_listener_thread()
         assert self._client.sync_thread
-        self._client.synced.wait()
 
         # Signal that startup has finished
         self.startup_finished.set()


### PR DESCRIPTION
Seems like a leftover. I saw the following exception:
```
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/rakan/Brainbot/raiden-services/src/raiden_libs/matrix.py", line 182, in _run
    self._client.synced.wait()
AttributeError: 'GMatrixClient' object has no attribute 'synced'
2019-12-04T14:13:58Z <MatrixListener "Greenlet-0" at 0x7f787e840598: _run> failed with AttributeEr
```