### PR TITLE
Call `monitor` when first allowed block is mined

### DIFF
--- a/src/monitoring_service/handlers.py
+++ b/src/monitoring_service/handlers.py
@@ -133,11 +133,14 @@ def channel_closed_event_handler(event: Event, context: Context) -> None:
         else:
             non_closing_participant = channel.participant1
 
-        # Transactions go into the next mined block, so trigger one block
+        # Transactions go into the next mined block, so we could trigger one block
         # before the `monitor` call is allowed to succeed to include it in the
         # first possible block.
+        # Unfortunately, parity does the gas estimation on the current block
+        # instead of the next one, so we have to wait for the first allowed
+        # block to be finished to send the transaction successfully on parity.
         trigger_block = BlockNumber(
-            _first_allowed_block_to_monitor(event.token_network_address, channel, context) - 1
+            _first_allowed_block_to_monitor(event.token_network_address, channel, context)
         )
 
         triggered_event = ActionMonitoringTriggeredEvent(

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -131,9 +131,12 @@ def test_first_allowed_monitoring(
     )
     assert channel
 
-    # Calling monitor too early must fail. To test this, we call it one block
+    # Calling monitor too early must fail. To test this, we call it two block
     # before the trigger block.
-    wait_for_blocks(monitor_trigger.trigger_block_number - web3.eth.blockNumber - 1)
+    # This should be only one block before, but we trigger one block too late
+    # to work around parity's gas estimation. See
+    # https://github.com/raiden-network/raiden-services/pull/728
+    wait_for_blocks(monitor_trigger.trigger_block_number - web3.eth.blockNumber - 2)
     handle_event(monitor_trigger.event, monitoring_service.context)
     assert [e.event for e in query()] == []
 


### PR DESCRIPTION
Unfortunately, parity does the gas estimation on the current block instead of the next one, so we have to wait for the first allowed block to be finished to send the transaction successfully on parity.

At least this is what I see from my experimentation. I don't have any parity docs or code snippets to prove it.