### PR TITLE
Using persistent data for Path debug endpoint

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -421,9 +421,15 @@ class DebugPathResource(PathfinderResource):
                     dict(source=req["source"], target=req["target"], routes=req["routes"])
                 )
 
+        decoded_target_address: Optional[Address] = None
+        if target_address:
+            decoded_target_address = Address(to_canonical_address(target_address))
+
         feedback_routes = list(
             self.pathfinding_service.database.get_feedback_routes(
-                token_network_address, source_address, target_address
+                TokenNetworkAddress(to_canonical_address(token_network_address)),
+                Address(to_canonical_address(source_address)),
+                decoded_target_address,
             )
         )
 

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -213,7 +213,7 @@ class PFSDatabase(BaseDatabase):
             )
 
     def prepare_feedback(
-        self, token: FeedbackToken, route: List[Address], estimated_fee: int
+        self, token: FeedbackToken, route: List[Address], estimated_fee: TokenAmount
     ) -> None:
         hexed_route = [to_checksum_address(e) for e in route]
         token_dict = dict(
@@ -221,7 +221,7 @@ class PFSDatabase(BaseDatabase):
             creation_time=token.creation_time,
             token_network_address=to_checksum_address(token.token_network_address),
             route=json.dumps(hexed_route),
-            estimated_fee=estimated_fee,
+            estimated_fee=hex256(estimated_fee),
             source_address=route[0],
             target_address=route[-1],
         )
