### PR TITLE
fix transaction failing because prev one isnt in current chain state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Unreleased
 
-* MS/PFS: Return `price_info` and `block_number` as strings in `/info` endpoint v2, since uint256 are not a safe part of JSON
-
+* MS/PFS: Return `price_info` and `block_number` as strings in `/info` endpoint v2, since uint256 are not a safe part of JSON (https://github.com/raiden-network/raiden-services/pull/862)
+* Service Registry: Wait until transactions are confirmed (https://github.com/raiden-network/raiden-services/issues/855)
 
 ### 0.12.0 (2020-09-16)
 

--- a/src/raiden_libs/service_registry.py
+++ b/src/raiden_libs/service_registry.py
@@ -88,8 +88,11 @@ def checked_transact(
     log.info(f"Starting: {task_name}")
     transaction_hash = function_call.transact({"from": sender_address})
 
+    confirmation_msg = ""
+    if wait_confirmation_interval:
+        confirmation_msg = " and waiting for confirmation"
     click.secho(
-        f"\nSending transaction: {task_name}"
+        f"\nSending transaction{confirmation_msg}: {task_name}"
         f"\n\tSee {etherscan_url_for_txhash(web3.eth.chainId, transaction_hash)}"
     )
 

--- a/tests/libs/test_service_registry.py
+++ b/tests/libs/test_service_registry.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+import gevent
 from web3 import Web3
 from web3.contract import Contract
 
@@ -9,7 +10,11 @@ from raiden_libs.service_registry import register_account
 
 
 def test_registration(
-    web3: Web3, service_registry: Contract, get_accounts: Callable, get_private_key: Callable
+    web3: Web3,
+    service_registry: Contract,
+    get_accounts: Callable,
+    get_private_key: Callable,
+    wait_for_blocks: Callable,
 ) -> None:
     (account,) = get_accounts(1)
     pk1 = get_private_key(account)
@@ -17,6 +22,12 @@ def test_registration(
     assert service_registry.functions.hasValidRegistration(account).call() is False
     assert service_registry.functions.urls(account).call() == ""
 
+    def create_blocks():
+        while True:
+            wait_for_blocks(1)
+            gevent.idle()
+
+    block_creator = gevent.spawn(create_blocks)
     register_account(
         private_key=pk1,
         web3=web3,
@@ -26,6 +37,8 @@ def test_registration(
         accept_disclaimer=True,
         accept_all=True,
     )
+
+    block_creator.kill()
 
     # check that registration worked
     assert service_registry.functions.hasValidRegistration(account).call() is True


### PR DESCRIPTION
This fix waits for `transaction_receipt["blockNumber"] + Confirmation interval` before sending a new transaction.
Also it waits on the transaction receipt to have a key "blockNumber". Parity returns a receipt of a non mined transaction with missing "blockNumber" field. 

The fix is done in the service registry script. Should also be checked in other code parts.

fixes: #855 

