### PR TITLE
Adaptive blockchain syncing

### DIFF
--- a/src/monitoring_service/constants.py
+++ b/src/monitoring_service/constants.py
@@ -1,8 +1,11 @@
 import textwrap
 from datetime import timedelta
 
-DEFAULT_REQUIRED_CONFIRMATIONS: int = 10
-MAX_FILTER_INTERVAL: int = 100_000
+from raiden.utils.typing import BlockTimeout
+
+DEFAULT_FILTER_INTERVAL: BlockTimeout = BlockTimeout(1_000)
+MAX_FILTER_INTERVAL: BlockTimeout = BlockTimeout(100_000)
+MIN_FILTER_INTERVAL: BlockTimeout = BlockTimeout(2)
 DEFAULT_GAS_BUFFER_FACTOR: int = 10
 DEFAULT_GAS_CHECK_BLOCKS: int = 100
 KEEP_MRS_WITHOUT_CHANNEL: timedelta = timedelta(minutes=15)

--- a/src/raiden_libs/blockchain.py
+++ b/src/raiden_libs/blockchain.py
@@ -151,17 +151,21 @@ def get_blockchain_events(
     web3: Web3,
     contract_manager: ContractManager,
     chain_state: BlockchainState,
+    from_block: BlockNumber,
     to_block: BlockNumber,
 ) -> Tuple[BlockchainState, List[Event]]:
-    # increment by one, as `latest_committed_block` has been queried last time already
-    from_block = BlockNumber(chain_state.latest_committed_block + 1)
-
     # Check if the current block was already processed
     if from_block > to_block:
         return chain_state, []
 
     new_chain_state = deepcopy(chain_state)
-    log.info("Querying new block(s)", from_block=from_block, end_block=to_block)
+    log.info(
+        "Querying new block(s)",
+        from_block=from_block,
+        to_block=to_block,
+        # When `to_block` == `from_block` we query one block, so add one
+        num_blocks=to_block - from_block + 1,
+    )
 
     # first check for new token networks and add to state
     registry_events = query_blockchain_events(

--- a/src/raiden_libs/states.py
+++ b/src/raiden_libs/states.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-from raiden.utils.typing import Address, BlockNumber, ChainID, TokenNetworkAddress
+from monitoring_service.constants import DEFAULT_FILTER_INTERVAL
+from raiden.utils.typing import Address, BlockNumber, BlockTimeout, ChainID, TokenNetworkAddress
 
 
 @dataclass
@@ -11,3 +12,4 @@ class BlockchainState:
     latest_committed_block: BlockNumber
     monitor_contract_address: Optional[Address] = None
     token_network_addresses: List[TokenNetworkAddress] = field(default_factory=list)
+    current_event_filter_interval: BlockTimeout = DEFAULT_FILTER_INTERVAL

--- a/tests/libs/fixtures/web3.py
+++ b/tests/libs/fixtures/web3.py
@@ -8,6 +8,7 @@ from eth_account import Account
 from tests.constants import KEYSTORE_FILE_NAME, KEYSTORE_PASSWORD
 from web3 import Web3
 
+from raiden.utils.typing import BlockNumber
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_libs.events import Event
 from raiden_libs.states import BlockchainState
@@ -48,14 +49,13 @@ def keystore_file(tmp_path) -> str:
 def mockchain(monkeypatch):
     state: Dict[str, List[List[Event]]] = dict(block_events=[])
 
-    def get_events(
+    def get_blockchain_events(
         web3: Web3,
         contract_manager: ContractManager,
         chain_state: BlockchainState,
-        to_block: int,
-        query_ms: bool = True,
+        from_block: BlockNumber,
+        to_block: BlockNumber,
     ):  # pylint: disable=unused-argument
-        from_block = chain_state.latest_committed_block + 1
         blocks = state["block_events"][from_block : to_block + 1]
         events = [ev for block in blocks for ev in block]  # flatten
         return chain_state, events
@@ -63,6 +63,6 @@ def mockchain(monkeypatch):
     def set_events(events):
         state["block_events"] = events
 
-    monkeypatch.setattr("monitoring_service.service.get_blockchain_events", get_events)
-    monkeypatch.setattr("pathfinding_service.service.get_blockchain_events", get_events)
+    monkeypatch.setattr("monitoring_service.service.get_blockchain_events", get_blockchain_events)
+    monkeypatch.setattr("pathfinding_service.service.get_blockchain_events", get_blockchain_events)
     return set_events

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -26,6 +26,7 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.tests.utils import get_random_address, get_random_privkey
 from raiden_libs.events import ReceiveChannelOpenedEvent, UpdatedHeadBlockEvent
+from raiden_libs.states import BlockchainState
 
 from ...libs.mocks.web3 import ContractMock, Web3Mock
 
@@ -125,7 +126,7 @@ def test_crash(
         stable_ms.monitor_mock.reset_mock()  # clear calls from last block
         result_state: List[dict] = []
         for ms in [stable_ms, crashy_ms]:
-            ms._process_new_blocks(to_block)  # pylint: disable=protected-access
+            ms._process_new_blocks(BlockNumber(to_block))  # pylint: disable=protected-access
             result_state.append(
                 dict(
                     blockchain_state=ms.context.ms_state.blockchain_state,
@@ -136,5 +137,17 @@ def test_crash(
 
         # both instances should have the same state after processing
         for stable_state, crashy_state in zip(result_state[0].values(), result_state[1].values()):
-            # do asserts for each key separately to get better error messages
-            assert stable_state == crashy_state
+            if isinstance(stable_state, BlockchainState):
+                assert stable_state.chain_id == crashy_state.chain_id
+                assert (
+                    stable_state.token_network_registry_address
+                    == crashy_state.token_network_registry_address
+                )
+                assert stable_state.latest_committed_block == crashy_state.latest_committed_block
+                assert (
+                    stable_state.monitor_contract_address == crashy_state.monitor_contract_address
+                )
+                assert stable_state.token_network_addresses == crashy_state.token_network_addresses
+                # Do not compare `current_event_filter_interval`, this is allowed to be different
+            else:
+                assert stable_state == crashy_state


### PR DESCRIPTION
This PR adds adaptive blockchain syncing to the services similar to what https://github.com/raiden-network/raiden/pull/6092 did in Raiden.

Mid-term we should try to merge the two systems as there is a lot of duplicated effort.

This is the minimal impact PR I could build, I have some refactorings at hand but are hesitant to merge them so close to release.

This measures the time the `eth_getLogs` RPC call takes and adjusts the query range accordingly. In comparison to https://github.com/raiden-network/raiden/pull/6092 I chose to reduce the range more aggressively when a timeout is hit.



Resolves https://github.com/raiden-network/raiden-services/issues/782
