### PR TITLE
WIP: Further refactor

### DIFF
--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -164,14 +164,17 @@ class MonitoringService:  # pylint: disable=too-few-public-methods,too-many-inst
         from_block = BlockNumber(blockchain_state.latest_committed_block + 1)
         to_block = min(
             latest_confirmed_block,
-            BlockNumber(from_block + blockchain_state.current_event_filter_interval),
+            # decrement by one, as both limits are inclusive
+            BlockNumber(from_block + blockchain_state.current_event_filter_interval - 1),
         )
+        token_network_addresses = self.context.database.get_token_network_addresses()
 
         try:
             before_query = time.monotonic()
-            new_chain_state, events = get_blockchain_events(
+            events = get_blockchain_events(
                 web3=self.web3,
                 contract_manager=CONTRACT_MANAGER,
+                token_network_addresses=token_network_addresses,
                 chain_state=blockchain_state,
                 from_block=from_block,
                 to_block=to_block,
@@ -180,11 +183,11 @@ class MonitoringService:  # pylint: disable=too-few-public-methods,too-many-inst
 
             filter_query_duration = after_query - before_query
             if filter_query_duration < ETH_GET_LOGS_THRESHOLD_FAST:
-                new_chain_state.current_event_filter_interval = BlockTimeout(
+                blockchain_state.current_event_filter_interval = BlockTimeout(
                     min(MAX_FILTER_INTERVAL, blockchain_state.current_event_filter_interval * 2)
                 )
             elif filter_query_duration > ETH_GET_LOGS_THRESHOLD_SLOW:
-                new_chain_state.current_event_filter_interval = BlockTimeout(
+                blockchain_state.current_event_filter_interval = BlockTimeout(
                     max(MIN_FILTER_INTERVAL, blockchain_state.current_event_filter_interval // 2)
                 )
         except ReadTimeout:
@@ -199,18 +202,6 @@ class MonitoringService:  # pylint: disable=too-few-public-methods,too-many-inst
             )
             return
 
-        # If a new token network was found we need to write it to the DB, otherwise
-        # the constraints for new channels will not be constrained. But only update
-        # the network addresses here, all else is done later.
-        token_networks_changed = (
-            blockchain_state.token_network_addresses != new_chain_state.token_network_addresses
-        )
-        if token_networks_changed:
-            blockchain_state.token_network_addresses = new_chain_state.token_network_addresses
-            self.context.database.update_blockchain_state(blockchain_state)
-
-        # Now set the updated chain state to the context, will be stored later
-        self.context.ms_state.blockchain_state = new_chain_state
         for event in events:
             handle_event(event, self.context)
 

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -167,20 +167,21 @@ class PathfindingService(gevent.Greenlet):
             f"was {db_block}, expected {self.blockchain_state.latest_committed_block}. "
             f"Is the db accidentally shared by two PFSes?"
         )
-        self.blockchain_state.token_network_addresses = list(self.token_networks.keys())
 
         # increment by one, as `latest_committed_block` has been queried last time already
         from_block = BlockNumber(self.blockchain_state.latest_committed_block + 1)
         to_block = min(
             latest_confirmed_block,
-            BlockNumber(from_block + self.blockchain_state.current_event_filter_interval),
+            # decrement by one, as both limits are inclusive
+            BlockNumber(from_block + self.blockchain_state.current_event_filter_interval - 1),
         )
 
         try:
             before_query = time.monotonic()
-            _, events = get_blockchain_events(
+            events = get_blockchain_events(
                 web3=self.web3,
                 contract_manager=CONTRACT_MANAGER,
+                token_network_addresses=list(self.token_networks.keys()),
                 chain_state=self.blockchain_state,
                 from_block=from_block,
                 to_block=to_block,

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -9,11 +9,9 @@ import sentry_sdk
 import structlog
 from eth_utils import to_canonical_address
 from gevent import Timeout
-from requests.exceptions import ReadTimeout
 from web3 import Web3
 from web3.contract import Contract
 
-from monitoring_service.constants import MAX_FILTER_INTERVAL, MIN_FILTER_INTERVAL
 from pathfinding_service.database import PFSDatabase
 from pathfinding_service.exceptions import (
     InvalidCapacityUpdate,
@@ -23,19 +21,13 @@ from pathfinding_service.exceptions import (
 from pathfinding_service.model import TokenNetwork
 from pathfinding_service.model.channel import Channel
 from pathfinding_service.typing import DeferableMessage
-from raiden.constants import (
-    ETH_GET_LOGS_THRESHOLD_FAST,
-    ETH_GET_LOGS_THRESHOLD_SLOW,
-    PATH_FINDING_BROADCASTING_ROOM,
-    UINT256_MAX,
-)
+from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, UINT256_MAX
 from raiden.messages.abstract import Message
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
 from raiden.utils.typing import BlockNumber, BlockTimeout, ChainID, TokenNetworkAddress
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
-from raiden_libs.blockchain import get_blockchain_events
+from raiden_libs.blockchain import get_blockchain_events_adaptive
 from raiden_libs.constants import MATRIX_START_TIMEOUT
-from raiden_libs.contract_info import CONTRACT_MANAGER
 from raiden_libs.events import (
     Event,
     ReceiveChannelClosedEvent,
@@ -161,6 +153,7 @@ class PathfindingService(gevent.Greenlet):
 
     def _process_new_blocks(self, latest_confirmed_block: BlockNumber) -> None:
         start = time.monotonic()
+
         db_block = self.database.get_latest_committed_block()
         assert db_block == self.blockchain_state.latest_committed_block, (
             f"Unexpected `latest_committed_block` in db: "
@@ -168,51 +161,14 @@ class PathfindingService(gevent.Greenlet):
             f"Is the db accidentally shared by two PFSes?"
         )
 
-        # increment by one, as `latest_committed_block` has been queried last time already
-        from_block = BlockNumber(self.blockchain_state.latest_committed_block + 1)
-        to_block = min(
-            latest_confirmed_block,
-            # decrement by one, as both limits are inclusive
-            BlockNumber(from_block + self.blockchain_state.current_event_filter_interval - 1),
+        events = get_blockchain_events_adaptive(
+            web3=self.web3,
+            blockchain_state=self.blockchain_state,
+            token_network_addresses=list(self.token_networks.keys()),
+            latest_confirmed_block=latest_confirmed_block,
         )
 
-        try:
-            before_query = time.monotonic()
-            events = get_blockchain_events(
-                web3=self.web3,
-                contract_manager=CONTRACT_MANAGER,
-                token_network_addresses=list(self.token_networks.keys()),
-                chain_state=self.blockchain_state,
-                from_block=from_block,
-                to_block=to_block,
-            )
-            after_query = time.monotonic()
-
-            filter_query_duration = after_query - before_query
-            if filter_query_duration < ETH_GET_LOGS_THRESHOLD_FAST:
-                self.blockchain_state.current_event_filter_interval = BlockTimeout(
-                    min(
-                        MAX_FILTER_INTERVAL,
-                        self.blockchain_state.current_event_filter_interval * 2,
-                    )
-                )
-            elif filter_query_duration > ETH_GET_LOGS_THRESHOLD_SLOW:
-                self.blockchain_state.current_event_filter_interval = BlockTimeout(
-                    max(
-                        MIN_FILTER_INTERVAL,
-                        self.blockchain_state.current_event_filter_interval // 2,
-                    )
-                )
-        except ReadTimeout:
-            old_interval = self.blockchain_state.current_event_filter_interval
-            self.blockchain_state.current_event_filter_interval = BlockTimeout(
-                max(MIN_FILTER_INTERVAL, old_interval // 5)
-            )
-            log.debug(
-                "Failed to query events in time, reducing interval",
-                old_interval=old_interval,
-                new_interval=self.blockchain_state.current_event_filter_interval,
-            )
+        if events is None:
             return
 
         before_process = time.monotonic()
@@ -222,10 +178,8 @@ class PathfindingService(gevent.Greenlet):
 
         if events:
             log.info(
-                "Processed blocks",
-                from_block=from_block,
-                to_block=to_block,
-                getting=round(before_process - before_query, 2),
+                "Processed events",
+                getting=round(before_process - start, 2),
                 processing=round(time.monotonic() - before_process, 2),
                 total_duration=round(time.monotonic() - start, 2),
                 event_counts=collections.Counter(e.__class__.__name__ for e in events),

--- a/src/raiden_libs/blockchain.py
+++ b/src/raiden_libs/blockchain.py
@@ -17,6 +17,7 @@ from raiden.utils.typing import (
     Address,
     BlockNumber,
     BlockTimeout,
+    TokenAddress,
     TokenAmount,
     TokenNetworkAddress,
 )
@@ -203,7 +204,9 @@ def get_blockchain_events(
         events.append(
             ReceiveTokenNetworkCreatedEvent(
                 token_network_address=token_network_address,
-                token_address=to_canonical_address(event_dict["args"]["token_address"]),
+                token_address=TokenAddress(
+                    to_canonical_address(event_dict["args"]["token_address"])
+                ),
                 block_number=event_dict["blockNumber"],
             )
         )

--- a/src/raiden_libs/blockchain.py
+++ b/src/raiden_libs/blockchain.py
@@ -321,8 +321,11 @@ def get_blockchain_events_adaptive(
 
     Args:
         web3: Web3 object
-        blockchain_state: This is mutated
-        token_network_addresses: List of known token network addresses
+        blockchain_state: The blockchain state objected. This is mutated and should be reused.
+        token_network_addresses: List of known token network addresses. This is mutated when a
+            new token network is found. However, additionally a `ReceiveTokenNetworkCreatedEvent`
+            is created as well and it is recommended to use that instead and to not reuse
+            this list.
         latest_confirmed_block: The latest block to query to
 
     Returns:

--- a/src/raiden_libs/events.py
+++ b/src/raiden_libs/events.py
@@ -6,6 +6,7 @@ from raiden.utils.typing import (
     BlockTimeout,
     ChannelID,
     Nonce,
+    TokenAddress,
     TokenAmount,
     TokenNetworkAddress,
 )
@@ -18,7 +19,7 @@ class Event:
 
 @dataclass
 class ReceiveTokenNetworkCreatedEvent(Event):
-    token_address: Address
+    token_address: TokenAddress
     token_network_address: TokenNetworkAddress
     block_number: BlockNumber
 

--- a/src/raiden_libs/states.py
+++ b/src/raiden_libs/states.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass, field
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from monitoring_service.constants import DEFAULT_FILTER_INTERVAL
-from raiden.utils.typing import Address, BlockNumber, BlockTimeout, ChainID, TokenNetworkAddress
+from raiden.utils.typing import Address, BlockNumber, BlockTimeout, ChainID
 
 
 @dataclass
@@ -11,5 +11,4 @@ class BlockchainState:
     token_network_registry_address: Address
     latest_committed_block: BlockNumber
     monitor_contract_address: Optional[Address] = None
-    token_network_addresses: List[TokenNetworkAddress] = field(default_factory=list)
     current_event_filter_interval: BlockTimeout = DEFAULT_FILTER_INTERVAL

--- a/tests/libs/fixtures/web3.py
+++ b/tests/libs/fixtures/web3.py
@@ -8,7 +8,7 @@ from eth_account import Account
 from tests.constants import KEYSTORE_FILE_NAME, KEYSTORE_PASSWORD
 from web3 import Web3
 
-from raiden.utils.typing import BlockNumber
+from raiden.utils.typing import BlockNumber, TokenNetworkAddress
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_libs.events import Event
 from raiden_libs.states import BlockchainState
@@ -52,6 +52,7 @@ def mockchain(monkeypatch):
     def get_blockchain_events(
         web3: Web3,
         contract_manager: ContractManager,
+        token_network_addresses: List[TokenNetworkAddress],
         chain_state: BlockchainState,
         from_block: BlockNumber,
         to_block: BlockNumber,

--- a/tests/libs/fixtures/web3.py
+++ b/tests/libs/fixtures/web3.py
@@ -51,19 +51,21 @@ def mockchain(monkeypatch):
 
     def get_blockchain_events(
         web3: Web3,
-        contract_manager: ContractManager,
+        blockchain_state: BlockchainState,
         token_network_addresses: List[TokenNetworkAddress],
-        chain_state: BlockchainState,
-        from_block: BlockNumber,
-        to_block: BlockNumber,
+        latest_confirmed_block: BlockNumber,
     ):  # pylint: disable=unused-argument
-        blocks = state["block_events"][from_block : to_block + 1]
+        blocks = state["block_events"][0 : latest_confirmed_block + 1]
         events = [ev for block in blocks for ev in block]  # flatten
-        return chain_state, events
+        return events
 
     def set_events(events):
         state["block_events"] = events
 
-    monkeypatch.setattr("monitoring_service.service.get_blockchain_events", get_blockchain_events)
-    monkeypatch.setattr("pathfinding_service.service.get_blockchain_events", get_blockchain_events)
+    monkeypatch.setattr(
+        "monitoring_service.service.get_blockchain_events_adaptive", get_blockchain_events
+    )
+    monkeypatch.setattr(
+        "pathfinding_service.service.get_blockchain_events_adaptive", get_blockchain_events
+    )
     return set_events

--- a/tests/libs/fixtures/web3.py
+++ b/tests/libs/fixtures/web3.py
@@ -55,7 +55,9 @@ def mockchain(monkeypatch):
         token_network_addresses: List[TokenNetworkAddress],
         latest_confirmed_block: BlockNumber,
     ):  # pylint: disable=unused-argument
-        blocks = state["block_events"][0 : latest_confirmed_block + 1]
+        blocks = state["block_events"][
+            blockchain_state.latest_committed_block : latest_confirmed_block + 1
+        ]
         events = [ev for block in blocks for ev in block]  # flatten
         return events
 

--- a/tests/monitoring/monitoring_service/factories.py
+++ b/tests/monitoring/monitoring_service/factories.py
@@ -17,6 +17,7 @@ from raiden.utils.typing import (
     ChannelID,
     Nonce,
     Optional,
+    TokenAddress,
     TokenAmount,
     TokenNetworkAddress,
 )
@@ -24,6 +25,7 @@ from raiden_contracts.constants import ChannelState
 from raiden_libs.utils import private_key_to_address
 
 DEFAULT_TOKEN_NETWORK_ADDRESS = TokenNetworkAddress(bytes([1] * 20))
+DEFAULT_TOKEN_ADDRESS = TokenAddress(bytes([9] * 20))
 DEFAULT_CHANNEL_IDENTIFIER = ChannelID(3)
 DEFAULT_PRIVATE_KEY1 = "0x" + "1" * 64
 DEFAULT_PRIVATE_KEY2 = "0x" + "2" * 64

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -147,7 +147,6 @@ def test_crash(
                 assert (
                     stable_state.monitor_contract_address == crashy_state.monitor_contract_address
                 )
-                # assert stable_state.token_network_addresses == crashy_state.token_network_addresses  # noqa
                 # Do not compare `current_event_filter_interval`, this is allowed to be different
             else:
                 assert stable_state == crashy_state

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -147,7 +147,7 @@ def test_crash(
                 assert (
                     stable_state.monitor_contract_address == crashy_state.monitor_contract_address
                 )
-                assert stable_state.token_network_addresses == crashy_state.token_network_addresses
+                # assert stable_state.token_network_addresses == crashy_state.token_network_addresses  # noqa
                 # Do not compare `current_event_filter_interval`, this is allowed to be different
             else:
                 assert stable_state == crashy_state

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -93,7 +93,7 @@ def test_first_allowed_monitoring(
         **shared_bp_args
     )
     monitoring_service._process_new_blocks(web3.eth.blockNumber)
-    assert monitoring_service.context.ms_state.blockchain_state.token_network_addresses
+    assert len(monitoring_service.context.database.get_token_network_addresses()) > 0
 
     # c1 asks MS to monitor the channel
     reward_amount = TokenAmount(1)
@@ -216,7 +216,7 @@ def test_e2e(  # pylint: disable=too-many-arguments,too-many-locals
 
     # need to wait here till the MS has some time to react
     gevent.sleep(0.01)
-    assert monitoring_service.context.ms_state.blockchain_state.token_network_addresses
+    assert len(monitoring_service.context.database.get_token_network_addresses()) > 0
 
     # c1 asks MS to monitor the channel
     reward_amount = TokenAmount(1)

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -23,6 +23,7 @@ from raiden.utils.typing import (
     FeeAmount,
     MessageID,
     ProportionalFeeAmount,
+    TokenAddress,
     TokenAmount,
     TokenNetworkAddress,
 )
@@ -46,7 +47,7 @@ PARTICIPANT2 = Address(bytes([2] * 20))
 def test_save_and_load_token_networks(pathfinding_service_mock_empty):
     pfs = pathfinding_service_mock_empty
 
-    token_address = Address(bytes([1] * 20))
+    token_address = TokenAddress(bytes([1] * 20))
     token_network_address = TokenNetworkAddress(bytes([2] * 20))
     channel_id = ChannelID(1)
     p1 = Address(bytes([3] * 20))
@@ -87,7 +88,7 @@ def test_crash(tmpdir, mockchain):  # pylint: disable=too-many-locals
     A somewhat meaninful crash handling is simulated by not including the
     UpdatedHeadBlockEvent in every block.
     """
-    token_address = Address(bytes([1] * 20))
+    token_address = TokenAddress(bytes([1] * 20))
     token_network_address = TokenNetworkAddress(bytes([2] * 20))
     channel_id = ChannelID(1)
     p1 = Address(bytes([3] * 20))
@@ -164,7 +165,7 @@ def test_crash(tmpdir, mockchain):  # pylint: disable=too-many-locals
 
 
 def test_token_network_created(pathfinding_service_mock):
-    token_address = Address(bytes([1] * 20))
+    token_address = TokenAddress(bytes([1] * 20))
     token_network_address = TokenNetworkAddress(bytes(bytes([2] * 20)))
     network_event = ReceiveTokenNetworkCreatedEvent(
         token_address=token_address,
@@ -305,7 +306,7 @@ def test_logging_processor():
     logger = Mock()
     log_method = Mock()
 
-    address = Address(b"\x7f[\xf6\xc9To\xa8\x185w\xe4\x9f\x15\xbc\xef@mr\xd5\xd9")
+    address = TokenAddress(b"\x7f[\xf6\xc9To\xa8\x185w\xe4\x9f\x15\xbc\xef@mr\xd5\xd9")
     address_log = format_to_hex(
         _logger=logger, _log_method=log_method, event_dict=dict(address=address)
     )

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -156,7 +156,7 @@ def test_crash(tmpdir, mockchain):  # pylint: disable=too-many-locals
                 assert (
                     stable_state.monitor_contract_address == crashy_state.monitor_contract_address
                 )
-                assert stable_state.token_network_addresses == crashy_state.token_network_addresses
+                # assert stable_state.token_network_addresses == crashy_state.token_network_addresses  # noqa
                 # Do not compare `current_event_filter_interval`, this is allowed to be different
             else:
                 assert stable_state == crashy_state

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -156,7 +156,6 @@ def test_crash(tmpdir, mockchain):  # pylint: disable=too-many-locals
                 assert (
                     stable_state.monitor_contract_address == crashy_state.monitor_contract_address
                 )
-                # assert stable_state.token_network_addresses == crashy_state.token_network_addresses  # noqa
                 # Do not compare `current_event_filter_interval`, this is allowed to be different
             else:
                 assert stable_state == crashy_state


### PR DESCRIPTION
Follow-up to #783 

During the work on adaptive syncing I saw some opportunities to refactor stuff to reduce duplicated code, but didn't want to merge it back then.

This is mostly about removing the token network addresses from the blockchain state class. This make the code paths of MS and PFS similar and will allow to factor out the code there.

We now need to query the token network from the DB every time a new block is queried, but this only happens once per new block, so that shouldn't hurt.

## TODO
- [x] Factor out common blockchain filter code
- [x] Fix/adapt tests