### PR TITLE
Use matrix sync filter to only listen on selected broadcasting room

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@75a2ad5d208d3e98a7c3b12c45848a0f7be6a5d0
+git+https://github.com/raiden-network/raiden.git@469337235a2d70398925f109e6f773f8d3cd3246
 raiden-contracts==0.36
 
 structlog==19.1.0

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -217,6 +217,9 @@ class MatrixListener(gevent.Greenlet):
             self._broadcast_room = join_broadcast_room(
                 client=self._client, broadcast_room_alias=room_alias
             )
+
+            sync_filter_id = self._client.create_sync_filter(rooms=[self._broadcast_room])
+            self._client.set_sync_filter_id(sync_filter_id)
         except (MatrixRequestError, TransportError):
             raise ConnectionError("Could not join monitoring broadcasting room.")
 


### PR DESCRIPTION
Because we use one ethereum account for both PFS and MS, we need to
whitelist the correct broadcast room in each service, so that we don't
receive the other messages.

This is a pure performance optimization.

Fixes #713 