### PR TITLE
Trigger scheduled events earlier

### DIFF
--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -54,14 +54,11 @@ class Context:
         return self.ms_state.blockchain_state.latest_committed_block
 
     @property
-    def latest_block(self) -> BlockNumber:
-        """ The latest block. """
-        return self.web3.eth.blockNumber
-
-    @property
     def latest_confirmed_block(self) -> BlockNumber:
-        """ The latest confirmed block. """
-        return BlockNumber(self.latest_block - self.required_confirmations)
+        return BlockNumber(self.get_latest_unconfirmed_block() - self.required_confirmations)
+
+    def get_latest_unconfirmed_block(self) -> BlockNumber:
+        return self.web3.eth.blockNumber
 
 
 def channel_opened_event_handler(event: Event, context: Context) -> None:

--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -54,9 +54,14 @@ class Context:
         return self.ms_state.blockchain_state.latest_committed_block
 
     @property
+    def latest_block(self) -> BlockNumber:
+        """ The latest block. """
+        return self.web3.eth.blockNumber
+
+    @property
     def latest_confirmed_block(self) -> BlockNumber:
         """ The latest confirmed block. """
-        return self.web3.eth.blockNumber - self.required_confirmations
+        return BlockNumber(self.latest_block - self.required_confirmations)
 
 
 def channel_opened_event_handler(event: Event, context: Context) -> None:

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -185,7 +185,7 @@ class MonitoringService:  # pylint: disable=too-few-public-methods,too-many-inst
         a chain reorg.
         """
         triggered_events = self.context.database.get_scheduled_events(
-            max_trigger_block=self.context.latest_block
+            max_trigger_block=self.context.get_latest_unconfirmed_block()
         )
         for scheduled_event in triggered_events:
             event = scheduled_event.event

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -88,7 +88,6 @@ class MonitoringService:  # pylint: disable=too-few-public-methods,too-many-inst
         self.web3 = web3
         self.private_key = private_key
         self.address = private_key_to_address(private_key)
-        self.required_confirmations = required_confirmations
         self.poll_interval = poll_interval
         self.service_registry = contracts[CONTRACT_SERVICE_REGISTRY]
 

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -47,7 +47,7 @@ def test_first_allowed_monitoring(
     service_registry,
     monitoring_service: MonitoringService,
     request_collector: RequestCollector,
-    contracts_manager,
+    contracts_manager: ContractManager,
     deposit_to_udc,
     create_channel,
     token_network,
@@ -152,7 +152,7 @@ def test_e2e(  # pylint: disable=too-many-arguments,too-many-locals
     service_registry,
     monitoring_service: MonitoringService,
     request_collector: RequestCollector,
-    contracts_manager,
+    contracts_manager: ContractManager,
     deposit_to_udc,
     create_channel,
     token_network,
@@ -233,9 +233,9 @@ def test_e2e(  # pylint: disable=too-many-arguments,too-many-locals
     ).transact({"from": c2})
     # Wait until the MS reacts, which it does after giving the client some time
     # to update the channel itself.
-    wait_for_blocks(3)  # 1 block for close + 30% of 5 blocks = 2
+    wait_for_blocks(2)  # 1 block for close + 1 block for triggering the event
     # Now give the monitoring service a chance to submit the missing BP
-    gevent.sleep(0.1)
+    gevent.sleep(0.01)
 
     assert [e.event for e in query()] == [MonitoringServiceEvent.NEW_BALANCE_PROOF_RECEIVED]
 
@@ -256,7 +256,7 @@ def test_e2e(  # pylint: disable=too-many-arguments,too-many-locals
 
     # Wait until the ChannelSettled is confirmed
     # Let the MS claim its reward
-    gevent.sleep(0.1)
+    gevent.sleep(0.01)
     assert [e.event for e in query()] == [
         MonitoringServiceEvent.NEW_BALANCE_PROOF_RECEIVED,
         MonitoringServiceEvent.REWARD_CLAIMED,

--- a/tests/monitoring/monitoring_service/test_service.py
+++ b/tests/monitoring/monitoring_service/test_service.py
@@ -1,13 +1,25 @@
+from typing import Callable, cast
 from unittest.mock import Mock, patch
 
+from tests.monitoring.monitoring_service.factories import DEFAULT_TOKEN_NETWORK_ADDRESS
+from tests.monitoring.monitoring_service.test_handlers import create_default_token_network
+from web3 import Web3
+
+from monitoring_service.events import ActionMonitoringTriggeredEvent, ScheduledEvent
 from monitoring_service.service import MonitoringService
-from raiden.tests.utils.factories import make_transaction_hash
+from raiden.tests.utils.factories import (
+    make_address,
+    make_channel_identifier,
+    make_transaction_hash,
+)
+from raiden.utils.typing import BlockNumber
+from raiden_libs.events import Event
 
 
-def test_check_pending_transactions(web3, wait_for_blocks, monitoring_service: MonitoringService):
-    required_confirmations = 3
-
-    monitoring_service.context.required_confirmations = required_confirmations
+def test_check_pending_transactions(
+    web3: Web3, wait_for_blocks: Callable[[int], None], monitoring_service: MonitoringService
+):
+    monitoring_service.context.required_confirmations = 3
     monitoring_service.database.add_waiting_transaction(waiting_tx_hash=make_transaction_hash())
 
     for tx_status in (0, 1):
@@ -20,3 +32,29 @@ def test_check_pending_transactions(web3, wait_for_blocks, monitoring_service: M
 
                 assert remove_mock.called == should_call
                 wait_for_blocks(1)
+
+
+def test_trigger_scheduled_events(monitoring_service: MonitoringService):
+    monitoring_service.context.required_confirmations = 5
+
+    create_default_token_network(monitoring_service.context)
+
+    triggered_event = ActionMonitoringTriggeredEvent(
+        token_network_address=DEFAULT_TOKEN_NETWORK_ADDRESS,
+        channel_identifier=make_channel_identifier(),
+        non_closing_participant=make_address(),
+    )
+
+    current_confirmed_block = monitoring_service.context.latest_confirmed_block
+    # Trigger the event on a currently unconfirmed block
+    trigger_block = BlockNumber(current_confirmed_block + 1)
+
+    assert len(monitoring_service.database.get_scheduled_events(trigger_block)) == 0
+    monitoring_service.context.database.upsert_scheduled_event(
+        ScheduledEvent(trigger_block_number=trigger_block, event=cast(Event, triggered_event))
+    )
+    assert len(monitoring_service.database.get_scheduled_events(trigger_block)) == 1
+
+    # Now run `_trigger_scheduled_events` and see if the event is removed
+    monitoring_service._trigger_scheduled_events()  # pylint: disable=protected-access
+    assert len(monitoring_service.database.get_scheduled_events(trigger_block)) == 0


### PR DESCRIPTION
Fixes https://github.com/raiden-network/raiden-services/issues/721

We used to trigger scheduled events based on the confirmed block, which lets valuable time pass. Especially in the scenarios with short settle timeouts the confirmation timeout of 5 blocks led to some flakyness.

This is possible because triggered events only rely on block number, and not on certain events that might change during a chain reorg.