### PR TITLE
Add matrix server to info endpoint

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -417,6 +417,7 @@ class InfoResource(PathfinderResource):
             "message": self.service_api.info_message,
             "payment_address": to_checksum_address(self.pathfinding_service.address),
             "UTC": datetime.utcnow().isoformat(),
+            "matrix_server": self.service_api.pathfinding_service.matrix_listener.base_url,
         }
         return info, 200
 

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -163,6 +163,7 @@ class MatrixListener(gevent.Greenlet):
         )
         self._broadcast_room: Optional[Room] = None
         self._displayname_cache = DisplayNameCache()
+        self.base_url = self._client.api.base_url
 
         self.user_manager = UserAddressManager(
             client=self._client,

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -318,6 +318,7 @@ def pathfinding_service_mock(
         token_network_model.address: token_network_model
     }
     pathfinding_service_mock_empty.database.upsert_token_network(token_network_model.address)
+    pathfinding_service_mock_empty.matrix_listener.base_url = "https://matrix.server"
 
     yield pathfinding_service_mock_empty
 

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -433,6 +433,7 @@ def test_get_info(api_url: str, api_sut, pathfinding_service_mock):
         "operator": "John Doe",
         "message": DEFAULT_INFO_MESSAGE,
         "payment_address": to_checksum_address(pathfinding_service_mock.address),
+        "matrix_server": "https://matrix.server",
     }
     response = requests.get(url)
     assert response.status_code == 200


### PR DESCRIPTION
This allows checking whether the PFS and client are connected to the
same matrix federation.