### PR TITLE
Remove default values for prameters in services

### DIFF
--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -9,7 +9,7 @@ from web3.contract import Contract
 from monitoring_service.constants import MS_DISCLAIMER
 from monitoring_service.service import MonitoringService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
-from raiden.utils.typing import BlockNumber
+from raiden.utils.typing import BlockNumber, BlockTimeout
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_SERVICE_REGISTRY,
@@ -18,7 +18,7 @@ from raiden_contracts.constants import (
 )
 from raiden_libs.blockchain import get_web3_provider_info
 from raiden_libs.cli import blockchain_options, common_options, setup_sentry
-from raiden_libs.constants import CONFIRMATION_OF_UNDERSTANDING
+from raiden_libs.constants import CONFIRMATION_OF_UNDERSTANDING, DEFAULT_POLL_INTERVALL
 
 log = structlog.get_logger(__name__)
 
@@ -64,7 +64,7 @@ def main(  # pylint: disable=too-many-arguments
     web3: Web3,
     contracts: Dict[str, Contract],
     start_block: BlockNumber,
-    confirmations: BlockNumber,
+    confirmations: BlockTimeout,
     min_reward: int,
     debug_shell: bool,
     accept_disclaimer: bool,
@@ -86,6 +86,7 @@ def main(  # pylint: disable=too-many-arguments
         contracts=contracts,
         sync_start_block=start_block,
         required_confirmations=confirmations,
+        poll_interval=DEFAULT_POLL_INTERVALL,
         db_filename=state_db,
         min_reward=min_reward,
     )

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -20,8 +20,7 @@ from monitoring_service.constants import (
 )
 from monitoring_service.database import Database
 from monitoring_service.handlers import HANDLERS, Context
-from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
-from raiden.utils.typing import BlockNumber, ChainID, MonitoringServiceAddress
+from raiden.utils.typing import BlockNumber, BlockTimeout, ChainID, MonitoringServiceAddress
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_SERVICE_REGISTRY,
@@ -88,9 +87,9 @@ class MonitoringService:  # pylint: disable=too-few-public-methods,too-many-inst
         private_key: str,
         db_filename: str,
         contracts: Dict[str, Contract],
-        sync_start_block: BlockNumber = BlockNumber(0),
-        required_confirmations: int = DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
-        poll_interval: float = 1,
+        sync_start_block: BlockNumber,
+        required_confirmations: BlockTimeout,
+        poll_interval: float,
         min_reward: int = 0,
     ):
         self.web3 = web3

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -15,15 +15,10 @@ from web3 import Web3
 from web3.contract import Contract
 
 from pathfinding_service.api import ServiceApi
-from pathfinding_service.constants import (
-    DEFAULT_API_HOST,
-    DEFAULT_INFO_MESSAGE,
-    DEFAULT_POLL_INTERVALL,
-    PFS_DISCLAIMER,
-)
+from pathfinding_service.constants import DEFAULT_API_HOST, DEFAULT_INFO_MESSAGE, PFS_DISCLAIMER
 from pathfinding_service.service import PathfindingService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
