### PR TITLE
Optimize channel deletion

### DIFF
--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -187,22 +187,6 @@ class PFSDatabase(BaseDatabase):
             channel_dict["fee_schedule2"] = json.loads(channel_dict["fee_schedule2"])
             yield Channel.Schema().load(channel_dict)
 
-    def get_channel(
-        self, token_network_address: TokenNetworkAddress, channel_id: ChannelID
-    ) -> Optional[Channel]:
-        row = self.conn.execute(
-            "SELECT * FROM channel where token_network_address = ? and channel_id = ?",
-            [to_checksum_address(token_network_address), hex256(channel_id)],
-        ).fetchone()
-
-        if row:
-            channel_dict = dict(zip(row.keys(), row))
-            channel_dict["fee_schedule1"] = json.loads(channel_dict["fee_schedule1"])
-            channel_dict["fee_schedule2"] = json.loads(channel_dict["fee_schedule2"])
-            return Channel.Schema().load(channel_dict)
-
-        return None
-
     def delete_channel(
         self, token_network_address: TokenNetworkAddress, channel_id: ChannelID
     ) -> None:
@@ -210,7 +194,7 @@ class PFSDatabase(BaseDatabase):
             "DELETE FROM channel WHERE token_network_address = ? AND channel_id = ?",
             [to_checksum_address(token_network_address), hex256(channel_id)],
         )
-        assert cursor.rowcount == 1, "Did not delete exactly one channel"
+        assert cursor.rowcount <= 1, "Did delete more than one channel"
 
     def get_token_networks(self) -> Iterator[TokenNetwork]:
         for row in self.conn.execute("SELECT address FROM token_network"):

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -189,12 +189,22 @@ class PFSDatabase(BaseDatabase):
 
     def delete_channel(
         self, token_network_address: TokenNetworkAddress, channel_id: ChannelID
-    ) -> None:
+    ) -> bool:
+        """ Tries to delete a channel from the database
+
+        Args:
+            token_network_address: The address of the token network of the channel
+            channel_id: The id of the channel
+
+        Returns: `True` if the channel was deleted, `False` if it did not exist
+        """
         cursor = self.conn.execute(
             "DELETE FROM channel WHERE token_network_address = ? AND channel_id = ?",
             [to_checksum_address(token_network_address), hex256(channel_id)],
         )
         assert cursor.rowcount <= 1, "Did delete more than one channel"
+
+        return cursor.rowcount == 1
 
     def get_token_networks(self) -> Iterator[TokenNetwork]:
         for row in self.conn.execute("SELECT address FROM token_network"):

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -267,17 +267,11 @@ class TokenNetwork:
 
         Corresponds to the ChannelClosed event."""
 
-        try:
-            # we need to unregister the channel_id here
-            participant1, participant2 = self.channel_id_to_addresses.pop(channel_identifier)
+        # we need to unregister the channel_id here
+        participant1, participant2 = self.channel_id_to_addresses.pop(channel_identifier)
 
-            self.G.remove_edge(participant1, participant2)
-            self.G.remove_edge(participant2, participant1)
-        except KeyError:
-            log.error(
-                "Received ChannelClosed event for unknown channel",
-                channel_identifier=channel_identifier,
-            )
+        self.G.remove_edge(participant1, participant2)
+        self.G.remove_edge(participant2, participant1)
 
     def get_channel_views_for_partner(
         self, updating_participant: Address, other_participant: Address

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -267,11 +267,17 @@ class TokenNetwork:
 
         Corresponds to the ChannelClosed event."""
 
-        # we need to unregister the channel_id here
-        participant1, participant2 = self.channel_id_to_addresses.pop(channel_identifier)
+        try:
+            # we need to unregister the channel_id here
+            participant1, participant2 = self.channel_id_to_addresses.pop(channel_identifier)
 
-        self.G.remove_edge(participant1, participant2)
-        self.G.remove_edge(participant2, participant1)
+            self.G.remove_edge(participant1, participant2)
+            self.G.remove_edge(participant2, participant1)
+        except KeyError:
+            log.error(
+                "Received ChannelClosed event for unknown channel",
+                channel_identifier=channel_identifier,
+            )
 
     def get_channel_views_for_partner(
         self, updating_participant: Address, other_participant: Address

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -257,16 +257,8 @@ class PathfindingService(gevent.Greenlet):
 
         log.info("Received ChannelClosed event", event_=event)
 
-        channel = self.database.get_channel(event.token_network_address, event.channel_identifier)
-        if channel:
-            token_network.handle_channel_closed_event(event.channel_identifier)
-            self.database.delete_channel(event.token_network_address, event.channel_identifier)
-        else:
-            log.error(
-                "Received ChannelClosed event for unknown channel",
-                token_network_address=event.token_network_address,
-                channel_identifier=event.channel_identifier,
-            )
+        token_network.handle_channel_closed_event(event.channel_identifier)
+        self.database.delete_channel(event.token_network_address, event.channel_identifier)
 
     def handle_message(self, message: Message) -> None:
         try:

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -257,8 +257,17 @@ class PathfindingService(gevent.Greenlet):
 
         log.info("Received ChannelClosed event", event_=event)
 
-        token_network.handle_channel_closed_event(event.channel_identifier)
-        self.database.delete_channel(event.token_network_address, event.channel_identifier)
+        channel_deleted = self.database.delete_channel(
+            event.token_network_address, event.channel_identifier,
+        )
+        if channel_deleted:
+            token_network.handle_channel_closed_event(event.channel_identifier)
+        else:
+            log.error(
+                "Received ChannelClosed event for unknown channel",
+                token_network_address=event.token_network_address,
+                channel_identifier=event.channel_identifier,
+            )
 
     def handle_message(self, message: Message) -> None:
         try:

--- a/tests/pathfinding/test_database.py
+++ b/tests/pathfinding/test_database.py
@@ -241,11 +241,6 @@ def test_channels(pathfinding_service_mock):
         channel2.channel_id,
     ]
 
-    # Test `get_channel`
-    assert database.get_channel(channel1.token_network_address, channel1.channel_id) == channel1
-    assert database.get_channel(channel2.token_network_address, channel2.channel_id) == channel2
-    assert database.get_channel(channel2.token_network_address, ChannelID(1234)) is None
-
     # Test `delete_channel`
     database.delete_channel(channel1.token_network_address, channel1.channel_id)
     assert [chan.channel_id for chan in database.get_channels()] == [channel2.channel_id]

--- a/tests/pathfinding/test_database.py
+++ b/tests/pathfinding/test_database.py
@@ -242,5 +242,8 @@ def test_channels(pathfinding_service_mock):
     ]
 
     # Test `delete_channel`
-    database.delete_channel(channel1.token_network_address, channel1.channel_id)
+    assert database.delete_channel(channel1.token_network_address, channel1.channel_id)
+    assert [chan.channel_id for chan in database.get_channels()] == [channel2.channel_id]
+
+    assert not database.delete_channel(channel1.token_network_address, channel1.channel_id)
     assert [chan.channel_id for chan in database.get_channels()] == [channel2.channel_id]

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -236,7 +236,6 @@ def test_token_channel_closed(pathfinding_service_mock, token_network_model):
 
     # Test non-existent channel
     close_event.channel_identifier = ChannelID(123)
-    print(close_event)
 
     pathfinding_service_mock.handle_event(close_event)
     assert len(pathfinding_service_mock.token_networks) == 1


### PR DESCRIPTION
Remove loading a channel just to delete it then. 

Instead, `delete_channel` expects to delete 0 or 1 row now.