### PR TITLE
Add override for `registration-goerli-backup`

### DIFF
--- a/deployment/docker-compose.latest.yml
+++ b/deployment/docker-compose.latest.yml
@@ -65,6 +65,9 @@ services:
   registration-goerli:
     <<: *defaults
 
+  registration-goerli-backup:
+    <<: *defaults
+
   builder:
     environment:
       - HOSTNAME=services-dev


### PR DESCRIPTION
This was missing, so the container started on the `stable` instead of
the `latest` image.