### PR TITLE
Use `MatrixListener.run` in request collector

### DIFF
--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -43,7 +43,7 @@ class RequestCollector(gevent.Greenlet):
         )
 
     def listen_forever(self) -> None:
-        self.matrix_listener.listen_forever()
+        self.matrix_listener.run()
 
     def _run(self) -> None:  # pylint: disable=method-hidden
         try:


### PR DESCRIPTION
Before we had `listen_forever` and `start` to run the MatrixListener in
a blocking respectively non-blocking way. Now we can use the same code
path to handle both cases.

Unfortunately, `Greenlet.run` is not documented in the gevent
documentation. But it seems to do exactly what we want here. If we want
to use something documented instead, we could do
```
matrix_listener.start()
matrix_listener.get()
```
instead.

Fixes https://sentry.io/share/issue/bfa38740026e44f1a1deaf8d92415719/