### PR TITLE
Check if IOUs expiration is still valid

### DIFF
--- a/src/pathfinding_service/claim_fees.py
+++ b/src/pathfinding_service/claim_fees.py
@@ -55,6 +55,7 @@ def main(
     ious = list(
         get_claimable_ious(
             database,
+            expires_after=web3.eth.blockNumber,
             expires_before=BlockNumber(web3.eth.blockNumber + expires_within),
             claim_cost_rdn=claim_cost_rdn,
         )
@@ -77,12 +78,17 @@ def calc_claim_cost_rdn(web3: Web3, rdn_per_eth: float) -> TokenAmount:
 
 
 def get_claimable_ious(
-    database: PFSDatabase, expires_before: BlockNumber, claim_cost_rdn: TokenAmount
+    database: PFSDatabase,
+    expires_after: BlockNumber,
+    expires_before: BlockNumber,
+    claim_cost_rdn: TokenAmount,
 ) -> Iterable[IOU]:
-    ious = database.get_ious(
-        claimed=False, expires_before=expires_before, amount_at_least=claim_cost_rdn
+    return database.get_ious(
+        claimed=False,
+        expires_after=expires_after,
+        expires_before=expires_before,
+        amount_at_least=claim_cost_rdn,
     )
-    return ious
 
 
 def claim_ious(

--- a/src/pathfinding_service/database.py
+++ b/src/pathfinding_service/database.py
@@ -115,6 +115,7 @@ class PFSDatabase(BaseDatabase):
         sender: Optional[Address] = None,
         expiration_block: Optional[BlockNumber] = None,
         claimed: Optional[bool] = None,
+        expires_after: Optional[BlockNumber] = None,
         expires_before: Optional[BlockNumber] = None,
         amount_at_least: Optional[TokenAmount] = None,
     ) -> Iterator[IOU]:
@@ -136,6 +137,9 @@ class PFSDatabase(BaseDatabase):
         if expires_before is not None:
             query += " AND expiration_block < ?"
             args.append(hex256(expires_before))
+        if expires_after is not None:
+            query += " AND expiration_block > ?"
+            args.append(hex256(expires_after))
         if amount_at_least is not None:
             query += " AND amount >= ?"
             args.append(hex256(amount_at_least))


### PR DESCRIPTION
Fixes #789 

Add an option to load only IOUs that are still valid and use that for the claim script.