### PR TITLE
Check block numbers instead of locking exclusively

### DIFF
--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -45,16 +45,6 @@ class PFSDatabase(BaseDatabase):
         super().__init__(filename, allow_create=allow_create)
         self.pfs_address = pfs_address
 
-        # Forbid concurrent access to the database. This fixes a class of
-        # DevOPS bugs were more than once process uses the same database,
-        # because of the lack of synchronization around the update of the
-        # confirmed block number this can lead to missing blockchain events.
-        # (Issue #5443).
-        #
-        # https://sqlite.org/atomiccommit.html#_exclusive_access_mode
-        # https://sqlite.org/pragma.html#pragma_locking_mode
-        self.conn.execute("PRAGMA locking_mode=EXCLUSIVE")
-
         # Keep the journal around and skip inode updates.
         # References:
         # https://sqlite.org/atomiccommit.html#_persistent_rollback_journals


### PR DESCRIPTION
In https://github.com/raiden-network/raiden/issues/5443, we had a problem with two PFSs sharing the same DB, which
lead to each of the PFSs processing roughly half of the blocks. Since
that was time consuming to debug, we should prevent that situation from
happening, again.

Our first approach was to prevent any access to the db by other
processes by acquiring an exclusive lock during the whole PFS runtime.
But this also prevents us from claiming PFS fees while the PFS is
running, since we need to mark the claimed IOUs in the db.

Using a single transaction when processing a block does not solve this
problems, since each PFS could still read the block number, process the
block and save the block number without any conflict. The processing of
blocks would only be serialized between the two PFSs, which does not
solve the problem.

The solution is to keep the last processed block in memory, so that
other processes writing to the db will not cause skipped blocks. To make
the bad situation of two PFSs on on db obvious, an assert is added that
compares the block number in memory with the one in the db.