-from raiden.utils.typing import BlockNumber, TokenAmount
+from raiden.utils.typing import BlockNumber, BlockTimeout, TokenAmount
 from raiden_contracts.constants import (
     CONTRACT_ONE_TO_N,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -31,7 +26,7 @@ from raiden_contracts.constants import (
 )
 from raiden_libs.blockchain import get_web3_provider_info
 from raiden_libs.cli import blockchain_options, common_options, setup_sentry
-from raiden_libs.constants import CONFIRMATION_OF_UNDERSTANDING
+from raiden_libs.constants import CONFIRMATION_OF_UNDERSTANDING, DEFAULT_POLL_INTERVALL
 
 log = structlog.get_logger(__name__)
 
@@ -83,7 +78,7 @@ def main(  # pylint: disable=too-many-arguments,too-many-locals
     web3: Web3,
     contracts: Dict[str, Contract],
     start_block: BlockNumber,
-    confirmations: int,
+    confirmations: BlockTimeout,
     host: str,
     service_fee: TokenAmount,
     operator: str,

--- a/src/pathfinding_service/constants.py
+++ b/src/pathfinding_service/constants.py
@@ -18,7 +18,6 @@ DEFAULT_REVEAL_TIMEOUT: BlockTimeout = BlockTimeout(50)
 
 DEFAULT_SETTLE_TO_REVEAL_TIMEOUT_RATIO = 2
 
-DEFAULT_POLL_INTERVALL = 2
 DEFAULT_INFO_MESSAGE = "This is your favorite PFS."
 
 # When a new IOU session is started, this is the minimum number of blocks

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -25,7 +25,7 @@ from pathfinding_service.typing import DeferableMessage
 from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, UINT256_MAX
 from raiden.messages.abstract import Message
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
-from raiden.utils.typing import BlockNumber, ChainID, TokenNetworkAddress
+from raiden.utils.typing import BlockNumber, BlockTimeout, ChainID, TokenNetworkAddress
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_libs.blockchain import get_blockchain_events
 from raiden_libs.constants import MATRIX_START_TIMEOUT
@@ -62,9 +62,9 @@ class PathfindingService(gevent.Greenlet):
         contracts: Dict[str, Contract],
         private_key: str,
         db_filename: str,
-        sync_start_block: BlockNumber = BlockNumber(0),
-        required_confirmations: int = 8,
-        poll_interval: float = 10,
+        sync_start_block: BlockNumber,
+        required_confirmations: BlockTimeout,
+        poll_interval: float,
         matrix_servers: Optional[List[str]] = None,
     ):
         super().__init__()

--- a/src/raiden_libs/constants.py
+++ b/src/raiden_libs/constants.py
@@ -8,3 +8,5 @@ MATRIX_START_TIMEOUT = 30  # in seconds
 CONFIRMATION_OF_UNDERSTANDING = (
     "Have you read, understood and hereby accept the above disclaimer and privacy warning?"
 )
+
+DEFAULT_POLL_INTERVALL = 2

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -11,7 +11,13 @@ from web3 import Web3
 
 from monitoring_service.database import Database
 from monitoring_service.service import MonitoringService
-from raiden.utils.typing import Address, ChainID, MonitoringServiceAddress
+from raiden.utils.typing import (
+    Address,
+    BlockNumber,
+    BlockTimeout,
+    ChainID,
+    MonitoringServiceAddress,
+)
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_SERVICE_REGISTRY,
@@ -73,7 +79,8 @@ def monitoring_service(  # pylint: disable=too-many-arguments
             CONTRACT_USER_DEPOSIT: user_deposit_contract,
             CONTRACT_SERVICE_REGISTRY: service_registry,
         },
-        required_confirmations=0,  # for faster tests
+        sync_start_block=BlockNumber(0),
+        required_confirmations=BlockTimeout(0),  # for faster tests
         poll_interval=0.01,  # for faster tests
         db_filename=":memory:",
     )

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -94,6 +94,9 @@ def test_crash(
             private_key=server_private_key,
             contracts=contracts,  # type: ignore
             db_filename=os.path.join(tmpdir, filename),
+            poll_interval=0,
+            required_confirmations=BlockTimeout(0),
+            sync_start_block=BlockNumber(0),
         )
         msc = Mock()
         ms.context.monitoring_service_contract = msc

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -16,6 +16,7 @@ from raiden.network.transport.matrix import AddressReachability
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.utils.typing import (
     Address,
+    BlockNumber,
     BlockTimeout,
     ChainID,
     ChannelID,
@@ -297,6 +298,9 @@ def pathfinding_service_mock_empty() -> Generator[PathfindingService, None, None
                 CONTRACT_TOKEN_NETWORK_REGISTRY: Mock(address=bytes([9] * 20)),
                 CONTRACT_USER_DEPOSIT: mock_udc,
             },
+            sync_start_block=BlockNumber(0),
+            required_confirmations=BlockTimeout(0),
+            poll_interval=0,
             private_key="3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266",
             db_filename=":memory:",
         )
@@ -333,9 +337,11 @@ def pathfinding_service_web3_mock(
                 CONTRACT_TOKEN_NETWORK_REGISTRY: Mock(address="0x" + "9" * 40),
                 CONTRACT_USER_DEPOSIT: user_deposit_contract,
             },
+            sync_start_block=BlockNumber(0),
+            required_confirmations=BlockTimeout(1),
+            poll_interval=0,
             private_key=get_private_key(pfs_address),
             db_filename=":memory:",
-            required_confirmations=1,
         )
 
         yield pathfinding_service

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -13,7 +13,7 @@ from monitoring_service.states import HashedBalanceProof
 from pathfinding_service.constants import DEFAULT_REVEAL_TIMEOUT
 from pathfinding_service.model import ChannelView
 from pathfinding_service.service import PathfindingService
-from raiden.utils.typing import BlockNumber, ChainID, Nonce, TokenNetworkAddress
+from raiden.utils.typing import BlockNumber, BlockTimeout, ChainID, Nonce, TokenNetworkAddress
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
@@ -48,7 +48,7 @@ def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
                 CONTRACT_TOKEN_NETWORK_REGISTRY: token_network_registry_contract,
                 CONTRACT_USER_DEPOSIT: user_deposit_contract,
             },
-            required_confirmations=1,
+            required_confirmations=BlockTimeout(1),
             db_filename=":memory:",
             poll_interval=0.1,
             sync_start_block=BlockNumber(0),

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -125,6 +125,9 @@ def test_crash(tmpdir, mockchain):  # pylint: disable=too-many-locals
             web3=Web3Mock(),
             private_key=server_private_key,
             contracts=contracts,  # type: ignore
+            sync_start_block=BlockNumber(0),
+            required_confirmations=BlockTimeout(0),
+            poll_interval=0,
             db_filename=os.path.join(tmpdir, filename),
         )
         return service


### PR DESCRIPTION
The defaults made it hard to understand which setting was used where,
now stuff is a bit longer but more explicit.