### PR TITLE
Removing extra mapping for address availability.

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -132,7 +132,7 @@ class PathsResource(PathfinderResource):
             source=path_req.from_,
             target=path_req.to,
             value=path_req.value,
-            address_to_reachability=self.pathfinding_service.address_to_reachability,
+            reachability_state=self.pathfinding_service.matrix_listener.user_manager,
         )
         if error:
             # this is for assertion via the scenario player
@@ -163,7 +163,7 @@ class PathsResource(PathfinderResource):
             source=path_req.from_,
             target=path_req.to,
             value=path_req.value,
-            address_to_reachability=self.pathfinding_service.address_to_reachability,
+            reachability_state=self.pathfinding_service.matrix_listener.user_manager,
             max_paths=path_req.max_paths,
             **optional_args,
         )

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -23,8 +23,7 @@ from pathfinding_service.typing import DeferableMessage
 from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, UINT256_MAX
 from raiden.messages.abstract import Message
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
-from raiden.network.transport.matrix import AddressReachability
-from raiden.utils.typing import Address, BlockNumber, ChainID, TokenNetworkAddress
+from raiden.utils.typing import BlockNumber, ChainID, TokenNetworkAddress
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_libs.blockchain import get_blockchain_events
 from raiden_libs.constants import MATRIX_START_TIMEOUT
@@ -100,11 +99,9 @@ class PathfindingService(gevent.Greenlet):
             chain_id=self.chain_id,
             service_room_suffix=PATH_FINDING_BROADCASTING_ROOM,
             message_received_callback=self.handle_message,
-            address_reachability_changed_callback=self.handle_reachability_change,
             servers=matrix_servers,
         )
 
-        self.address_to_reachability: Dict[Address, AddressReachability] = dict()
         self.token_networks = self._load_token_networks()
         self.updated = gevent.event.Event()  # set whenever blocks are processed
         self.startup_finished = gevent.event.Event()
@@ -191,11 +188,6 @@ class PathfindingService(gevent.Greenlet):
     def follows_token_network(self, token_network_address: TokenNetworkAddress) -> bool:
         """ Checks if a token network is followed by the pathfinding service. """
         return token_network_address in self.token_networks.keys()
-
-    def handle_reachability_change(
-        self, address: Address, reachability: AddressReachability
-    ) -> None:
-        self.address_to_reachability[address] = reachability
 
     def get_token_network(
         self, token_network_address: TokenNetworkAddress

--- a/src/pathfinding_service/typing.py
+++ b/src/pathfinding_service/typing.py
@@ -1,5 +1,16 @@
 from typing import Union
 
+from typing_extensions import Protocol
+
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
+from raiden.network.transport.matrix.utils import AddressReachability
+from raiden.utils.typing import Address
 
 DeferableMessage = Union[PFSFeeUpdate, PFSCapacityUpdate]
+
+
+class AddressReachabilityProtocol(Protocol):
+    # pylint: disable=unused-argument,no-self-use,too-few-public-methods
+
+    def get_address_reachability(self, address: Address) -> AddressReachability:
+        ...

--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -177,7 +177,6 @@ def test_matrix_lister_smoke_test(get_accounts, get_private_key):
             chain_id=ChainID(1),
             service_room_suffix="_service",
             message_received_callback=lambda _: None,
-            address_reachability_changed_callback=lambda _addr, _reachability: None,
         )
         listener._run()  # pylint: disable=protected-access
 

--- a/tests/pathfinding/fixtures/__init__.py
+++ b/tests/pathfinding/fixtures/__init__.py
@@ -1,9 +1,9 @@
 import pytest
 
 from pathfinding_service.model.token_network import TokenNetwork
-from raiden.network.transport.matrix import AddressReachability
-from raiden.utils.typing import Address, Dict, TokenNetworkAddress
+from raiden.utils.typing import TokenNetworkAddress
 
+from ..utils import SimpleReachabilityContainer
 from .accounts import *  # noqa
 from .api import *  # noqa
 from .iou import *  # noqa
@@ -16,5 +16,5 @@ def token_network_model() -> TokenNetwork:
 
 
 @pytest.fixture
-def address_to_reachability() -> Dict[Address, AddressReachability]:
-    return {}
+def reachability_state() -> SimpleReachabilityContainer:
+    return SimpleReachabilityContainer({})

--- a/tests/pathfinding/fixtures/api.py
+++ b/tests/pathfinding/fixtures/api.py
@@ -1,13 +1,14 @@
 # pylint: disable=redefined-outer-name
 import socket
