### PR TITLE
Fix metrics endpoint path

### DIFF
--- a/src/monitoring_service/api.py
+++ b/src/monitoring_service/api.py
@@ -102,7 +102,7 @@ class MSApi:
         self.flask_app = DispatcherMiddleware(
             NotFound(),
             {
-                f"{API_PATH}/metrics": make_wsgi_app(registry=metrics.REGISTRY),
+                "/metrics": make_wsgi_app(registry=metrics.REGISTRY),
                 API_PATH: flask_app.wsgi_app,
             },
         )

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -602,7 +602,7 @@ class PFSApi:
         self.flask_app = DispatcherMiddleware(
             NotFound(),
             {
-                f"{API_PATH}/metrics": make_wsgi_app(registry=metrics.REGISTRY),
+                "/metrics": make_wsgi_app(registry=metrics.REGISTRY),
                 API_PATH: flask_app.wsgi_app,
             },
         )

--- a/tests/monitoring/fixtures/api.py
+++ b/tests/monitoring/fixtures/api.py
@@ -22,8 +22,13 @@ from raiden_libs.constants import DEFAULT_API_HOST
 
 
 @pytest.fixture(scope="session")
-def api_url(free_port: int) -> str:
-    return "http://localhost:{}{}".format(free_port, API_PATH)
+def base_url(free_port: int) -> str:
+    return f"http://localhost:{free_port}"
+
+
+@pytest.fixture(scope="session")
+def api_url(base_url: str) -> str:
+    return f"{base_url}{API_PATH}"
 
 
 @pytest.fixture

--- a/tests/monitoring/monitoring_service/test_api.py
+++ b/tests/monitoring/monitoring_service/test_api.py
@@ -97,12 +97,12 @@ def test_get_info2(api_url: str, ms_api_sut: MSApi, monitoring_service_mock: Mon
 
 
 def test_prometheus_exposure(
-    api_url: str, ms_api_sut: MSApi, monitoring_service_mock: MonitoringService
+    base_url: str, ms_api_sut: MSApi, monitoring_service_mock: MonitoringService
 ):
 
     monitoring_service_mock.context.min_reward = 123
     ms_api_sut.operator = "John Doe"
-    url = api_url + "/metrics"
+    url = f"{base_url}/metrics"
 
     # call one of the metrics here, just to make sure that there is some output on the
     # API's '/metrics' prometheus endpoint. Create a new category label,


### PR DESCRIPTION
The metrics endpoint shouldn't be nested below `/api`.