### PR TITLE
Add cli option to set PFS port

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -23,8 +23,6 @@ from web3 import Web3
 import pathfinding_service.exceptions as exceptions
 from pathfinding_service.constants import (
     API_PATH,
-    DEFAULT_API_HOST,
-    DEFAULT_API_PORT,
     DEFAULT_INFO_MESSAGE,
     DEFAULT_MAX_PATHS,
     MAX_AGE_OF_IOU_REQUESTS,
@@ -580,7 +578,7 @@ class ServiceApi:
                 resource, endpoint_url, resource_class_kwargs=kwargs, endpoint=endpoint
             )
 
-    def run(self, host: str = DEFAULT_API_HOST, port: int = DEFAULT_API_PORT) -> None:
+    def run(self, host: str, port: int) -> None:
         self.rest_server = WSGIServer((host, port), self.flask_app)
         self.rest_server.start()
 

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -15,7 +15,12 @@ from web3 import Web3
 from web3.contract import Contract
 
 from pathfinding_service.api import ServiceApi
-from pathfinding_service.constants import DEFAULT_API_HOST, DEFAULT_INFO_MESSAGE, PFS_DISCLAIMER
+from pathfinding_service.constants import (
+    DEFAULT_API_HOST,
+    DEFAULT_API_PORT,
+    DEFAULT_INFO_MESSAGE,
+    PFS_DISCLAIMER,
+)
 from pathfinding_service.service import PathfindingService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.utils.typing import BlockNumber, BlockTimeout, TokenAmount
@@ -37,6 +42,9 @@ log = structlog.get_logger(__name__)
 @click.command()
 @click.option(
     "--host", default=DEFAULT_API_HOST, type=str, help="The host to use for serving the REST API"
+)
+@click.option(
+    "--port", default=DEFAULT_API_PORT, type=int, help="The port to use for serving the REST API"
 )
 @click.option(
     "--service-fee",
@@ -80,6 +88,7 @@ def main(  # pylint: disable=too-many-arguments,too-many-locals
     start_block: BlockNumber,
     confirmations: BlockTimeout,
     host: str,
+    port: int,
     service_fee: TokenAmount,
     operator: str,
     info_message: str,
@@ -127,7 +136,7 @@ def main(  # pylint: disable=too-many-arguments,too-many-locals
             operator=operator,
             info_message=info_message,
         )
-        api.run(host=host)
+        api.run(host=host, port=port)
 
         service.get()
     except (KeyboardInterrupt, SystemExit):

--- a/tests/pathfinding/fixtures/api.py
+++ b/tests/pathfinding/fixtures/api.py
@@ -5,7 +5,7 @@ from typing import Iterator
 import pytest
 
 from pathfinding_service.api import ServiceApi
-from pathfinding_service.constants import API_PATH
+from pathfinding_service.constants import API_PATH, DEFAULT_API_HOST
 from raiden.utils.typing import Address
 
 from ..utils import SimpleReachabilityContainer
@@ -38,7 +38,7 @@ def api_sut(
         one_to_n_address=Address(bytes([1] * 20)),
         operator="",
     )
-    api.run(port=free_port)
+    api.run(host=DEFAULT_API_HOST, port=free_port)
     yield api
     api.stop()
 
@@ -58,6 +58,6 @@ def api_sut_with_debug(
         operator="",
         info_message="",
     )
-    api.run(port=free_port)
+    api.run(host=DEFAULT_API_HOST, port=free_port)
     yield api
     api.stop()


### PR DESCRIPTION
As @kelsos noticed, we don't provide a way to choose the port used by
the PFS. This is an unusual and unnecessary limitation for a service.