### PR TITLE
Return PFS broadcast room id in info response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 CODE_DIRS = src/ tests/ setup.py
 ISORT_PARAMS = --ignore-whitespace --settings-path . --recursive $(CODE_DIRS)
-BLACK_PARAMS = --line-length 99
 
 all: lint
 
 lint: mypy
-	black --check --diff $(BLACK_PARAMS) $(CODE_DIRS)
+	black --check --diff $(CODE_DIRS)
 	flake8 $(CODE_DIRS)
 	isort $(ISORT_PARAMS) --diff --check-only
 	pylint $(CODE_DIRS)
@@ -17,7 +16,7 @@ isort:
 	isort $(ISORT_PARAMS)
 
 black:
-	black $(BLACK_PARAMS) $(CODE_DIRS)
+	black $(CODE_DIRS)
 
 format: isort black
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 99
+target-version = ['py37']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -417,6 +417,7 @@ class InfoResource(PathfinderResource):
             "payment_address": to_checksum_address(self.pathfinding_service.address),
             "UTC": datetime.utcnow().isoformat(),
             "matrix_server": self.api.pathfinding_service.matrix_listener.base_url,
+            "matrix_room_id": self.api.pathfinding_service.matrix_listener.broadcast_room_id,
         }
         return info, 200
 
@@ -445,7 +446,10 @@ class SuggestPartnerResource(PathfinderResource):
 
 class DebugPathResource(PathfinderResource):
     def get(  # pylint: disable=no-self-use
-        self, token_network_address: str, source_address: str, target_address: Optional[str] = None
+        self,
+        token_network_address: str,
+        source_address: str,
+        target_address: Optional[str] = None,
     ) -> Tuple[dict, int]:
         request_count = 0
         responses = []

