### PR TITLE
Add `suggest_partner` api endpoint

### DIFF
--- a/src/pathfinding_service/constants.py
+++ b/src/pathfinding_service/constants.py
@@ -24,6 +24,7 @@ MIN_IOU_EXPIRY: int = 7 * 24 * 60 * 4
 
 MAX_AGE_OF_IOU_REQUESTS: timedelta = timedelta(hours=1)
 MAX_AGE_OF_FEEDBACK_REQUESTS: timedelta = timedelta(minutes=10)
+CACHE_TIMEOUT_SUGGEST_PARTNER = timedelta(hours=1)
 
 PFS_DISCLAIMER: str = textwrap.dedent(
     """\

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -617,3 +617,15 @@ def test_cors(api_url: str):
     response = requests.options(api_url, headers=headers)
     assert response.headers["Access-Control-Allow-Origin"] == "*"
     assert response.headers["Access-Control-Allow-Headers"] == "Origin, Content-Type, Accept"
+
+
+@pytest.mark.usefixtures("api_sut")
+def test_suggest_partner_api(api_url: str, token_network_model: TokenNetwork):
+    """ Smoke test for partner suggestion REST endpoint
+
+    The actual content is tested in ``test_graphs.test_suggest_partner``.
+    """
+    token_network_address_hex = to_checksum_address(token_network_model.address)
+    url = api_url + f"/{token_network_address_hex}/suggest_partner"
+    response = requests.get(url)
+    assert response.status_code == 200

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -1,11 +1,21 @@
+from datetime import datetime
+
 from raiden.network.transport.matrix import AddressReachability
+from raiden.network.transport.matrix.utils import ReachabilityState
 from raiden.utils.typing import Address, Dict
 
 
 class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
     def __init__(self, reachabilities: Dict[Address, AddressReachability]) -> None:
         self.reachabilities = reachabilities
+        self.times = {address: datetime.utcnow() for address in reachabilities}
         self._userid_to_presence: dict = {}
 
     def get_address_reachability(self, address: Address) -> AddressReachability:
         return self.reachabilities.get(address, AddressReachability.UNKNOWN)
+
+    def get_address_reachability_state(self, address: Address) -> ReachabilityState:
+        return ReachabilityState(
+            self.reachabilities.get(address, AddressReachability.UNKNOWN),
+            self.times.get(address, datetime.utcnow()),
+        )


### PR DESCRIPTION
When a Raiden node joins a token network, it should connect to nodes
which will be able to mediate payments. The PFS has a global view and
should have an easier time to find such nodes than the client.

See https://github.com/raiden-network/raiden-services/issues/684

The suggested partners are cached for one hour, which makes it
reasonable to offer this service without requiring fees. The amount of
results is fixed to make caching simpler.

The results are ordered and choosing just the first entry will be
sufficient for most use cases. For less common cases and for debugging,
additional scoring information is provided (The overall score as
`score`, as well as `centrality`, `uptime` and `capacity`). There is no
long term guarantee regarding the meaning of the specific values, but
greater values will always be better.
The current scoring is not very sophisticated, but should be good enough
as a starting point. Improvements to the scoring will be possible
without breaking compatibility.

I will start adding information about this endpoint to the spec once
this is reviewed and merged.