### PR TITLE
Added confirmed block number to info api

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -390,12 +390,16 @@ class InfoResource(PathfinderResource):
                 "user_deposit_address": to_checksum_address(
                     self.pathfinding_service.user_deposit_contract.address
                 ),
+                "confirmed_block": {
+                    "number": self.pathfinding_service.blockchain_state.latest_committed_block
+                },
             },
             "version": self.version,
             "contracts_version": self.contracts_version,
             "operator": self.service_api.operator,
             "message": self.service_api.info_message,
             "payment_address": to_checksum_address(self.pathfinding_service.address),
+            "UTC": datetime.utcnow().isoformat(),
         }
         if info["message"] == DEFAULT_INFO_MESSAGE:
             info["message"] = str(info["message"]) + to_checksum_address(

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -406,6 +406,7 @@ def test_get_info(api_url: str, api_sut, pathfinding_service_mock):
             "chain_id": pathfinding_service_mock.chain_id,
             "token_network_registry_address": token_network_registry_address,
             "user_deposit_address": user_deposit_address,
+            "confirmed_block": {"number": 0},
         },
         "version": pkg_resources.require("raiden-services")[0].version,
         "contracts_version": pkg_resources.require("raiden-contracts")[0].version,
@@ -416,13 +417,17 @@ def test_get_info(api_url: str, api_sut, pathfinding_service_mock):
     }
     response = requests.get(url)
     assert response.status_code == 200
-    assert response.json() == expected_response
+    response_json = response.json()
+    del response_json["UTC"]
+    assert response_json == expected_response
 
     # Test with a custom info message
     api_sut.info_message = expected_response["message"] = "Other message"
     response = requests.get(url)
     assert response.status_code == 200
-    assert response.json() == expected_response
+    response_json = response.json()
+    del response_json["UTC"]
+    assert response_json == expected_response
 
 
 #


### PR DESCRIPTION
This information is useful to fix race conditions among the Raiden
client and the PFS server. It allows the Raiden node to wait for the PFS
to synchronize with the same state it expects.