### PR TITLE
Update raiden[-contracts] and other dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,13 +5,13 @@ pip
 wheel>=0.30.0
 watchdog>=0.8.3
 
-flake8==3.7.9
-flake8-bugbear==20.1.2
+flake8==3.8.3
+flake8-bugbear==20.1.4
 flake8-tuple==0.4.1
 isort==4.3.21
-mypy==0.770
+mypy==0.780
 black==19.10b0
-pylint==2.4.4
+pylint==2.5.3
 
 pytest
 pytest-gevent
@@ -24,7 +24,7 @@ coverage>=4.5.4
 ipython==4.2.1
 pdbpp
 
-eth-tester[py-evm]==0.4.0b2
+eth-tester[py-evm]==0.5.0b1
 
 # Release
 bump2version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,3 @@
-raiden==1.0.1
-raiden-contracts==0.37.1
-
-structlog==20.1.0
-colorama==0.4.1
-
-click==7.0
-coincurve==13.0.0
-
-web3==5.9.0
-eth-utils==1.8.4
-eth-abi==2.1.0
-eth-account==0.5.2
-eth-typing==2.2.1
-
-flask==1.0.3
-flask-restful==0.3.7
-gevent==1.5a3
-networkx==2.3
-requests==2.22.0
-
-marshmallow==3.4.0
-marshmallow-dataclass==6.0.0
+raiden==1.0.2rc
 
 sentry-sdk[flask]==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-raiden==0.200.0rc9
-raiden-contracts==0.37.0
+raiden==1.0.1
+raiden-contracts==0.37.1
 
 structlog==20.1.0
 colorama==0.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 current_version = major
 
 [flake8]
-ignore = E731, E203, W503, B008
+ignore = E731, E203, W503, B008, E402
 max-line-length = 99
 exclude = build,dist,.git,.venv
 

--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -1,7 +1,6 @@
 from gevent import monkey, config  # isort:skip # noqa
 
 # there were some issues with the 'thread' resolver, remove it from the options
-
 config.resolver = ["dnspython", "ares", "block"]  # noqa
 monkey.patch_all(subprocess=False, thread=False)  # isort:skip # noqa
 
