### PR TITLE
Use `AsyncResult` to raise errors while waiting

### DIFF
--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -178,4 +178,4 @@ def test_matrix_lister_smoke_test(get_accounts, get_private_key):
         )
         listener._run()  # pylint: disable=protected-access
 
-    assert listener.startup_finished.is_set()
+    assert listener.startup_finished.done()


### PR DESCRIPTION
We were waiting on `event`s that never came when the greenlet we're
waiting for threw an exception at an unfortunate time. Because we we're
stuck in the `wait`, we did not event collect and raise the exception
from the underlying greenlet.

If should probably have split some of the changes in `matrix.py` into a
separate commit, but I don't think it's worth the effort to pull the
changes apart, now.