### PR TITLE
Fix reward claim

### DIFF
--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -58,7 +58,12 @@ def handle_event(event: Event, context: Context) -> None:
     Exceptions are caught and generate both error logs and sentry issues.
     Events are not retried after an exception.
     """
-    log.debug("Processing event", event_=event)
+    log.debug(
+        "Processing event",
+        event_=event,
+        latest_confirmed_block=context.latest_confirmed_block,
+        latest_unconfirmed_block=context.get_latest_unconfirmed_block(),
+    )
     handler = HANDLERS.get(type(event))
 
     if handler:


### PR DESCRIPTION
Fixes #734 

This fixes the claim of the MS reward by pushing the transaction back one block. This is necessary because of the same parity problem we already discovered in https://github.com/raiden-network/raiden-services/pull/728

As we have no time pressure to claim early, adding one block doesn't hurt.

I locally tested this with MS1 and it fixed the run.