### PR TITLE
Longer timeouts for first matrix sync

### DIFF
--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -14,7 +14,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from pathfinding_service.api import PFSApi
-from pathfinding_service.constants import DEFAULT_INFO_MESSAGE, PFS_DISCLAIMER
+from pathfinding_service.constants import DEFAULT_INFO_MESSAGE, PFS_DISCLAIMER, PFS_START_TIMEOUT
 from pathfinding_service.service import PathfindingService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.utils.typing import BlockNumber, BlockTimeout, TokenAmount
@@ -126,7 +126,7 @@ def main(  # pylint: disable=too-many-arguments,too-many-locals
         service.start()
         log.debug("Waiting for service to start before accepting API requests")
         try:
-            service.startup_finished.get(timeout=60)
+            service.startup_finished.get(timeout=PFS_START_TIMEOUT)
         except gevent.Timeout:
             raise Exception("PFS did not start within time.")
 

--- a/src/pathfinding_service/constants.py
+++ b/src/pathfinding_service/constants.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from raiden.utils.typing import BlockTimeout
 
+PFS_START_TIMEOUT = 300  # in seconds
 API_PATH: str = "/api"
 
 WEB3_PROVIDER_DEFAULT: str = "http://127.0.0.1:8545"

--- a/src/raiden_libs/constants.py
+++ b/src/raiden_libs/constants.py
@@ -3,7 +3,7 @@
 UDC_SECURITY_MARGIN_FACTOR_MS: float = 1.1
 UDC_SECURITY_MARGIN_FACTOR_PFS: float = 2
 
-MATRIX_START_TIMEOUT = 30  # in seconds
+MATRIX_START_TIMEOUT = 240  # in seconds
 
 CONFIRMATION_OF_UNDERSTANDING = (
     "Have you read, understood and hereby accept the above disclaimer and privacy warning?"


### PR DESCRIPTION
This has been a problem when starting services that have not been
running in a while or were started for the first time. I still think it
should be faster than this, but I don't see a quick way to optimize,
right now.