### PR TITLE
Fix error on empty cache, reduce cache duration

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -431,7 +431,7 @@ class SuggestPartnerResource(PathfinderResource):
         cache_key = token_network_address
         cache_entry, cache_timestamp = self.cache.get(cache_key, (None, datetime(MINYEAR, 1, 1)))
         if cache_timestamp > datetime.utcnow() - CACHE_TIMEOUT_SUGGEST_PARTNER:
-            assert cache_entry
+            assert cache_entry is not None
             return cache_entry, 200
 
         # Get result and write to cache

--- a/src/pathfinding_service/constants.py
+++ b/src/pathfinding_service/constants.py
@@ -24,7 +24,7 @@ MIN_IOU_EXPIRY: int = 7 * 24 * 60 * 4
 
 MAX_AGE_OF_IOU_REQUESTS: timedelta = timedelta(hours=1)
 MAX_AGE_OF_FEEDBACK_REQUESTS: timedelta = timedelta(minutes=10)
-CACHE_TIMEOUT_SUGGEST_PARTNER = timedelta(hours=1)
+CACHE_TIMEOUT_SUGGEST_PARTNER = timedelta(minutes=1)
 
 PFS_DISCLAIMER: str = textwrap.dedent(
     """\


### PR DESCRIPTION
If no suggestions could be generated, the assert failed when reading the
cache.

Also reduce the cache duration. This is more helpful when
developing/debugging and the optimization seems premature at this
point.