### PR TITLE
Batch the RPC request for token network events

### DIFF
--- a/tests/libs/test_blockchain.py
+++ b/tests/libs/test_blockchain.py
@@ -27,9 +27,8 @@ def create_tnr_contract_events_query(
         return query_blockchain_events(
             web3=web3,
             contract_manager=contract_manager,
-            contract_address=contract_address,
+            contract_addresses=contract_address,
             contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
-            topics=[],
             from_block=BlockNumber(0),
             to_block=web3.eth.blockNumber,
         )
@@ -39,13 +38,16 @@ def create_tnr_contract_events_query(
 
 @pytest.mark.usefixtures("token_network")
 def test_limit_inclusivity_in_query_blockchain_events(
-    web3, wait_for_blocks, contracts_manager, token_network_registry_contract
+    web3: Web3,
+    wait_for_blocks,
+    contracts_manager: ContractManager,
+    token_network_registry_contract,
 ):
     query = create_tnr_contract_events_query(
         web3, contracts_manager, token_network_registry_contract.address
     )
 
-    # A new token network has been registered by the `token_network` fixture
+    # A new token network has been registered by the `token_network_registry_contract` fixture
     events = query()
     assert len(events) == 1
     event = events[0]
@@ -56,9 +58,8 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_address=token_network_registry_contract.address,
+        contract_addresses=token_network_registry_contract.address,
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
-        topics=[],
         from_block=BlockNumber(0),
         to_block=BlockNumber(registry_event_block - 1),
     )
@@ -67,9 +68,8 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_address=token_network_registry_contract.address,
+        contract_addresses=token_network_registry_contract.address,
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
-        topics=[],
         from_block=BlockNumber(0),
         to_block=registry_event_block,
     )
@@ -84,9 +84,8 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_address=token_network_registry_contract.address,
+        contract_addresses=token_network_registry_contract.address,
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
-        topics=[],
         from_block=BlockNumber(registry_event_block + 1),
         to_block=current_block_number,
     )
@@ -95,9 +94,8 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_address=token_network_registry_contract.address,
+        contract_addresses=token_network_registry_contract.address,
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
-        topics=[],
         from_block=registry_event_block,
         to_block=current_block_number,
     )
@@ -107,9 +105,8 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_address=token_network_registry_contract.address,
+        contract_addresses=token_network_registry_contract.address,
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
-        topics=[],
         from_block=registry_event_block,
         to_block=registry_event_block,
     )

--- a/tests/libs/test_blockchain.py
+++ b/tests/libs/test_blockchain.py
@@ -27,7 +27,7 @@ def create_tnr_contract_events_query(
         return query_blockchain_events(
             web3=web3,
             contract_manager=contract_manager,
-            contract_addresses=contract_address,
+            contract_addresses=[contract_address],
             contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
             from_block=BlockNumber(0),
             to_block=web3.eth.blockNumber,
@@ -58,7 +58,7 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_addresses=token_network_registry_contract.address,
+        contract_addresses=[token_network_registry_contract.address],
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
         from_block=BlockNumber(0),
         to_block=BlockNumber(registry_event_block - 1),
@@ -68,7 +68,7 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_addresses=token_network_registry_contract.address,
+        contract_addresses=[token_network_registry_contract.address],
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
         from_block=BlockNumber(0),
         to_block=registry_event_block,
@@ -84,7 +84,7 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_addresses=token_network_registry_contract.address,
+        contract_addresses=[token_network_registry_contract.address],
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
         from_block=BlockNumber(registry_event_block + 1),
         to_block=current_block_number,
@@ -94,7 +94,7 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_addresses=token_network_registry_contract.address,
+        contract_addresses=[token_network_registry_contract.address],
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
         from_block=registry_event_block,
         to_block=current_block_number,
@@ -105,7 +105,7 @@ def test_limit_inclusivity_in_query_blockchain_events(
     events = query_blockchain_events(
         web3=web3,
         contract_manager=contracts_manager,
-        contract_addresses=token_network_registry_contract.address,
+        contract_addresses=[token_network_registry_contract.address],
         contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
         from_block=registry_event_block,
         to_block=registry_event_block,

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -31,7 +31,7 @@ def create_ms_contract_events_query(
         return query_blockchain_events(
             web3=web3,
             contract_manager=contract_manager,
-            contract_addresses=contract_address,
+            contract_addresses=[contract_address],
             contract_name=CONTRACT_MONITORING_SERVICE,
             from_block=BlockNumber(0),
             to_block=web3.eth.blockNumber,

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -31,9 +31,8 @@ def create_ms_contract_events_query(
         return query_blockchain_events(
             web3=web3,
             contract_manager=contract_manager,
-            contract_address=contract_address,
+            contract_addresses=contract_address,
             contract_name=CONTRACT_MONITORING_SERVICE,
-            topics=[],
             from_block=BlockNumber(0),
             to_block=web3.eth.blockNumber,
         )


### PR DESCRIPTION
On deployments with multiple token networks this lowers the number of
RPC requests by a big margin.

As we are interested in all events we do not need the filter topics. With them gone we can query multiple contracts at the same time. For now I chose to only do this for the token networks, as it is the easiest to do.

Part of https://github.com/raiden-network/raiden-services/issues/672