### PR TITLE
Add gas price CLI option

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ coverage>=4.5.4
 ipython==4.2.1
 pdbpp
 
-eth-tester[py-evm]==0.4.0b1
+eth-tester[py-evm]==0.4.0b2
 
 # Release
 bump2version


### PR DESCRIPTION
This adds the `--gas-price` CLI option from raiden to the services. 

It doesn't make much sense for the PFS, so one could argue to move it out of  `blockchain_options` or make it optional.