### PR TITLE
change event name to processed due to PR #5734 in raiden

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@469337235a2d70398925f109e6f773f8d3cd3246
+git+https://github.com/raiden-network/raiden.git@d5bf345d5e5dee208b8bc3ae0d15b72e186a4a00
 raiden-contracts==0.36
 
 structlog==19.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ structlog==19.1.0
 colorama==0.4.1
 
 click==7.0
-coincurve==12.0.0
+coincurve==13.0.0
 
 web3==4.9.2
 eth-utils==1.8.1

--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -2,12 +2,12 @@ from typing import Dict
 
 import click
 import structlog
+from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
 
 from monitoring_service.service import MonitoringService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,

--- a/src/monitoring_service/database.py
+++ b/src/monitoring_service/database.py
@@ -3,7 +3,7 @@ import sqlite3
 from typing import List, Optional, Union, cast
 
 import structlog
-from eth_utils import decode_hex, encode_hex, to_canonical_address, to_hex
+from eth_utils import decode_hex, encode_hex, to_canonical_address, to_checksum_address, to_hex
 
 from monitoring_service.events import (
     ActionClaimRewardTriggeredEvent,
@@ -16,7 +16,6 @@ from monitoring_service.states import (
     MonitorRequest,
     OnChainUpdateStatus,
 )
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockNumber,

--- a/src/monitoring_service/states.py
+++ b/src/monitoring_service/states.py
@@ -2,12 +2,11 @@ from dataclasses import dataclass, field
 from typing import Iterable, Optional
 
 from eth_typing.evm import HexAddress
-from eth_utils import decode_hex, encode_hex
+from eth_utils import decode_hex, encode_hex, to_checksum_address
 from web3 import Web3
 
 from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages.monitoring_service import RequestMonitoring, SignedBlindedBalanceProof
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.keys import privatekey_to_address
 from raiden.utils.signer import LocalSigner, recover
 from raiden.utils.typing import (

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -10,6 +10,7 @@ from typing import Dict, List
 import click
 import gevent
 import structlog
+from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
 
@@ -21,7 +22,6 @@ from pathfinding_service.constants import (
 )
 from pathfinding_service.service import PathfindingService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import BlockNumber, TokenAmount
 from raiden_contracts.constants import (
     CONTRACT_ONE_TO_N,

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterator, List, Optional, Tuple
 from uuid import UUID
 
 import structlog
-from eth_utils import to_canonical_address
+from eth_utils import to_canonical_address, to_checksum_address
 
 from pathfinding_service.model import IOU
 from pathfinding_service.model.channel import Channel
@@ -14,7 +14,6 @@ from pathfinding_service.model.token_network import TokenNetwork
 from pathfinding_service.typing import DeferableMessage
 from raiden.messages.path_finding_service import PFSCapacityUpdate
 from raiden.storage.serialization.serializer import JSONSerializer
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockNumber,

--- a/src/pathfinding_service/model/channel.py
+++ b/src/pathfinding_service/model/channel.py
@@ -3,13 +3,13 @@ from datetime import datetime
 from typing import ClassVar, Tuple, Type
 
 import marshmallow
+from eth_utils import to_checksum_address
 from marshmallow.fields import NaiveDateTime
 from marshmallow_dataclass import add_schema
 
 from pathfinding_service.constants import DEFAULT_REVEAL_TIMEOUT
 from pathfinding_service.exceptions import InvalidFeeUpdate
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState as FeeScheduleRaiden
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockTimeout,

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import networkx as nx
 import structlog
+from eth_utils import to_checksum_address
 from networkx import DiGraph
 from networkx.exception import NetworkXNoPath, NodeNotFound
 
@@ -20,7 +21,6 @@ from pathfinding_service.typing import AddressReachabilityProtocol
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
 from raiden.network.transport.matrix.utils import AddressReachability
 from raiden.tests.utils.mediation_fees import get_amount_with_fees
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
     Balance,

--- a/src/raiden_libs/blockchain.py
+++ b/src/raiden_libs/blockchain.py
@@ -2,13 +2,12 @@ from copy import deepcopy
 from typing import Dict, List, Optional, Tuple
 
 import structlog
-from eth_utils import decode_hex, encode_hex, to_canonical_address
+from eth_utils import decode_hex, encode_hex, to_canonical_address, to_checksum_address
 from eth_utils.abi import event_abi_to_log_topic
 from web3 import Web3
 from web3.contract import Contract, get_event_data
 from web3.utils.abi import filter_by_type
 
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address, BlockNumber, TokenAmount, TokenNetworkAddress
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,

--- a/src/raiden_libs/database.py
+++ b/src/raiden_libs/database.py
@@ -4,9 +4,8 @@ import sys
 from typing import Any, Dict
 
 import structlog
-from eth_utils import to_canonical_address
+from eth_utils import to_canonical_address, to_checksum_address
 
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address, BlockNumber, ChainID, TokenNetworkAddress
 from raiden_libs.states import BlockchainState
 

--- a/src/raiden_libs/logging.py
+++ b/src/raiden_libs/logging.py
@@ -8,6 +8,7 @@ from eth_utils import to_hex
 
 from raiden.messages.abstract import Message
 from raiden.utils.formatting import to_checksum_address
+from raiden.utils.typing import Address
 from raiden_libs.events import Event
 
 
@@ -46,7 +47,7 @@ def setup_logging(log_level: str, log_json: bool) -> None:
 def make_bytes_readable(value: Any) -> Any:
     if isinstance(value, bytes):
         if len(value) == 20:
-            return to_checksum_address(value)
+            return to_checksum_address(Address(value))
 
         return to_hex(value)
     return value

--- a/src/raiden_libs/logging.py
+++ b/src/raiden_libs/logging.py
@@ -4,11 +4,9 @@ from dataclasses import asdict
 from typing import Any, Dict
 
 import structlog
-from eth_utils import to_hex
+from eth_utils import to_checksum_address, to_hex
 
 from raiden.messages.abstract import Message
-from raiden.utils.formatting import to_checksum_address
-from raiden.utils.typing import Address
 from raiden_libs.events import Event
 
 
@@ -47,7 +45,7 @@ def setup_logging(log_level: str, log_json: bool) -> None:
 def make_bytes_readable(value: Any) -> Any:
     if isinstance(value, bytes):
         if len(value) == 20:
-            return to_checksum_address(Address(value))
+            return to_checksum_address(value)
 
         return to_hex(value)
     return value

--- a/src/raiden_libs/marshmallow.py
+++ b/src/raiden_libs/marshmallow.py
@@ -1,10 +1,7 @@
 from typing import Any
 
 import marshmallow
-from eth_utils import decode_hex, encode_hex, is_checksum_address
-
-from raiden.utils.formatting import to_checksum_address
-from raiden.utils.typing import AddressTypes
+from eth_utils import decode_hex, encode_hex, is_checksum_address, to_checksum_address
 
 
 class HexedBytes(marshmallow.fields.Field):
@@ -20,7 +17,7 @@ class HexedBytes(marshmallow.fields.Field):
 class ChecksumAddress(marshmallow.fields.Field):
     """ Use `bytes` in the dataclass, serialize to checksum address"""
 
-    def _serialize(self, value: AddressTypes, attr: Any, obj: Any, **kwargs: Any) -> str:
+    def _serialize(self, value: bytes, attr: Any, obj: Any, **kwargs: Any) -> str:
         return to_checksum_address(value)
 
     def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> bytes:

--- a/src/raiden_libs/marshmallow.py
+++ b/src/raiden_libs/marshmallow.py
@@ -4,6 +4,7 @@ import marshmallow
 from eth_utils import decode_hex, encode_hex, is_checksum_address
 
 from raiden.utils.formatting import to_checksum_address
+from raiden.utils.typing import AddressTypes
 
 
 class HexedBytes(marshmallow.fields.Field):
@@ -19,7 +20,7 @@ class HexedBytes(marshmallow.fields.Field):
 class ChecksumAddress(marshmallow.fields.Field):
     """ Use `bytes` in the dataclass, serialize to checksum address"""
 
-    def _serialize(self, value: bytes, attr: Any, obj: Any, **kwargs: Any) -> str:
+    def _serialize(self, value: AddressTypes, attr: Any, obj: Any, **kwargs: Any) -> str:
         return to_checksum_address(value)
 
     def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> bytes:

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -156,6 +156,7 @@ class MatrixListener(gevent.Greenlet):
 
         self._client = make_client(
             handle_messages_callback=self._handle_matrix_sync,
+            handle_member_join_callback=lambda room: None,
             servers=self.available_servers,
             http_pool_maxsize=4,
             http_retry_timeout=40,
@@ -203,7 +204,9 @@ class MatrixListener(gevent.Greenlet):
         try:
             self.user_manager.start()
 
-            login(self._client, signer=LocalSigner(private_key=decode_hex(self.private_key)))
+            login(
+                self._client, signer=LocalSigner(private_key=decode_hex(self.private_key)),
+            )
         except (MatrixRequestError, ValueError):
             raise ConnectionError("Could not login/register to matrix.")
 
@@ -226,7 +229,7 @@ class MatrixListener(gevent.Greenlet):
         if refresh:
             self.user_manager.populate_userids_for_address(address)
             self.user_manager.track_address_presence(
-                address=address, user_ids=self.user_manager.get_userids_for_address(address)
+                address=address, user_ids=self.user_manager.get_userids_for_address(address),
             )
 
         log.debug(

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -18,11 +18,7 @@ from monitoring_service.constants import (
 from raiden.constants import Environment
 from raiden.exceptions import SerializationError, TransportError
 from raiden.messages.abstract import Message, SignedMessage
-from raiden.network.transport.matrix.client import (
-    MatrixMessage,
-    MatrixSyncMessages,
-    Room,
-)
+from raiden.network.transport.matrix.client import MatrixMessage, MatrixSyncMessages, Room
 from raiden.network.transport.matrix.utils import (
     AddressReachability,
     DisplayNameCache,
@@ -108,9 +104,7 @@ def deserialize_messages(
         try:
             message = MessageSerializer.deserialize(line)
         except (SerializationError, ValidationError, KeyError, ValueError) as ex:
-            logger.warning(
-                "Message data JSON is not a valid message", message_data=line, _exc=ex
-            )
+            logger.warning("Message data JSON is not a valid message", message_data=line, _exc=ex)
             continue
 
         if not isinstance(message, SignedMessage):
@@ -118,9 +112,7 @@ def deserialize_messages(
             continue
 
         if message.sender != peer_address:
-            logger.warning(
-                "Message not signed by sender!", message=message, signer=message.sender
-            )
+            logger.warning("Message not signed by sender!", message=message, signer=message.sender)
             continue
 
         messages.append(message)
@@ -211,10 +203,7 @@ class MatrixListener(gevent.Greenlet):
         try:
             self.user_manager.start()
 
-            login(
-                self._client,
-                signer=LocalSigner(private_key=decode_hex(self.private_key)),
-            )
+            login(self._client, signer=LocalSigner(private_key=decode_hex(self.private_key)))
         except (MatrixRequestError, ValueError):
             raise ConnectionError("Could not login/register to matrix.")
 
@@ -226,9 +215,7 @@ class MatrixListener(gevent.Greenlet):
                 client=self._client, broadcast_room_alias=room_alias
             )
 
-            sync_filter_id = self._client.create_sync_filter(
-                rooms=[self._broadcast_room]
-            )
+            sync_filter_id = self._client.create_sync_filter(rooms=[self._broadcast_room])
             self._client.set_sync_filter_id(sync_filter_id)
         except (MatrixRequestError, TransportError):
             raise ConnectionError("Could not join monitoring broadcasting room.")
@@ -239,8 +226,7 @@ class MatrixListener(gevent.Greenlet):
         if refresh:
             self.user_manager.populate_userids_for_address(address)
             self.user_manager.track_address_presence(
-                address=address,
-                user_ids=self.user_manager.get_userids_for_address(address),
+                address=address, user_ids=self.user_manager.get_userids_for_address(address)
             )
 
         log.debug(
@@ -254,9 +240,7 @@ class MatrixListener(gevent.Greenlet):
         """Creates an User from an user_id, if none, or fetch a cached User """
         assert self._broadcast_room
         if user_id in self._broadcast_room._members:  # pylint: disable=protected-access
-            user: User = self._broadcast_room._members[
-                user_id
-            ]  # pylint: disable=protected-access
+            user: User = self._broadcast_room._members[user_id]  # pylint: disable=protected-access
         else:
             user = self._client.get_user(user_id)
 
@@ -275,17 +259,14 @@ class MatrixListener(gevent.Greenlet):
 
         return True
 
-    def _handle_message(
-        self, room: Room, message: MatrixMessage
-    ) -> List[SignedMessage]:
+    def _handle_message(self, room: Room, message: MatrixMessage) -> List[SignedMessage]:
         """ Handle a single Matrix message.
 
         The matrix message is expected to be a NDJSON, and each entry should be
         a valid JSON encoded Raiden message.
         """
         is_valid_type = (
-            message["type"] == "m.room.message"
-            and message["content"]["msgtype"] == "m.text"
+            message["type"] == "m.room.message" and message["content"]["msgtype"] == "m.text"
         )
         if not is_valid_type:
             return []

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 import gevent
 import structlog
-from eth_utils import decode_hex
+from eth_utils import decode_hex, to_checksum_address
 from gevent.event import AsyncResult
 from marshmallow import ValidationError
 from matrix_client.errors import MatrixRequestError
@@ -40,7 +40,6 @@ from raiden.settings import (
 )
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.utils.cli import get_matrix_servers
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import Address, ChainID
 

--- a/src/raiden_libs/register_service.py
+++ b/src/raiden_libs/register_service.py
@@ -3,12 +3,11 @@ from typing import Dict
 
 import click
 import structlog
-from eth_utils import to_hex
+from eth_utils import to_checksum_address, to_hex
 from web3 import Web3
 from web3.contract import Contract, ContractFunction
 from web3.middleware import construct_sign_and_send_raw_middleware
 
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address, BlockNumber
 from raiden_contracts.constants import (
     CONTRACT_CUSTOM_TOKEN,

--- a/tests/monitoring/fixtures/factories.py
+++ b/tests/monitoring/fixtures/factories.py
@@ -1,10 +1,9 @@
 import pytest
-from eth_utils import encode_hex
+from eth_utils import encode_hex, to_checksum_address
 from tests.constants import TEST_MSC_ADDRESS
 
 from monitoring_service.states import HashedBalanceProof
 from raiden.messages.monitoring_service import RequestMonitoring
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import ChannelID, Nonce, TokenAmount, TokenNetworkAddress
 from raiden_contracts.tests.utils.address import get_random_privkey
 from raiden_contracts.utils.type_aliases import ChainID

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -2,13 +2,12 @@ import os
 from typing import List
 from unittest.mock import Mock
 
-from eth_utils import encode_hex, to_canonical_address
+from eth_utils import encode_hex, to_canonical_address, to_checksum_address
 from tests.constants import TEST_MSC_ADDRESS
 
 from monitoring_service.events import ActionMonitoringTriggeredEvent
 from monitoring_service.service import MonitoringService
 from monitoring_service.states import HashedBalanceProof
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     BlockNumber,
     BlockTimeout,

--- a/tests/monitoring/monitoring_service/test_database.py
+++ b/tests/monitoring/monitoring_service/test_database.py
@@ -1,5 +1,6 @@
 import random
 
+from eth_utils import to_checksum_address
 from tests.monitoring.monitoring_service.factories import (
     DEFAULT_TOKEN_NETWORK_ADDRESS,
     create_channel,
@@ -11,7 +12,6 @@ from monitoring_service.events import ActionMonitoringTriggeredEvent, ScheduledE
 from monitoring_service.states import Channel, OnChainUpdateStatus
 from raiden.constants import UINT256_MAX
 from raiden.tests.utils.factories import make_token_network_address
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockNumber,

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -1,15 +1,15 @@
 import gevent
-from eth_utils import decode_hex, encode_hex, to_canonical_address
+from eth_utils import decode_hex, encode_hex, to_canonical_address, to_checksum_address
 from request_collector.server import RequestCollector
 from web3 import Web3
 
 from monitoring_service.service import MonitoringService, handle_event
 from monitoring_service.states import HashedBalanceProof
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockNumber,
     ChainID,
+    MonitoringServiceAddress,
     Nonce,
     TokenAmount,
     TokenNetworkAddress,
@@ -98,7 +98,11 @@ def test_first_allowed_monitoring(
     # c1 asks MS to monitor the channel
     reward_amount = TokenAmount(1)
     request_monitoring = balance_proof_c2.get_request_monitoring(
-        get_private_key(c1), reward_amount, monitoring_service_contract.address
+        privkey=get_private_key(c1),
+        reward_amount=reward_amount,
+        monitoring_service_contract_address=MonitoringServiceAddress(
+            to_canonical_address(monitoring_service_contract.address)
+        ),
     )
     request_collector.on_monitor_request(request_monitoring)
 
@@ -216,7 +220,11 @@ def test_e2e(  # pylint: disable=too-many-arguments,too-many-locals
     # c1 asks MS to monitor the channel
     reward_amount = TokenAmount(1)
     request_monitoring = balance_proof_c2.get_request_monitoring(
-        get_private_key(c1), reward_amount, monitoring_service_contract.address
+        privkey=get_private_key(c1),
+        reward_amount=reward_amount,
+        monitoring_service_contract_address=MonitoringServiceAddress(
+            to_canonical_address(monitoring_service_contract.address)
+        ),
     )
     request_collector.on_monitor_request(request_monitoring)
 

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -2,6 +2,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from eth_utils import to_checksum_address
 from tests.libs.mocks.web3 import Web3Mock
 from tests.monitoring.monitoring_service.factories import (
     DEFAULT_CHANNEL_IDENTIFIER,
@@ -30,7 +31,6 @@ from monitoring_service.handlers import (
     updated_head_block_event_handler,
 )
 from monitoring_service.states import OnChainUpdateStatus
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address, BlockNumber, BlockTimeout, ChannelID, Nonce, TokenAmount
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.tests.utils import get_random_privkey

--- a/tests/monitoring/request_collector/test_server.py
+++ b/tests/monitoring/request_collector/test_server.py
@@ -2,11 +2,11 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from eth_utils import to_checksum_address
 
 from monitoring_service.constants import CHANNEL_CLOSE_MARGIN
 from monitoring_service.states import Channel
 from raiden.storage.serialization.serializer import DictSerializer
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address
 
 

--- a/tests/pathfinding/fixtures/iou.py
+++ b/tests/pathfinding/fixtures/iou.py
@@ -1,9 +1,8 @@
 import pytest
-from eth_utils import encode_hex
+from eth_utils import encode_hex, to_checksum_address
 
 from pathfinding_service.constants import MIN_IOU_EXPIRY
 from pathfinding_service.model import IOU
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address
 from raiden_contracts.utils.proofs import sign_one_to_n_iou
 from raiden_libs.utils import private_key_to_address

--- a/tests/pathfinding/test_database.py
+++ b/tests/pathfinding/test_database.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from typing import List
 from uuid import uuid4
 
+from eth_utils import to_checksum_address
+
 from pathfinding_service.database import PFSDatabase
 from pathfinding_service.model.channel import Channel
 from pathfinding_service.model.feedback import FeedbackToken
@@ -15,7 +17,6 @@ from raiden.tests.utils.factories import (
 )
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -4,14 +4,13 @@ from copy import deepcopy
 from typing import List
 
 import pytest
-from eth_utils import to_canonical_address
+from eth_utils import to_canonical_address, to_checksum_address
 from tests.pathfinding.utils import SimpleReachabilityContainer
 
 from pathfinding_service.constants import DIVERSITY_PEN_DEFAULT
 from pathfinding_service.model import ChannelView, TokenNetwork
 from pathfinding_service.model.channel import Channel
 from raiden.network.transport.matrix import AddressReachability
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockTimeout,

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -4,6 +4,7 @@ from typing import List
 from unittest.mock import Mock, call, patch
 
 import pytest
+from eth_utils import to_checksum_address
 
 from pathfinding_service.model.token_network import PFSFeeUpdate
 from pathfinding_service.service import PathfindingService
@@ -12,7 +13,6 @@ from raiden.messages.synchronization import Processed
 from raiden.tests.utils.factories import make_privkey_address, make_token_network_address
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
-from raiden.utils.formatting import to_checksum_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -290,15 +290,15 @@ def test_logging_processor():
     logger = Mock()
     log_method = Mock()
 
-    address = b"\x7f[\xf6\xc9To\xa8\x185w\xe4\x9f\x15\xbc\xef@mr\xd5\xd9"
+    address = Address(b"\x7f[\xf6\xc9To\xa8\x185w\xe4\x9f\x15\xbc\xef@mr\xd5\xd9")
     address_log = format_to_hex(
         _logger=logger, _log_method=log_method, event_dict=dict(address=address)
     )
     assert to_checksum_address(address) == address_log["address"]
 
-    address2 = b"\x7f[\xf6\xc9To\xa8\x185w\xe4\x9f\x15\xbc\xef@mr\xd5\xd1"
+    address2 = Address(b"\x7f[\xf6\xc9To\xa8\x185w\xe4\x9f\x15\xbc\xef@mr\xd5\xd1")
     event = ReceiveTokenNetworkCreatedEvent(
-        token_address=Address(address),
+        token_address=address,
         token_network_address=TokenNetworkAddress(address2),
         block_number=BlockNumber(1),
     )


### PR DESCRIPTION
With PR [#5734](https://github.com/raiden-network/raiden/pull/5734) the synced event how it is used here is renamed to `processed`. Thats what is desired here in the PFS which is the current sync to be processed.