### PR TITLE
Catch TransportError if displayname can not be read

### DIFF
--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -276,7 +276,13 @@ class MatrixListener(gevent.Greenlet):
 
         sender_id = message["sender"]
         user = self._get_user_from_user_id(sender_id)
-        self._displayname_cache.warm_users([user])
+        try:
+            self._displayname_cache.warm_users([user])
+        # handles the "Could not get 'display_name' for user" case
+        except TransportError as ex:
+            log.error("Could not warm display cache", peer_user=user.user_id, error=str(ex))
+            return []
+
         peer_address = validate_userid_signature(user)
 
         if not peer_address:


### PR DESCRIPTION
In that case just skip the message.

Related to https://github.com/raiden-network/raiden/issues/6128