--- a/src/raiden_libs/blockchain.py
+++ b/src/raiden_libs/blockchain.py
@@ -331,17 +331,11 @@ def get_blockchain_events_adaptive(
         filter_query_duration = after_query - before_query
         if filter_query_duration < ETH_GET_LOGS_THRESHOLD_FAST:
             blockchain_state.current_event_filter_interval = BlockTimeout(
-                min(
-                    MAX_FILTER_INTERVAL,
-                    blockchain_state.current_event_filter_interval * 2,
-                )
+                min(MAX_FILTER_INTERVAL, blockchain_state.current_event_filter_interval * 2)
             )
         elif filter_query_duration > ETH_GET_LOGS_THRESHOLD_SLOW:
             blockchain_state.current_event_filter_interval = BlockTimeout(
-                max(
-                    MIN_FILTER_INTERVAL,
-                    blockchain_state.current_event_filter_interval // 2,
-                )
+                max(MIN_FILTER_INTERVAL, blockchain_state.current_event_filter_interval // 2)
             )
 
         return events

--- a/tests/libs/test_blockchain.py
+++ b/tests/libs/test_blockchain.py
@@ -33,9 +33,7 @@ def create_tnr_contract_events_query(web3: Web3, contract_address: Address):
 
 @pytest.mark.usefixtures("token_network")
 def test_limit_inclusivity_in_query_blockchain_events(
-    web3: Web3,
-    wait_for_blocks,
-    token_network_registry_contract,
+    web3: Web3, wait_for_blocks, token_network_registry_contract
 ):
     query = create_tnr_contract_events_query(web3, token_network_registry_contract.address)
 

--- a/tests/libs/test_service_registry.py
+++ b/tests/libs/test_service_registry.py
@@ -9,10 +9,7 @@ from raiden_libs.service_registry import register_account
 
 
 def test_registration(
-    web3: Web3,
-    service_registry: Contract,
-    get_accounts: Callable,
-    get_private_key: Callable,
+    web3: Web3, service_registry: Contract, get_accounts: Callable, get_private_key: Callable
 ) -> None:
     (account,) = get_accounts(1)
     pk1 = get_private_key(account)

--- a/tests/monitoring/monitoring_service/test_end_to_end.py
+++ b/tests/monitoring/monitoring_service/test_end_to_end.py
@@ -70,14 +70,14 @@ def test_first_allowed_monitoring(
         nonce=Nonce(1),
         transferred_amount=transferred_c1,
         priv_key=get_private_key(c1),
-        **shared_bp_args
+        **shared_bp_args,
     )
     transferred_c2 = 6
     balance_proof_c2 = HashedBalanceProof(
         nonce=Nonce(2),
         transferred_amount=transferred_c2,
         priv_key=get_private_key(c2),
-        **shared_bp_args
+        **shared_bp_args,
     )
     monitoring_service._process_new_blocks(web3.eth.blockNumber)
     assert len(monitoring_service.context.database.get_token_network_addresses()) > 0
@@ -186,14 +186,14 @@ def test_e2e(  # pylint: disable=too-many-arguments,too-many-locals
         nonce=Nonce(1),
         transferred_amount=transferred_c1,
         priv_key=get_private_key(c1),
-        **shared_bp_args
+        **shared_bp_args,
     )
     transferred_c2 = 6
     balance_proof_c2 = HashedBalanceProof(
         nonce=Nonce(2),
         transferred_amount=transferred_c2,
         priv_key=get_private_key(c2),
-        **shared_bp_args
+        **shared_bp_args,
     )
 
     ms_greenlet = gevent.spawn(monitoring_service.start)

--- a/tests/pathfinding/fixtures/network_service.py
+++ b/tests/pathfinding/fixtures/network_service.py
@@ -322,6 +322,7 @@ def pathfinding_service_mock(
     }
     pathfinding_service_mock_empty.database.upsert_token_network(token_network_model.address)
     pathfinding_service_mock_empty.matrix_listener.base_url = "https://matrix.server"
+    pathfinding_service_mock_empty.matrix_listener.broadcast_room_id = "!room-id:matrix.server"
 
     yield pathfinding_service_mock_empty
 

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -435,6 +435,7 @@ def test_get_info(api_url: str, api_sut, pathfinding_service_mock):
         "message": DEFAULT_INFO_MESSAGE,
         "payment_address": to_checksum_address(pathfinding_service_mock.address),
         "matrix_server": "https://matrix.server",
+        "matrix_room_id": "!room-id:matrix.server",
     }
     response = requests.get(url)
     assert response.status_code == 200

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -238,35 +238,44 @@ def test_diversity_penalty(
 ):
     """ Check changes in routing when increasing diversity penalty """
 
-    assert (
-        get_paths(
-            token_network_model=token_network_model,
-            reachability_state=reachability_state,
-            addresses=addresses,
-            diversity_penalty=0.1,
-        )
-        == [[0, 7, 8], [0, 7, 6, 8], [0, 7, 9, 10, 8], [0, 7, 6, 5, 8], [0, 1, 2, 3, 4, 8]]
-    )
+    assert get_paths(
+        token_network_model=token_network_model,
+        reachability_state=reachability_state,
+        addresses=addresses,
+        diversity_penalty=0.1,
+    ) == [
+        [0, 7, 8],
+        [0, 7, 6, 8],
+        [0, 7, 9, 10, 8],
+        [0, 7, 6, 5, 8],
+        [0, 1, 2, 3, 4, 8],
+    ]
 
-    assert (
-        get_paths(
-            token_network_model=token_network_model,
-            reachability_state=reachability_state,
-            addresses=addresses,
-            diversity_penalty=1.1,
-        )
-        == [[0, 7, 8], [0, 7, 6, 8], [0, 1, 2, 3, 4, 8], [0, 7, 9, 10, 8], [0, 7, 6, 5, 8]]
-    )
+    assert get_paths(
+        token_network_model=token_network_model,
+        reachability_state=reachability_state,
+        addresses=addresses,
+        diversity_penalty=1.1,
+    ) == [
+        [0, 7, 8],
+        [0, 7, 6, 8],
+        [0, 1, 2, 3, 4, 8],
+        [0, 7, 9, 10, 8],
+        [0, 7, 6, 5, 8],
+    ]
 
-    assert (
-        get_paths(
-            token_network_model=token_network_model,
-            reachability_state=reachability_state,
-            addresses=addresses,
-            diversity_penalty=10,
-        )
-        == [[0, 7, 8], [0, 1, 2, 3, 4, 8], [0, 7, 6, 8], [0, 7, 9, 10, 8], [0, 7, 6, 5, 8]]
-    )
+    assert get_paths(
+        token_network_model=token_network_model,
+        reachability_state=reachability_state,
+        addresses=addresses,
+        diversity_penalty=10,
+    ) == [
+        [0, 7, 8],
+        [0, 1, 2, 3, 4, 8],
+        [0, 7, 6, 8],
+        [0, 7, 9, 10, 8],
+        [0, 7, 6, 5, 8],
+    ]
 
 
 @pytest.mark.usefixtures("populate_token_network_case_3")
@@ -276,14 +285,17 @@ def test_reachability_initiator(
     addresses: List[Address],
 ):
 
-    assert (
-        get_paths(
-            token_network_model=token_network_model,
-            reachability_state=reachability_state,
-            addresses=addresses,
-        )
-        == [[0, 7, 8], [0, 1, 2, 3, 4, 8], [0, 7, 6, 8], [0, 7, 9, 10, 8], [0, 7, 6, 5, 8]]
-    )
+    assert get_paths(
+        token_network_model=token_network_model,
+        reachability_state=reachability_state,
+        addresses=addresses,
+    ) == [
+        [0, 7, 8],
+        [0, 1, 2, 3, 4, 8],
+        [0, 7, 6, 8],
+        [0, 7, 9, 10, 8],
+        [0, 7, 6, 5, 8],
+    ]
 
     reachability_state.reachabilities[addresses[0]] = AddressReachability.UNREACHABLE
     assert (
@@ -313,24 +325,26 @@ def test_reachability_mediator(
     addresses: List[Address],
 ):
 
-    assert (
-        get_paths(
-            token_network_model=token_network_model,
-            reachability_state=reachability_state,
-            addresses=addresses,
-        )
-        == [[0, 7, 8], [0, 1, 2, 3, 4, 8], [0, 7, 6, 8], [0, 7, 9, 10, 8], [0, 7, 6, 5, 8]]
-    )
+    assert get_paths(
+        token_network_model=token_network_model,
+        reachability_state=reachability_state,
+        addresses=addresses,
+    ) == [
+        [0, 7, 8],
+        [0, 1, 2, 3, 4, 8],
+        [0, 7, 6, 8],
+        [0, 7, 9, 10, 8],
+        [0, 7, 6, 5, 8],
+    ]
 
     reachability_state.reachabilities[addresses[7]] = AddressReachability.UNREACHABLE
-    assert (
-        get_paths(
-            token_network_model=token_network_model,
-            reachability_state=reachability_state,
-            addresses=addresses,
-        )
-        == [[0, 1, 2, 3, 4, 8]]
-    )
+    assert get_paths(
+        token_network_model=token_network_model,
+        reachability_state=reachability_state,
+        addresses=addresses,
+    ) == [
+        [0, 1, 2, 3, 4, 8],
+    ]
 
     reachability_state.reachabilities[addresses[1]] = AddressReachability.UNKNOWN
     assert (
@@ -350,14 +364,17 @@ def test_reachability_target(
     addresses: List[Address],
 ):
 
-    assert (
-        get_paths(
-            token_network_model=token_network_model,
-            reachability_state=reachability_state,
-            addresses=addresses,
-        )
-        == [[0, 7, 8], [0, 1, 2, 3, 4, 8], [0, 7, 6, 8], [0, 7, 9, 10, 8], [0, 7, 6, 5, 8]]
-    )
+    assert get_paths(
+        token_network_model=token_network_model,
+        reachability_state=reachability_state,
+        addresses=addresses,
+    ) == [
+        [0, 7, 8],
+        [0, 1, 2, 3, 4, 8],
+        [0, 7, 6, 8],
+        [0, 7, 9, 10, 8],
+        [0, 7, 6, 5, 8],
+    ]
 
     reachability_state.reachabilities[addresses[8]] = AddressReachability.UNREACHABLE
     assert (


### PR DESCRIPTION
This is necessary for
- raiden-network/raiden-service-bundle#187
- raiden-network/raiden#6442

With those PRs the set of federation servers can become disjunct between different Raiden client versions.
Therefore we can't rely on the previous check in the Raiden client if the PFS' server is in the known servers set.

The RoomID is uniquely identifying a specific broadcasting room and can therefore be used as a better information source for this check.