-from typing import Dict, Iterator
+from typing import Iterator
 
 import pytest
 
 from pathfinding_service.api import ServiceApi
 from pathfinding_service.constants import API_PATH
-from raiden.network.transport.matrix import AddressReachability
 from raiden.utils.typing import Address
+
+from ..utils import SimpleReachabilityContainer
 
 
 @pytest.fixture(scope="session")
@@ -27,11 +28,11 @@ def api_url(free_port: int) -> str:
 @pytest.fixture
 def api_sut(
     pathfinding_service_mock,
-    address_to_reachability: Dict[Address, AddressReachability],
+    reachability_state: SimpleReachabilityContainer,
     free_port: int,
     populate_token_network_case_1,  # pylint: disable=unused-argument
 ) -> Iterator[ServiceApi]:
-    pathfinding_service_mock.address_to_reachability = address_to_reachability
+    pathfinding_service_mock.matrix_listener.user_manager = reachability_state
     api = ServiceApi(
         pathfinding_service=pathfinding_service_mock,
         one_to_n_address=Address(bytes([1] * 20)),
@@ -46,11 +47,11 @@ def api_sut(
 @pytest.fixture
 def api_sut_with_debug(
     pathfinding_service_mock,
-    address_to_reachability: Dict[Address, AddressReachability],
+    reachability_state: SimpleReachabilityContainer,
     free_port: int,
     populate_token_network_case_1,  # pylint: disable=unused-argument
 ) -> Iterator[ServiceApi]:
-    pathfinding_service_mock.address_to_reachability = address_to_reachability
+    pathfinding_service_mock.matrix_listener.user_manager = reachability_state
     api = ServiceApi(
         pathfinding_service=pathfinding_service_mock,
         one_to_n_address=Address(bytes([1] * 20)),

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -1,6 +1,6 @@
 # pylint: disable=redefined-outer-name
 import random
-from typing import Callable, Dict, Generator, List
+from typing import Callable, Generator, List
 from unittest.mock import Mock, patch
 
 import pytest
@@ -25,6 +25,8 @@ from raiden.utils.typing import (
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_libs.utils import private_key_to_address
+
+from ..utils import SimpleReachabilityContainer
 
 
 @pytest.fixture(scope="session")
@@ -164,7 +166,7 @@ def populate_token_network() -> Callable:
     # pylint: disable=too-many-locals
     def populate_token_network(
         token_network: TokenNetwork,
-        address_to_reachability: Dict[Address, AddressReachability],
+        reachability_state: SimpleReachabilityContainer,
         addresses: List[Address],
         channel_descriptions: List,
     ):
@@ -233,8 +235,8 @@ def populate_token_network() -> Callable:
             )
 
             # Update presence state according to scenario
-            address_to_reachability[participant1] = p1_reachability
-            address_to_reachability[participant2] = p2_reachability
+            reachability_state.reachabilities[participant1] = p1_reachability
+            reachability_state.reachabilities[participant2] = p2_reachability
 
     return populate_token_network
 
@@ -243,12 +245,12 @@ def populate_token_network() -> Callable:
 def populate_token_network_case_1(
     populate_token_network: Callable,
     token_network_model: TokenNetwork,
-    address_to_reachability: Dict[Address, AddressReachability],
+    reachability_state: SimpleReachabilityContainer,
     addresses: List[Address],
     channel_descriptions_case_1: List,
 ):
     populate_token_network(
-        token_network_model, address_to_reachability, addresses, channel_descriptions_case_1
+        token_network_model, reachability_state, addresses, channel_descriptions_case_1
     )
 
 
@@ -256,12 +258,12 @@ def populate_token_network_case_1(
 def populate_token_network_case_2(
     populate_token_network: Callable,
     token_network_model: TokenNetwork,
-    address_to_reachability: Dict[Address, AddressReachability],
+    reachability_state: SimpleReachabilityContainer,
     addresses: List[Address],
     channel_descriptions_case_2: List,
 ):
     populate_token_network(
-        token_network_model, address_to_reachability, addresses, channel_descriptions_case_2
+        token_network_model, reachability_state, addresses, channel_descriptions_case_2
     )
 
 
@@ -269,12 +271,12 @@ def populate_token_network_case_2(
 def populate_token_network_case_3(
     populate_token_network: Callable,
     token_network_model: TokenNetwork,
-    address_to_reachability: Dict[Address, AddressReachability],
+    reachability_state: SimpleReachabilityContainer,
     addresses: List[Address],
     channel_descriptions_case_3: List,
 ):
     populate_token_network(
-        token_network_model, address_to_reachability, addresses, channel_descriptions_case_3
+        token_network_model, reachability_state, addresses, channel_descriptions_case_3
     )
 
 

--- a/tests/pathfinding/test_fee_schedule.py
+++ b/tests/pathfinding/test_fee_schedule.py
@@ -1,8 +1,9 @@
 import itertools
 from datetime import datetime
-from typing import Dict, List
+from typing import List
 
 import pytest
+from tests.pathfinding.utils import SimpleReachabilityContainer
 
 from pathfinding_service.model import ChannelView
 from pathfinding_service.model.token_network import TokenNetwork
@@ -60,9 +61,9 @@ class TokenNetworkForTests(TokenNetwork):
             cv2.capacity = chan.get("capacity2", default_capacity)
 
         # create reachability mapping for testing
-        self.address_to_reachability: Dict[Address, AddressReachability] = {
-            node: AddressReachability.REACHABLE for node in self.G.nodes
-        }
+        self.reachability_state = SimpleReachabilityContainer(
+            {node: AddressReachability.REACHABLE for node in self.G.nodes}
+        )
 
     def set_fee(self, node1: int, node2: int, **fee_params):
         channel_id = self.G[a(node1)][a(node2)]["view"].channel_id
@@ -86,7 +87,7 @@ class TokenNetworkForTests(TokenNetwork):
             target=a(target),
             value=value,
             max_paths=max_paths,
-            address_to_reachability=self.address_to_reachability,
+            reachability_state=self.reachability_state,
         )
         if not paths:
             return None

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -9,7 +9,6 @@ from pathfinding_service.model.token_network import PFSFeeUpdate
 from pathfinding_service.service import PathfindingService
 from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages.synchronization import Processed
-from raiden.network.transport.matrix import AddressReachability
 from raiden.tests.utils.factories import make_privkey_address, make_token_network_address
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
@@ -28,7 +27,7 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
-from raiden_contracts.tests.utils import get_random_privkey, to_canonical_address
+from raiden_contracts.tests.utils import get_random_privkey
 from raiden_libs.events import (
     ReceiveChannelClosedEvent,
     ReceiveChannelOpenedEvent,
@@ -240,31 +239,6 @@ def test_token_channel_closed(pathfinding_service_mock, token_network_model):
     pathfinding_service_mock.handle_event(close_event)
     assert len(pathfinding_service_mock.token_networks) == 1
     assert len(token_network_model.channel_id_to_addresses) == 0
-
-
-def test_handle_reachability_change(pathfinding_service_mock, token_network_model):
-    setup_channel(pathfinding_service_mock, token_network_model)
-
-    assert len(pathfinding_service_mock.address_to_reachability) == 0
-    pathfinding_service_mock.handle_reachability_change(
-        to_canonical_address(PARTICIPANT1), AddressReachability.REACHABLE
-    )
-    assert (
-        pathfinding_service_mock.address_to_reachability[PARTICIPANT1]
-        == AddressReachability.REACHABLE
-    )
-
-    pathfinding_service_mock.handle_reachability_change(
-        to_canonical_address(PARTICIPANT2), AddressReachability.REACHABLE
-    )
-    assert (
-        pathfinding_service_mock.address_to_reachability[PARTICIPANT1]
-        == AddressReachability.REACHABLE
-    )
-    assert (
-        pathfinding_service_mock.address_to_reachability[PARTICIPANT2]
-        == AddressReachability.REACHABLE
-    )
 
 
 @pytest.mark.parametrize("order", ["normal", "fee_update_before_channel_open"])

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -1,0 +1,10 @@
+from raiden.network.transport.matrix import AddressReachability
+from raiden.utils.typing import Address, Dict
+
+
+class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
+    def __init__(self, reachabilities: Dict[Address, AddressReachability]) -> None:
+        self.reachabilities = reachabilities
+
+    def get_address_reachability(self, address: Address) -> AddressReachability:
+        return self.reachabilities.get(address, AddressReachability.UNKNOWN)


### PR DESCRIPTION
Instead of having a copy of the availability in the PFS, this changes
the code to rely on the data available in the UserAddressManager, which
already tracks the data. This is done just to simplify the code
(hopefully), and to remove the changes of data desynchronization.