@@ -254,7 +254,10 @@ class PFSDatabase(BaseDatabase):
         return updated_rows
 
     def get_feedback_routes(
-        self, token_network_address: str, source_address: str, target_address: str = None
+        self,
+        token_network_address: TokenNetworkAddress,
+        source_address: Address,
+        target_address: Address = None,
     ) -> Iterator[Dict]:
         filters = {
             "token_network_address": to_checksum_address(token_network_address),

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -20,6 +20,7 @@ from raiden.utils.typing import (
     BlockNumber,
     ChainID,
     ChannelID,
+    FeeAmount,
     TokenAmount,
     TokenNetworkAddress,
 )
@@ -213,7 +214,7 @@ class PFSDatabase(BaseDatabase):
             )
 
     def prepare_feedback(
-        self, token: FeedbackToken, route: List[Address], estimated_fee: TokenAmount
+        self, token: FeedbackToken, route: List[Address], estimated_fee: FeeAmount
     ) -> None:
         hexed_route = [to_checksum_address(e) for e in route]
         token_dict = dict(
@@ -222,8 +223,8 @@ class PFSDatabase(BaseDatabase):
             token_network_address=to_checksum_address(token.token_network_address),
             route=json.dumps(hexed_route),
             estimated_fee=hex256(estimated_fee),
-            source_address=route[0],
-            target_address=route[-1],
+            source_address=hexed_route[0],
+            target_address=hexed_route[-1],
         )
         self.insert("feedback", token_dict)
 

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -68,7 +68,7 @@ CREATE TABLE feedback (
     source_address CHAR(42) NOT NULL,
     target_address CHAR(42) NOT NULL,
     route TEXT NOT NULL,
-    estimated_fee INTEGER NOT NULL,
+    estimated_fee HEX_INT NOT NULL,
     successful BOOLEAN CHECK (successful IN (0,1)),
     feedback_time TIMESTAMP,
     PRIMARY KEY (token_id, token_network_address, route)

--- a/src/pathfinding_service/schema.sql
+++ b/src/pathfinding_service/schema.sql
@@ -65,7 +65,10 @@ CREATE TABLE feedback (
     token_id CHAR(32) NOT NULL,
     creation_time TIMESTAMP NOT NULL,
     token_network_address CHAR(42) NOT NULL,
+    source_address CHAR(42) NOT NULL,
+    target_address CHAR(42) NOT NULL,
     route TEXT NOT NULL,
+    estimated_fee INTEGER NOT NULL,
     successful BOOLEAN CHECK (successful IN (0,1)),
     feedback_time TIMESTAMP,
     PRIMARY KEY (token_id, token_network_address, route)

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -48,7 +48,8 @@ def test_get_paths_via_debug_endpoint_with_debug_disabled(
 def test_get_paths_via_debug_endpoint(
     api_url: str, addresses: List[Address], token_network_model: TokenNetwork
 ):
-    # `last_failed_requests` is a module variable, so it might have entries from tests that ran earlier.
+    # `last_failed_requests` is a module variable, so it might have entries
+    # from tests that ran earlier.
     last_failed_requests.clear()
     hex_addrs = [to_checksum_address(addr) for addr in addresses]
     token_network_address = to_checksum_address(token_network_model.address)
@@ -497,7 +498,7 @@ def test_feedback(api_sut: ServiceApi, api_url: str, token_network_model: TokenN
     database = api_sut.pathfinding_service.database
     default_path_hex = ["0x" + "1" * 40, "0x" + "2" * 40, "0x" + "3" * 40]
     default_path = [to_canonical_address(e) for e in default_path_hex]
-    estimated_fee = 0
+    estimated_fee = TokenAmount(0)
 
     def make_request(token_id: str = None, success: bool = True, path: List[str] = None):
         url = api_url + f"/{to_checksum_address(token_network_model.address)}/feedback"
@@ -550,7 +551,7 @@ def test_stats_endpoint(
     database = api_sut_with_debug.pathfinding_service.database
     default_path = [Address(b"1" * 20), Address(b"2" * 20), Address(b"3" * 20)]
     feedback_token = FeedbackToken(token_network_model.address)
-    estimated_fee = 0
+    estimated_fee = TokenAmount(0)
 
     def check_response(num_all: int, num_only_feedback: int, num_only_success: int) -> None:
         url = api_url + f"/_debug/stats"

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -20,7 +20,7 @@ from pathfinding_service.model import IOU, TokenNetwork
 from pathfinding_service.model.feedback import FeedbackToken
 from raiden.utils.signer import LocalSigner
 from raiden.utils.signing import pack_data
-from raiden.utils.typing import Address, BlockNumber, ChainID, Signature, TokenAmount
+from raiden.utils.typing import Address, BlockNumber, ChainID, FeeAmount, Signature, TokenAmount
 from raiden_contracts.tests.utils import get_random_privkey
 from raiden_libs.utils import private_key_to_address
 
@@ -45,7 +45,7 @@ def test_get_paths_via_debug_endpoint_with_debug_disabled(
 
 
 @pytest.mark.usefixtures("api_sut_with_debug")
-def test_get_paths_via_debug_endpoint(
+def test_get_paths_via_debug_endpoint_a(
     api_url: str, addresses: List[Address], token_network_model: TokenNetwork
 ):
     # `last_failed_requests` is a module variable, so it might have entries
@@ -498,7 +498,7 @@ def test_feedback(api_sut: ServiceApi, api_url: str, token_network_model: TokenN
     database = api_sut.pathfinding_service.database
     default_path_hex = ["0x" + "1" * 40, "0x" + "2" * 40, "0x" + "3" * 40]
     default_path = [to_canonical_address(e) for e in default_path_hex]
-    estimated_fee = TokenAmount(0)
+    estimated_fee = FeeAmount(0)
 
     def make_request(token_id: str = None, success: bool = True, path: List[str] = None):
         url = api_url + f"/{to_checksum_address(token_network_model.address)}/feedback"
@@ -551,7 +551,7 @@ def test_stats_endpoint(
     database = api_sut_with_debug.pathfinding_service.database
     default_path = [Address(b"1" * 20), Address(b"2" * 20), Address(b"3" * 20)]
     feedback_token = FeedbackToken(token_network_model.address)
-    estimated_fee = TokenAmount(0)
+    estimated_fee = FeeAmount(0)
 
     def check_response(num_all: int, num_only_feedback: int, num_only_success: int) -> None:
         url = api_url + f"/_debug/stats"

--- a/tests/pathfinding/test_database.py
+++ b/tests/pathfinding/test_database.py
@@ -52,10 +52,11 @@ def db_has_feedback_for(database: PFSDatabase, token: FeedbackToken, route: List
 def test_insert_feedback_token(pathfinding_service_mock):
     token_network_address = TokenNetworkAddress(b"1" * 20)
     route = [Address(b"2" * 20), Address(b"3" * 20)]
+    estimated_fee = 0
 
     token = FeedbackToken(token_network_address=token_network_address)
     database = pathfinding_service_mock.database
-    database.prepare_feedback(token=token, route=route)
+    database.prepare_feedback(token=token, route=route, estimated_fee=estimated_fee)
 
     # Test round-trip
     stored = database.get_feedback_token(
@@ -94,6 +95,7 @@ def test_feedback(pathfinding_service_mock):
     token_network_address = TokenNetworkAddress(b"1" * 20)
     route = [Address(b"2" * 20), Address(b"3" * 20)]
     other_route = [Address(b"2" * 20), Address(b"4" * 20)]
+    estimated_fee = 0
 
     token = FeedbackToken(token_network_address=token_network_address)
     other_token = FeedbackToken(token_network_address=token_network_address)
@@ -103,7 +105,7 @@ def test_feedback(pathfinding_service_mock):
     assert not db_has_feedback_for(database=database, token=token, route=other_route)
     assert not db_has_feedback_for(database=database, token=other_token, route=route)
 
-    database.prepare_feedback(token=token, route=route)
+    database.prepare_feedback(token=token, route=route, estimated_fee=estimated_fee)
     assert not db_has_feedback_for(database=database, token=token, route=route)
     assert not db_has_feedback_for(database=database, token=other_token, route=route)
     assert not db_has_feedback_for(database=database, token=token, route=other_route)
@@ -123,8 +125,9 @@ def test_feedback_stats(pathfinding_service_mock):
     default_path = [b"1" * 20, b"2" * 20, b"3" * 20]
     feedback_token = FeedbackToken(token_network_address)
     database = pathfinding_service_mock.database
+    estimated_fee = 0
 
-    database.prepare_feedback(feedback_token, default_path)
+    database.prepare_feedback(feedback_token, default_path, estimated_fee)
     assert database.get_num_routes_feedback() == 1
     assert database.get_num_routes_feedback(only_with_feedback=True) == 0
     assert database.get_num_routes_feedback(only_successful=True) == 0
@@ -137,7 +140,7 @@ def test_feedback_stats(pathfinding_service_mock):
     default_path2 = default_path[1:]
     feedback_token2 = FeedbackToken(token_network_address)
 
-    database.prepare_feedback(feedback_token2, default_path2)
+    database.prepare_feedback(feedback_token2, default_path2, estimated_fee)
     assert database.get_num_routes_feedback() == 2
     assert database.get_num_routes_feedback(only_with_feedback=True) == 1
     assert database.get_num_routes_feedback(only_successful=True) == 0

--- a/tests/pathfinding/test_fee_schedule.py
+++ b/tests/pathfinding/test_fee_schedule.py
@@ -81,16 +81,16 @@ class TokenNetworkForTests(TokenNetwork):
         )
 
     def estimate_fee(self, initator: int, target: int, value=PA(100), max_paths=1):
-        result = self.get_paths(
+        paths = self.get_paths(
             source=a(initator),
             target=a(target),
             value=value,
             max_paths=max_paths,
             address_to_reachability=self.address_to_reachability,
         )
-        if not result:
+        if not paths:
             return None
-        return result[0]["estimated_fee"]
+        return paths[0].estimated_fee
 
 
 def test_fees_in_balanced_routing():  # pylint: disable=too-many-statements


### PR DESCRIPTION
Fixes https://github.com/raiden-network/raiden/issues/5503

If the PFS is restarted while a scenario is running the data of the PFS
requests will be lost, which has led to scenario failures. This commit
changes the debug endpoint to use data persisted in the database, so
that restarts will no lead to a problem.

Note: This is relying on the feedback data, which does not contain all
the requests. Specifically, requests which failed with a validation
error are not included in the table, therefore are still successtible to
loss of data.