### PR TITLE
Update to latest raiden and raiden-contracts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ coverage>=4.5.4
 ipython==4.2.1
 pdbpp
 
-eth-tester[py-evm]==0.1.0b33
+eth-tester[py-evm]==0.1.0b39
 
 # Release
 bump2version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/raiden-network/raiden.git@34c0a46c62c628a47bc5238c97b750d92f5edc3b
-raiden-contracts==0.35
+git+https://github.com/raiden-network/raiden.git@3469ff5e9714e820b74f0eed07ce3bab18772783
+raiden-contracts==0.36
 
 structlog==19.1.0
 colorama==0.4.1

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -10,7 +10,6 @@ from raiden.messages.monitoring_service import RequestMonitoring, SignedBlindedB
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.keys import privatekey_to_address
 from raiden.utils.signer import LocalSigner, recover
-from raiden.utils.signing import pack_data
 from raiden.utils.typing import (
     AdditionalHash,
     Address,
@@ -26,7 +25,7 @@ from raiden.utils.typing import (
     TransactionHash,
 )
 from raiden_contracts.constants import ChannelState, MessageTypeId
-from raiden_contracts.utils.proofs import pack_reward_proof
+from raiden_contracts.utils.proofs import pack_balance_proof, pack_reward_proof
 from raiden_libs.states import BlockchainState
 
 
@@ -111,14 +110,14 @@ class HashedBalanceProof:
             self.signature = signature
 
     def serialize_bin(self, msg_type: MessageTypeId = MessageTypeId.BALANCE_PROOF) -> bytes:
-        return pack_data(
-            (self.token_network_address, "address"),
-            (self.chain_id, "uint256"),
-            (msg_type.value, "uint256"),
-            (self.channel_identifier, "uint256"),
-            (decode_hex(self.balance_hash), "bytes32"),
-            (self.nonce, "uint256"),
-            (decode_hex(self.additional_hash), "bytes32"),
+        return pack_balance_proof(
+            to_checksum_address(self.token_network_address),
+            self.chain_id,
+            self.channel_identifier,
+            decode_hex(self.balance_hash),
+            self.nonce,
+            decode_hex(self.additional_hash),
+            msg_type,
         )
 
     def get_request_monitoring(
@@ -230,14 +229,14 @@ class UnsignedMonitorRequest:
     def packed_balance_proof_data(
         self, message_type: MessageTypeId = MessageTypeId.BALANCE_PROOF
     ) -> bytes:
-        return pack_data(
-            (self.token_network_address, "address"),
-            (self.chain_id, "uint256"),
-            (message_type.value, "uint256"),
-            (self.channel_identifier, "uint256"),
-            (decode_hex(self.balance_hash), "bytes32"),
-            (self.nonce, "uint256"),
-            (decode_hex(self.additional_hash), "bytes32"),
+        return pack_balance_proof(
+            to_checksum_address(self.token_network_address),
+            self.chain_id,
+            self.channel_identifier,
+            decode_hex(self.balance_hash),
+            self.nonce,
+            decode_hex(self.additional_hash),
+            message_type,
         )
 
     def packed_reward_proof_data(self, non_closing_signature: Signature) -> bytes:

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -118,7 +118,7 @@ class PFSDatabase(BaseDatabase):
         iou_dict = IOU.Schema(exclude=["receiver", "chain_id"]).dump(iou)
         iou_dict["one_to_n_address"] = to_checksum_address(iou_dict["one_to_n_address"])
         for key in ("amount", "expiration_block"):
-            iou_dict[key] = hex256(iou_dict[key])
+            iou_dict[key] = hex256(int(iou_dict[key]))
         self.upsert("iou", iou_dict)
 
     def get_ious(
@@ -176,7 +176,7 @@ class PFSDatabase(BaseDatabase):
             "reveal_timeout2",
             "update_nonce2",
         ):
-            channel_dict[key] = hex256(channel_dict[key])
+            channel_dict[key] = hex256(int(channel_dict[key]))
         channel_dict["fee_schedule1"] = json.dumps(channel_dict["fee_schedule1"])
         channel_dict["fee_schedule2"] = json.dumps(channel_dict["fee_schedule2"])
         self.upsert("channel", channel_dict)

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -19,7 +19,6 @@ from pathfinding_service.api import DEFAULT_MAX_PATHS, ServiceApi, last_failed_r
 from pathfinding_service.model import IOU, TokenNetwork
 from pathfinding_service.model.feedback import FeedbackToken
 from raiden.utils.signer import LocalSigner
-from raiden.utils.signing import pack_data
 from raiden.utils.typing import Address, BlockNumber, ChainID, FeeAmount, Signature, TokenAmount
 from raiden_contracts.tests.utils import get_random_privkey
 from raiden_libs.utils import private_key_to_address
@@ -457,11 +456,9 @@ def test_get_iou(api_sut: ServiceApi, api_url: str, token_network_model: TokenNe
         local_signer = LocalSigner(private_key=decode_hex(privkey))
         params["signature"] = encode_hex(
             local_signer.sign(
-                pack_data(
-                    (params["sender"], "address"),
-                    (params["receiver"], "address"),
-                    (params["timestamp"], "string"),
-                )
+                to_canonical_address(params["sender"])
+                + to_canonical_address(params["receiver"])
+                + params["timestamp"].encode("utf8")
             )
         )
         return params


### PR DESCRIPTION
Required changes:
- avoid using pack_data
- `dump` yields strings for some numbers. Cast them back to int before
calling `hex256`.