### PR TITLE
Change MS DEFAULT_MIN_REWARD to Raiden's default

### DIFF
--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -6,7 +6,7 @@ from eth_utils import to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
 
-from monitoring_service.constants import MS_DISCLAIMER
+from monitoring_service.constants import DEFAULT_MIN_REWARD, MS_DISCLAIMER
 from monitoring_service.service import MonitoringService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.utils.typing import BlockNumber, BlockTimeout
@@ -34,7 +34,7 @@ log = structlog.get_logger(__name__)
 @click.command()
 @click.option(
     "--min-reward",
-    default=0,
+    default=DEFAULT_MIN_REWARD,
     type=click.IntRange(min=0),
     help="Minimum reward which is required before processing requests",
 )

--- a/src/monitoring_service/constants.py
+++ b/src/monitoring_service/constants.py
@@ -6,6 +6,9 @@ MAX_FILTER_INTERVAL: int = 100_000
 DEFAULT_GAS_BUFFER_FACTOR: int = 10
 DEFAULT_GAS_CHECK_BLOCKS: int = 100
 KEEP_MRS_WITHOUT_CHANNEL: timedelta = timedelta(minutes=15)
+# Make sure this stays <= Raiden's MONITORING_REWARD until there is a way to
+# inform Raiden about the expected rewards.
+DEFAULT_MIN_REWARD = 5 * 10 ** 18
 
 # A LockedTransfer message is roughly 1kb. Having 1000/min = 17/sec will be
 # hard to achieve outside of benchmarks for now. To have some safety margin for


### PR DESCRIPTION
We don't have a communication channel to establish a good reward during
runtime, so using the same fixed value is best in the meantime.
This also prevents MS operators from accidentally not demanding a
reward, which is a bad idea since they have to pay transaction fees.