### PR TITLE
Structlog can't take `event` as kwarg

### DIFF
--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -71,7 +71,7 @@ def handle_event(event: Event, context: Context) -> None:
                     num_scheduled_events=context.database.scheduled_event_count(),
                 )
             except Exception as ex:  # pylint: disable=broad-except
-                log.error("Error during event handler", event=event, exc_info=ex)
+                log.error("Error during event handler", handled_event=event, exc_info=ex)
                 sentry_sdk.capture_exception(ex)
 
 


### PR DESCRIPTION
That is already used at the name for the first parameter. So if you
write
```python
log.error('Error', event=ev)
```
that is equivalent to
```python
log.error(event='Error', event=ev)
```
which must fail.

Resolves
https://sentry.io/organizations/raiden-network/issues/1262420995/?project=1509055.