@@ -25,6 +24,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.blockchain import get_web3_provider_info
 from raiden_libs.cli import blockchain_options, common_options, setup_sentry
 from raiden_libs.constants import (
@@ -89,7 +89,7 @@ log = structlog.get_logger(__name__)
 )
 @common_options("raiden-monitoring-service")
 def main(  # pylint: disable=too-many-arguments,too-many-locals
-    private_key: str,
+    private_key: PrivateKey,
     state_db: str,
     web3: Web3,
     contracts: Dict[str, Contract],

--- a/src/monitoring_service/service.py
+++ b/src/monitoring_service/service.py
@@ -27,6 +27,7 @@ from raiden_contracts.constants import (
     CONTRACT_USER_DEPOSIT,
 )
 from raiden_contracts.contract_manager import gas_measurements
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.blockchain import get_blockchain_events_adaptive
 from raiden_libs.events import Event
 from raiden_libs.utils import private_key_to_address
@@ -34,7 +35,7 @@ from raiden_libs.utils import private_key_to_address
 log = structlog.get_logger(__name__)
 
 
-def check_gas_reserve(web3: Web3, private_key: str) -> None:
+def check_gas_reserve(web3: Web3, private_key: PrivateKey) -> None:
     """ Check periodically for gas reserve in the account """
     gas_price = web3.eth.gasPrice
     gas_limit = gas_measurements()["MonitoringService.monitor"]
@@ -83,7 +84,7 @@ class MonitoringService:
     def __init__(  # pylint: disable=too-many-arguments
         self,
         web3: Web3,
-        private_key: str,
+        private_key: PrivateKey,
         db_filename: str,
         contracts: Dict[str, Contract],
         sync_start_block: BlockNumber,

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -23,6 +23,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.blockchain import get_web3_provider_info
 from raiden_libs.cli import blockchain_options, common_options, setup_sentry
 from raiden_libs.constants import (
@@ -83,7 +84,7 @@ log = structlog.get_logger(__name__)
 )
 @common_options("raiden-pathfinding-service")
 def main(  # pylint: disable=too-many-arguments,too-many-locals
-    private_key: str,
+    private_key: PrivateKey,
     state_db: str,
     web3: Web3,
     contracts: Dict[str, Contract],

--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -26,6 +26,7 @@ from raiden.messages.abstract import Message
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
 from raiden.utils.typing import BlockNumber, BlockTimeout, ChainID, TokenNetworkAddress
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.blockchain import get_blockchain_events_adaptive
 from raiden_libs.constants import MATRIX_START_TIMEOUT
 from raiden_libs.events import (
@@ -58,7 +59,7 @@ class PathfindingService(gevent.Greenlet):
         self,
         web3: Web3,
         contracts: Dict[str, Contract],
-        private_key: str,
+        private_key: PrivateKey,
         db_filename: str,
         sync_start_block: BlockNumber,
         required_confirmations: BlockTimeout,

--- a/src/raiden_libs/blockchain.py
+++ b/src/raiden_libs/blockchain.py
@@ -105,11 +105,7 @@ def query_blockchain_events(
         All matching events
     """
     filter_params = FilterParams(
-        {
-            "fromBlock": from_block,
-            "toBlock": to_block,
-            "address": contract_addresses,  # type: ignore
-        }
+        {"fromBlock": from_block, "toBlock": to_block, "address": contract_addresses}
     )
 
     events = web3.eth.getLogs(filter_params)

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -34,19 +34,20 @@ from raiden_contracts.constants import (
     CONTRACT_USER_DEPOSIT,
     CONTRACTS_VERSION,
 )
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.contract_info import CONTRACT_MANAGER, get_contract_addresses_and_start_block
 from raiden_libs.logging import setup_logging
 
 log = structlog.get_logger(__name__)
 
 
-def _open_keystore(keystore_file: str, password: str) -> str:
+def _open_keystore(keystore_file: str, password: str) -> PrivateKey:
     with open(keystore_file, "r") as keystore:
         try:
-            private_key = Account.decrypt(
-                keyfile_json=json.load(keystore), password=password
-            ).hex()
-            return private_key
+            private_key = bytes(
+                Account.decrypt(keyfile_json=json.load(keystore), password=password)
+            )
+            return PrivateKey(private_key)
         except ValueError as error:
             log.critical(
                 "Could not decode keyfile with given password. Please try again.",

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 import gevent
 import structlog
-from eth_utils import decode_hex, to_checksum_address
+from eth_utils import to_checksum_address
 from gevent.event import AsyncResult
 from marshmallow import ValidationError
 from matrix_client.errors import MatrixRequestError
@@ -42,6 +42,7 @@ from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.utils.cli import get_matrix_servers
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import Address, ChainID
+from raiden_contracts.utils.type_aliases import PrivateKey
 
 log = structlog.get_logger(__name__)
 
@@ -131,7 +132,7 @@ class MatrixListener(gevent.Greenlet):
     # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
-        private_key: str,
+        private_key: PrivateKey,
         chain_id: ChainID,
         service_room_suffix: str,
         message_received_callback: Callable[[Message], None],
@@ -205,7 +206,7 @@ class MatrixListener(gevent.Greenlet):
             self.user_manager.start()
 
             login(
-                self._client, signer=LocalSigner(private_key=decode_hex(self.private_key)),
+                self._client, signer=LocalSigner(private_key=self.private_key),
             )
         except (MatrixRequestError, ValueError):
             raise ConnectionError("Could not login/register to matrix.")

--- a/src/raiden_libs/service_registry.py
+++ b/src/raiden_libs/service_registry.py
@@ -299,7 +299,7 @@ def register_account(
             function_call=service_registry_contract.functions.deposit(latest_deposit),
             task_name="Depositing to service registry",
         )
-        events = service_registry_contract.events.RegisteredService().processReceipt(  # type: ignore # noqa
+        events = service_registry_contract.events.RegisteredService().processReceipt(
             receipt, errors=DISCARD
         )
         assert len(events) == 1

--- a/src/raiden_libs/utils.py
+++ b/src/raiden_libs/utils.py
@@ -1,9 +1,8 @@
-from typing import Union
-
 from coincurve import PrivateKey, PublicKey
-from eth_utils import decode_hex, keccak
+from eth_utils import keccak
 
 from raiden.utils.typing import Address
+from raiden_contracts.utils.type_aliases import PrivateKey as PrivateKeyType
 
 
 def public_key_to_address(public_key: PublicKey) -> Address:
@@ -12,11 +11,7 @@ def public_key_to_address(public_key: PublicKey) -> Address:
     return Address(keccak(key_bytes[1:])[-20:])
 
 
-def private_key_to_address(private_key: Union[str, bytes]) -> Address:
+def private_key_to_address(private_key: PrivateKeyType) -> Address:
     """ Converts a private key to an Ethereum address. """
-    if isinstance(private_key, str):
-        private_key = decode_hex(private_key)
-
-    assert isinstance(private_key, bytes)
     privkey = PrivateKey(private_key)
     return public_key_to_address(privkey.public_key)

--- a/src/request_collector/cli.py
+++ b/src/request_collector/cli.py
@@ -13,6 +13,7 @@ from request_collector.server import RequestCollector
 from monitoring_service.constants import MS_DISCLAIMER
 from monitoring_service.database import SharedDatabase
 from raiden.utils.cli import NetworkChoiceType
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.cli import common_options, setup_sentry
 from raiden_libs.constants import CONFIRMATION_OF_UNDERSTANDING
 
@@ -51,7 +52,7 @@ log = structlog.get_logger(__name__)
 )
 @common_options("raiden-monitoring-service")
 def main(
-    private_key: str, state_db: str, matrix_server: List[str], accept_disclaimer: bool
+    private_key: PrivateKey, state_db: str, matrix_server: List[str], accept_disclaimer: bool
 ) -> int:
     """ The request collector for the monitoring service. """
     log.info("Starting Raiden Monitoring Request Collector")

--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -14,6 +14,7 @@ from raiden.exceptions import InvalidSignature
 from raiden.messages.abstract import Message
 from raiden.messages.monitoring_service import RequestMonitoring
 from raiden.utils.typing import List, Optional, TokenNetworkAddress
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.constants import MATRIX_START_TIMEOUT
 from raiden_libs.matrix import MatrixListener
 
@@ -23,7 +24,7 @@ log = structlog.get_logger(__name__)
 class RequestCollector(gevent.Greenlet):
     def __init__(
         self,
-        private_key: str,
+        private_key: PrivateKey,
         state_db: SharedDatabase,
         matrix_servers: Optional[List[str]] = None,
     ):

--- a/tests/libs/test_contract_info.py
+++ b/tests/libs/test_contract_info.py
@@ -9,8 +9,8 @@ from raiden_contracts.constants import (
 )
 from raiden_libs.contract_info import get_contract_addresses_and_start_block
 
-DEFAULT_CHAIN_ID = ChainID(3)
-DEFAULT_VERSION = "0.10.1"
+DEFAULT_CHAIN_ID = ChainID(5)
+DEFAULT_VERSION = "0.37.0"
 
 
 def test_contract_info_defaults():
@@ -26,13 +26,13 @@ def test_contract_info_defaults():
     )
     assert infos is not None
     assert infos[CONTRACT_TOKEN_NETWORK_REGISTRY] == decode_hex(
-        "0xde1fAa1385403f05C20a8ca5a0D5106163A35B6e"
+        "0x5a5cf4a63022f61f1506d1a2398490c2e8dfbb98"
     )
     assert infos[CONTRACT_MONITORING_SERVICE] == decode_hex(
-        "0x58c73CabCFB3c55B420E3F60a4b06098e9D1960E"
+        "0x20e8e5181000e60799a523a2023d630868f378fd"
     )
-    assert infos[CONTRACT_USER_DEPOSIT] == decode_hex("0x85F2c5eA50861DF5eA2EBd3651fAB091e14B849C")
-    assert start_block == 5235446
+    assert infos[CONTRACT_USER_DEPOSIT] == decode_hex("0x0794f09913aa8c77c8c5bdd1ec4bb51759ee0cc5")
+    assert start_block == 2723614
 
 
 def test_contract_info_overwrite_defaults():

--- a/tests/monitoring/fixtures/api.py
+++ b/tests/monitoring/fixtures/api.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 from eth_typing import BlockNumber
-from eth_utils import to_checksum_address
+from eth_utils import decode_hex, to_checksum_address
 from tests.libs.mocks.web3 import Web3Mock
 
 from monitoring_service.api import MSApi
@@ -17,6 +17,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.constants import DEFAULT_API_HOST
 
 
@@ -34,7 +35,9 @@ def monitoring_service_mock() -> Generator[MonitoringService, None, None]:
     mock_udc.functions.token.return_value.call.return_value = to_checksum_address(bytes([7] * 20))
     ms = MonitoringService(
         web3=web3_mock,
-        private_key="3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266",
+        private_key=PrivateKey(
+            decode_hex("3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266")
+        ),
         db_filename=":memory:",
         contracts={
             CONTRACT_TOKEN_NETWORK_REGISTRY: Mock(address=bytes([9] * 20)),

--- a/tests/monitoring/fixtures/factories.py
+++ b/tests/monitoring/fixtures/factories.py
@@ -1,18 +1,18 @@
 import pytest
-from eth_utils import encode_hex, to_checksum_address
+from eth_utils import decode_hex, encode_hex, to_checksum_address
 from tests.constants import TEST_MSC_ADDRESS
 
 from monitoring_service.states import HashedBalanceProof
 from raiden.messages.monitoring_service import RequestMonitoring
 from raiden.utils.typing import ChannelID, Nonce, TokenAmount, TokenNetworkAddress
 from raiden_contracts.tests.utils.address import get_random_privkey
-from raiden_contracts.utils.type_aliases import ChainID
+from raiden_contracts.utils.type_aliases import ChainID, PrivateKey
 from raiden_libs.utils import private_key_to_address
 
 
 @pytest.fixture
 def build_request_monitoring():
-    non_closing_privkey = get_random_privkey()
+    non_closing_privkey = PrivateKey(decode_hex(get_random_privkey()))
     non_closing_address = private_key_to_address(non_closing_privkey)
 
     def f(
@@ -28,7 +28,7 @@ def build_request_monitoring():
             nonce=nonce,
             additional_hash="",
             balance_hash=encode_hex(bytes([amount])),
-            priv_key=get_random_privkey(),
+            priv_key=PrivateKey(decode_hex(get_random_privkey())),
         )
         request_monitoring = balance_proof.get_request_monitoring(
             privkey=non_closing_privkey,

--- a/tests/monitoring/monitoring_service/factories.py
+++ b/tests/monitoring/monitoring_service/factories.py
@@ -1,5 +1,6 @@
 import random
 
+from eth_utils import decode_hex
 from tests.constants import TEST_MSC_ADDRESS
 
 from monitoring_service.states import (
@@ -22,13 +23,14 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
 )
 from raiden_contracts.constants import ChannelState
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.utils import private_key_to_address
 
 DEFAULT_TOKEN_NETWORK_ADDRESS = TokenNetworkAddress(bytes([1] * 20))
 DEFAULT_TOKEN_ADDRESS = TokenAddress(bytes([9] * 20))
 DEFAULT_CHANNEL_IDENTIFIER = ChannelID(3)
-DEFAULT_PRIVATE_KEY1 = "0x" + "1" * 64
-DEFAULT_PRIVATE_KEY2 = "0x" + "2" * 64
+DEFAULT_PRIVATE_KEY1 = PrivateKey(decode_hex("0x" + "1" * 64))
+DEFAULT_PRIVATE_KEY2 = PrivateKey(decode_hex("0x" + "2" * 64))
 DEFAULT_PARTICIPANT1 = private_key_to_address(DEFAULT_PRIVATE_KEY1)
 DEFAULT_PARTICIPANT2 = private_key_to_address(DEFAULT_PRIVATE_KEY2)
 DEFAULT_REWARD_AMOUNT = TokenAmount(1)
@@ -39,8 +41,8 @@ def create_signed_monitor_request(
     chain_id: ChainID = ChainID(61),
     nonce: Nonce = Nonce(5),
     reward_amount: TokenAmount = DEFAULT_REWARD_AMOUNT,
-    closing_privkey: str = DEFAULT_PRIVATE_KEY1,
-    nonclosing_privkey: str = DEFAULT_PRIVATE_KEY2,
+    closing_privkey: PrivateKey = DEFAULT_PRIVATE_KEY1,
+    nonclosing_privkey: PrivateKey = DEFAULT_PRIVATE_KEY2,
 ) -> MonitorRequest:
     bp = HashedBalanceProof(
         channel_identifier=DEFAULT_CHANNEL_IDENTIFIER,

--- a/tests/monitoring/monitoring_service/test_cli.py
+++ b/tests/monitoring/monitoring_service/test_cli.py
@@ -4,9 +4,11 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from click.testing import CliRunner
+from eth_utils import decode_hex
 
 from monitoring_service.cli import main
 from monitoring_service.service import check_gas_reserve
+from raiden_contracts.utils.type_aliases import PrivateKey
 
 
 @pytest.fixture(autouse=True)
@@ -23,7 +25,9 @@ def service_mock(monkeypatch):
 
 
 def test_account_check(web3, capsys):
-    private_key = "0F951D6EAF7685D420AACCA3900127E669892FE5CA6C8E4C572A59B0609AAE6B"
+    private_key = PrivateKey(
+        decode_hex("0F951D6EAF7685D420AACCA3900127E669892FE5CA6C8E4C572A59B0609AAE6B")
+    )
     check_gas_reserve(web3, private_key)
     out = capsys.readouterr().out
     assert "Your account's balance is below the estimated gas reserve of" in out

--- a/tests/monitoring/monitoring_service/test_crash.py
+++ b/tests/monitoring/monitoring_service/test_crash.py
@@ -2,7 +2,7 @@ import os
 from typing import List
 from unittest.mock import Mock
 
-from eth_utils import encode_hex, to_canonical_address, to_checksum_address
+from eth_utils import decode_hex, encode_hex, to_canonical_address, to_checksum_address
 from tests.constants import TEST_MSC_ADDRESS
 
 from monitoring_service.events import ActionMonitoringTriggeredEvent
@@ -25,6 +25,7 @@ from raiden_contracts.constants import (
     LOCKSROOT_OF_NO_LOCKS,
 )
 from raiden_contracts.tests.utils import get_random_address, get_random_privkey
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.events import ReceiveChannelOpenedEvent, UpdatedHeadBlockEvent
 from raiden_libs.states import BlockchainState
 
@@ -80,7 +81,7 @@ def test_crash(
     ]
     mockchain(events)
 
-    server_private_key = get_random_privkey()
+    server_private_key = PrivateKey(decode_hex(get_random_privkey()))
 
     contracts = {
         CONTRACT_TOKEN_NETWORK_REGISTRY: ContractMock(),

--- a/tests/monitoring/monitoring_service/test_handlers.py
+++ b/tests/monitoring/monitoring_service/test_handlers.py
@@ -3,7 +3,7 @@ from typing import Optional
 from unittest.mock import Mock, patch
 
 import pytest
-from eth_utils import to_checksum_address
+from eth_utils import decode_hex, to_checksum_address
 from tests.libs.mocks.web3 import Web3Mock
 from tests.monitoring.monitoring_service.factories import (
     DEFAULT_CHANNEL_IDENTIFIER,
@@ -38,6 +38,7 @@ from monitoring_service.states import OnChainUpdateStatus
 from raiden.utils.typing import Address, BlockNumber, BlockTimeout, ChannelID, Nonce, TokenAmount
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.tests.utils import get_random_privkey
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR_MS
 from raiden_libs.events import (
     Event,
@@ -723,8 +724,14 @@ def test_mr_with_unknown_signatures(context: Context):
         action_monitoring_triggered_event_handler(event, context)
         assert not context.monitoring_service_contract.functions.monitor.called
 
-    assert_mr_is_ignored(create_signed_monitor_request(closing_privkey=get_random_privkey()))
-    assert_mr_is_ignored(create_signed_monitor_request(nonclosing_privkey=get_random_privkey()))
+    assert_mr_is_ignored(
+        create_signed_monitor_request(closing_privkey=PrivateKey(decode_hex(get_random_privkey())))
+    )
+    assert_mr_is_ignored(
+        create_signed_monitor_request(
+            nonclosing_privkey=PrivateKey(decode_hex(get_random_privkey()))
+        )
+    )
 
 
 def test_action_claim_reward_triggered_event_handler_does_trigger_claim_call(  # noqa

--- a/tests/pathfinding/fixtures/accounts.py
+++ b/tests/pathfinding/fixtures/accounts.py
@@ -2,19 +2,20 @@
 from typing import List
 
 import pytest
-from eth_utils import encode_hex, keccak
+from eth_utils import keccak
 from tests.pathfinding.config import NUMBER_OF_NODES
 
 from raiden.utils.typing import Address
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.utils import private_key_to_address
 
 
 @pytest.fixture(scope="session")
-def private_keys() -> List[str]:
+def private_keys() -> List[PrivateKey]:
     offset = 14789632
-    return [encode_hex(keccak(offset + i)) for i in range(NUMBER_OF_NODES)]
+    return [PrivateKey(keccak(offset + i)) for i in range(NUMBER_OF_NODES)]
 
 
 @pytest.fixture(scope="session")
-def addresses(private_keys: List[str]) -> List[Address]:
+def addresses(private_keys: List[PrivateKey]) -> List[Address]:
     return [private_key_to_address(private_key) for private_key in private_keys]

--- a/tests/pathfinding/fixtures/iou.py
+++ b/tests/pathfinding/fixtures/iou.py
@@ -6,7 +6,7 @@ from pathfinding_service.constants import MIN_IOU_EXPIRY
 from pathfinding_service.model import IOU
 from raiden.utils.typing import Address
 from raiden_contracts.utils.proofs import sign_one_to_n_iou
-from raiden_contracts.utils.type_aliases import ChainID
+from raiden_contracts.utils.type_aliases import ChainID, PrivateKey
 from raiden_libs.utils import private_key_to_address
 
 
@@ -15,7 +15,7 @@ def make_iou(one_to_n_contract: Contract):
     one_to_n_contract_address = to_canonical_address(one_to_n_contract.address)
 
     def f(
-        sender_priv_key,
+        sender_priv_key: PrivateKey,
         receiver: Address,
         amount=1,
         expiration_block=MIN_IOU_EXPIRY + 100,

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -4,7 +4,7 @@ from typing import Callable, Generator, List
 from unittest.mock import Mock, patch
 
 import pytest
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import decode_hex, to_canonical_address, to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
 
@@ -25,6 +25,7 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.utils import private_key_to_address
 
 from ...libs.mocks.web3 import Web3Mock
@@ -301,7 +302,9 @@ def pathfinding_service_mock_empty() -> Generator[PathfindingService, None, None
             sync_start_block=BlockNumber(0),
             required_confirmations=BlockTimeout(0),
             poll_interval=0,
-            private_key="3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266",
+            private_key=PrivateKey(
+                decode_hex("3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266")
+            ),
             db_filename=":memory:",
         )
 

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -31,6 +31,7 @@ from raiden.utils.typing import (
     TokenAmount,
 )
 from raiden_contracts.tests.utils import get_random_privkey
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.utils import private_key_to_address
 
 ID_12 = 12
@@ -273,7 +274,7 @@ def test_get_paths_validation(
 
     # prepare iou for payment tests
     iou = make_iou(
-        get_random_privkey(),
+        PrivateKey(decode_hex(get_random_privkey())),
         api_sut.pathfinding_service.address,
         one_to_n_address=api_sut.one_to_n_address,
     )
@@ -380,7 +381,7 @@ def test_payment_with_new_iou_rejected(  # pylint: disable=too-many-locals
 
     # test with payment
     api_sut.service_fee = 100
-    sender = get_random_privkey()
+    sender = PrivateKey(decode_hex(get_random_privkey()))
     iou = make_iou(
         sender,
         api_sut.pathfinding_service.address,
@@ -454,7 +455,7 @@ def test_get_info(api_url: str, api_sut, pathfinding_service_mock):
 # tests for /payment/iou endpoint
 #
 def test_get_iou(api_sut: PFSApi, api_url: str, token_network_model: TokenNetwork, make_iou):
-    privkey = get_random_privkey()
+    privkey = PrivateKey(decode_hex(get_random_privkey()))
     sender = private_key_to_address(privkey)
     url = api_url + f"/{to_checksum_address(token_network_model.address)}/payment/iou"
 
@@ -464,7 +465,7 @@ def test_get_iou(api_sut: PFSApi, api_url: str, token_network_model: TokenNetwor
             "receiver": to_checksum_address(api_sut.pathfinding_service.address),
             "timestamp": timestamp,
         }
-        local_signer = LocalSigner(private_key=decode_hex(privkey))
+        local_signer = LocalSigner(private_key=privkey)
         params["signature"] = encode_hex(
             local_signer.sign(
                 to_canonical_address(params["sender"])
@@ -579,7 +580,7 @@ def test_stats_endpoint(
     estimated_fee = FeeAmount(0)
 
     def check_response(num_all: int, num_only_feedback: int, num_only_success: int) -> None:
-        url = api_url + f"/_debug/stats"
+        url = api_url + "/_debug/stats"
         response = requests.get(url)
 
         assert response.status_code == 200

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -7,7 +7,7 @@ Therefore, usually mocked_integration should be used.
 from typing import List
 from unittest.mock import Mock, patch
 
-from eth_utils import encode_hex, to_canonical_address
+from eth_utils import decode_hex, encode_hex, to_canonical_address
 
 from monitoring_service.states import HashedBalanceProof
 from pathfinding_service.constants import DEFAULT_REVEAL_TIMEOUT
@@ -20,6 +20,7 @@ from raiden_contracts.constants import (
     LOCKSROOT_OF_NO_LOCKS,
     TEST_SETTLE_TIMEOUT_MIN,
 )
+from raiden_contracts.utils.type_aliases import PrivateKey
 
 
 def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
@@ -52,7 +53,9 @@ def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
             db_filename=":memory:",
             poll_interval=0.1,
             sync_start_block=BlockNumber(0),
-            private_key="3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266",
+            private_key=PrivateKey(
+                decode_hex("3a1076bf45ab87712ad64ccb3b10217737f7faacbf2872e88fdd9a537d8fe266")
+            ),
         )
 
     # greenlet needs to be started and context switched to

--- a/tests/pathfinding/test_claim_fees.py
+++ b/tests/pathfinding/test_claim_fees.py
@@ -42,7 +42,7 @@ def test_claim_fees(  # pylint: disable=too-many-locals
     # Create IOUs from `iou_inputs`
     ious: List[IOU] = []
     for iou_dict in iou_inputs:
-        local_signer = LocalSigner(private_key=decode_hex(get_private_key(iou_dict["sender"])))
+        local_signer = LocalSigner(private_key=get_private_key(iou_dict["sender"]))
         iou = IOU(
             sender=iou_dict["sender"],
             receiver=pfs.address,

--- a/tests/pathfinding/test_cli.py
+++ b/tests/pathfinding/test_cli.py
@@ -68,7 +68,7 @@ def test_bad_eth_client(log, default_cli_args):
 def test_success(default_cli_args):
     """ Calling the pathfinding_service with default args should succeed after heavy mocking """
     runner = CliRunner()
-    with patch.multiple(**PATCH_ARGS), patch.multiple(**PATCH_INFO_ARGS):
+    with patch.multiple(**PATCH_ARGS), patch.multiple(**PATCH_INFO_ARGS):  # type: ignore
         result = runner.invoke(main, default_cli_args, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -77,7 +77,7 @@ def test_eth_rpc(default_cli_args, provider_mock):
     """ The `eth-rpc` parameter must reach the `HTTPProvider` """
     runner = CliRunner()
     eth_rpc = "example.com:1234"
-    with patch.multiple(**PATCH_ARGS), patch.multiple(**PATCH_INFO_ARGS):
+    with patch.multiple(**PATCH_ARGS), patch.multiple(**PATCH_INFO_ARGS):  # type: ignore
         runner.invoke(main, default_cli_args + ["--eth-rpc", eth_rpc])
     provider_mock.assert_called_with(eth_rpc)
 
@@ -105,7 +105,7 @@ def test_registry_address(default_cli_args):
 def test_confirmations(default_cli_args):
     """ The `confirmations` parameter must reach the `PathfindingService` """
     runner = CliRunner()
-    with patch.multiple(**PATCH_ARGS) as mocks, patch.multiple(**PATCH_INFO_ARGS):
+    with patch.multiple(**PATCH_ARGS) as mocks, patch.multiple(**PATCH_INFO_ARGS):  # type: ignore
         confirmations = 77
         result = runner.invoke(
             main,
@@ -120,7 +120,7 @@ def test_confirmations(default_cli_args):
 def test_shutdown(default_cli_args):
     """ Clean shutdown after KeyboardInterrupt """
     runner = CliRunner()
-    with patch.multiple(**PATCH_ARGS) as mocks, patch.multiple(**PATCH_INFO_ARGS):
+    with patch.multiple(**PATCH_ARGS) as mocks, patch.multiple(**PATCH_INFO_ARGS):  # type: ignore
         mocks["PathfindingService"].return_value.get.side_effect = KeyboardInterrupt
         result = runner.invoke(main, default_cli_args, catch_exceptions=False)
         assert result.exit_code == 0
@@ -133,7 +133,7 @@ def test_shutdown(default_cli_args):
 def test_log_level(default_cli_args):
     """ Setting of log level via command line switch """
     runner = CliRunner()
-    with patch.multiple(**PATCH_ARGS), patch.multiple(**PATCH_INFO_ARGS), patch(
+    with patch.multiple(**PATCH_ARGS), patch.multiple(**PATCH_INFO_ARGS), patch(  # type: ignore
         "logging.basicConfig"
     ) as basic_config:
         for log_level in ("CRITICAL", "WARNING"):

--- a/tests/pathfinding/test_middleware.py
+++ b/tests/pathfinding/test_middleware.py
@@ -26,7 +26,7 @@ def test_retries(make_post_request_mock):
     start_time = time()
     retry_times = []
 
-    def side_effect(*args, **kwargs):
+    def side_effect(*_args, **_kwargs):
         retry_times.append(time() - start_time)
         raise requests.exceptions.ConnectionError
 

--- a/tests/pathfinding/test_payment.py
+++ b/tests/pathfinding/test_payment.py
@@ -1,5 +1,5 @@
 import pytest
-from eth_utils import to_canonical_address
+from eth_utils import decode_hex, to_canonical_address
 
 import pathfinding_service.exceptions as exceptions
 from pathfinding_service.api import process_payment
@@ -10,7 +10,7 @@ from raiden_libs.constants import UDC_SECURITY_MARGIN_FACTOR_PFS
 
 def test_save_and_load_iou(pathfinding_service_mock, make_iou):
     pfs = pathfinding_service_mock
-    iou = make_iou(get_random_privkey(), pfs.address)
+    iou = make_iou(decode_hex(get_random_privkey()), pfs.address)
     pfs.database.upsert_iou(iou)
     stored_iou = pfs.database.get_iou(iou.sender, iou.expiration_block)
     assert stored_iou == iou

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -4,7 +4,7 @@ from typing import List
 from unittest.mock import Mock, call, patch
 
 import pytest
-from eth_utils import to_checksum_address
+from eth_utils import decode_hex, to_checksum_address
 
 from pathfinding_service.model.token_network import PFSFeeUpdate
 from pathfinding_service.service import PathfindingService
@@ -29,6 +29,7 @@ from raiden.utils.typing import (
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, CONTRACT_USER_DEPOSIT
 from raiden_contracts.tests.utils import get_random_privkey
+from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.events import (
     ReceiveChannelClosedEvent,
     ReceiveChannelOpenedEvent,
@@ -116,7 +117,7 @@ def test_crash(tmpdir, mockchain):  # pylint: disable=too-many-locals
     ]
     mockchain(events)
 
-    server_private_key = get_random_privkey()
+    server_private_key = PrivateKey(decode_hex(get_random_privkey()))
     contracts = {
         CONTRACT_TOKEN_NETWORK_REGISTRY: ContractMock(),
         CONTRACT_USER_DEPOSIT: ContractMock(),


### PR DESCRIPTION
Update to latest Raiden release.

This also updates the contracts package, which requires some typing changes. The biggest one is that `PrivateKey` is not bytes, whereas we used `str` before. In the contracts we should make `get_random_privkey` return a `PrivateKey` to make stuff easier.