### PR TITLE
Use str to represent uint256 in JSON info endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+* MS/PFS: Return price_info and block_number as strings, since uint256 are not a safe part of JSON
+
 ### 0.12.0 (2020-09-16)
 
 * MS/PFS: Add prometheus endpoints for accessing metrics (https://github.com/raiden-network/raiden-services/pull/836)

--- a/src/monitoring_service/api.py
+++ b/src/monitoring_service/api.py
@@ -34,7 +34,7 @@ class InfoResource(MSResource):
 
     def get(self) -> Tuple[dict, int]:
         info = {
-            "price_info": self.api.monitoring_service.context.min_reward,
+            "price_info": str(self.api.monitoring_service.context.min_reward),
             "network_info": {
                 "chain_id": self.monitoring_service.chain_id,
                 "token_network_registry_address": to_checksum_address(
@@ -45,7 +45,9 @@ class InfoResource(MSResource):
                 ),
                 "service_token_address": to_checksum_address(self.service_token_address),
                 "confirmed_block": {
-                    "number": self.monitoring_service.context.ms_state.blockchain_state.latest_committed_block  # noqa
+                    "number": str(
+                        self.monitoring_service.context.ms_state.blockchain_state.latest_committed_block  # noqa
+                    )
                 },
             },
             "version": self.version,

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -398,7 +398,7 @@ class InfoResource(PathfinderResource):
 
     def get(self) -> Tuple[dict, int]:
         info = {
-            "price_info": self.api.service_fee,
+            "price_info": str(self.api.service_fee),
             "network_info": {
                 "chain_id": self.pathfinding_service.chain_id,
                 "token_network_registry_address": to_checksum_address(
@@ -411,7 +411,7 @@ class InfoResource(PathfinderResource):
                     self.pathfinding_service.service_token_address
                 ),
                 "confirmed_block": {
-                    "number": self.pathfinding_service.blockchain_state.latest_committed_block
+                    "number": str(self.pathfinding_service.blockchain_state.latest_committed_block)
                 },
             },
             "version": self.version,

--- a/tests/monitoring/monitoring_service/test_api.py
+++ b/tests/monitoring/monitoring_service/test_api.py
@@ -24,13 +24,13 @@ def test_get_info(api_url: str, ms_api_sut: MSApi, monitoring_service_mock: Moni
     )
 
     expected_response = {
-        "price_info": 123,
+        "price_info": "123",
         "network_info": {
             "chain_id": monitoring_service_mock.chain_id,
             "token_network_registry_address": token_network_registry_address,
             "user_deposit_address": user_deposit_address,
             "service_token_address": service_token_address,
-            "confirmed_block": {"number": 0},
+            "confirmed_block": {"number": "0"},
         },
         "version": pkg_resources.require("raiden-services")[0].version,
         "contracts_version": pkg_resources.require("raiden-contracts")[0].version,

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -421,13 +421,13 @@ def test_get_info(api_url: str, api_sut, pathfinding_service_mock):
     service_token_address = pathfinding_service_mock.user_deposit_contract.functions.token().call()
 
     expected_response = {
-        "price_info": 123,
+        "price_info": "123",
         "network_info": {
             "chain_id": pathfinding_service_mock.chain_id,
             "token_network_registry_address": token_network_registry_address,
             "user_deposit_address": user_deposit_address,
             "service_token_address": service_token_address,
-            "confirmed_block": {"number": 0},
+            "confirmed_block": {"number": "0"},
         },
         "version": pkg_resources.require("raiden-services")[0].version,
         "contracts_version": pkg_resources.require("raiden-contracts")[0].version,


### PR DESCRIPTION
These can't be deserialized correctly by all browsers, otherwise.