### PR TITLE
Don't do complicated routing for direct channels

### DIFF
--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -488,6 +488,17 @@ class TokenNetwork:
             fee_penalty=fee_penalty,
         )
 
+        if self.G.has_edge(source, target):
+            log.info("Using shortcut for direct channel")
+            return [
+                Path(
+                    G=self.G,
+                    nodes=[source, target],
+                    value=value,
+                    reachability_state=reachability_state,
+                )
+            ]
+
         # TODO: improve the pruning
         # Currently we make a snapshot of the currently reachable nodes, so the searched graph
         # becomes smaller

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -105,6 +105,26 @@ def test_edge_weight(addresses):
 
 
 @pytest.mark.usefixtures("populate_token_network_case_1")
+def test_direct_route_speed(
+    token_network_model: TokenNetwork,
+    reachability_state: SimpleReachabilityContainer,
+    addresses: List[Address],
+):
+    start = time.monotonic()
+    for _ in range(1000):
+        # 0->2 is a direct channel
+        paths = token_network_model.get_paths(
+            source=addresses[0],
+            target=addresses[2],
+            value=PaymentAmount(10),
+            max_paths=1,
+            reachability_state=reachability_state,
+        )
+        assert len(paths) == 1
+    assert time.monotonic() - start < 2
+
+
+@pytest.mark.usefixtures("populate_token_network_case_1")
 def test_routing_simple(
     token_network_model: TokenNetwork,
     reachability_state: SimpleReachabilityContainer,


### PR DESCRIPTION
We only ask the PFS for routes in direct channels to gather global
information for the raiddit demo. In production use, these requests
would not get sent at all. To avoid slowing doing the PFS during the
demo too much, add a simple shortcut for that case.