### PR TITLE
Add UDC info to /info endpoint

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -390,6 +390,9 @@ class InfoResource(PathfinderResource):
             "network_info": {
                 "chain_id": self.pathfinding_service.chain_id,
                 "registry_address": to_checksum_address(self.pathfinding_service.registry_address),
+                "user_deposit_address": to_checksum_address(
+                    self.pathfinding_service.user_deposit_contract.address
+                ),
             },
             "version": self.version,
             "contracts_version": self.contracts_version,

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -389,7 +389,9 @@ class InfoResource(PathfinderResource):
             "price_info": self.service_api.service_fee,
             "network_info": {
                 "chain_id": self.pathfinding_service.chain_id,
-                "registry_address": to_checksum_address(self.pathfinding_service.registry_address),
+                "token_network_registry_address": to_checksum_address(
+                    self.pathfinding_service.registry_address
+                ),
                 "user_deposit_address": to_checksum_address(
                     self.pathfinding_service.user_deposit_contract.address
                 ),

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -402,7 +402,7 @@ def test_get_info(api_url: str, api_sut, pathfinding_service_mock):
         "price_info": 123,
         "network_info": {
             "chain_id": pathfinding_service_mock.chain_id,
-            "registry_address": token_network_registry_address,
+            "token_network_registry_address": token_network_registry_address,
             "user_deposit_address": user_deposit_address,
         },
         "version": pkg_resources.require("raiden-services")[0].version,

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -393,19 +393,23 @@ def test_get_info(api_url: str, api_sut, pathfinding_service_mock):
     api_sut.info_message = "This is your favorite pfs for token network registry "
     url = api_url + "/info"
 
-    token_network_registry = to_checksum_address(pathfinding_service_mock.registry_address)
+    token_network_registry_address = to_checksum_address(pathfinding_service_mock.registry_address)
+    user_deposit_address = to_checksum_address(
+        pathfinding_service_mock.user_deposit_contract.address
+    )
 
     expected_response = {
         "price_info": 123,
         "network_info": {
             "chain_id": pathfinding_service_mock.chain_id,
-            "registry_address": token_network_registry,
+            "registry_address": token_network_registry_address,
+            "user_deposit_address": user_deposit_address,
         },
         "version": pkg_resources.require("raiden-services")[0].version,
         "contracts_version": pkg_resources.require("raiden-contracts")[0].version,
         "operator": "John Doe",
         "message": "This is your favorite pfs for token network registry "
-        + token_network_registry,
+        + token_network_registry_address,
         "payment_address": to_checksum_address(pathfinding_service_mock.address),
     }
     response = requests.get(url)


### PR DESCRIPTION
Fixes #688 

I also think we should rename `registry_address` to `token_network_registry_address`. Opinions on that?

@andrevmatos @kelsos @nephix This changes the info endpoint of the API.