### PR TITLE
Improve registry script usability

### DIFF
--- a/src/raiden_libs/service_registry.py
+++ b/src/raiden_libs/service_registry.py
@@ -292,6 +292,11 @@ def register_account(
             "\n\tNote: The required deposit may change over time."
             # TODO: add link to high level description of the auction format
         )
+        if web3.eth.chainId == 1:
+            click.secho("You don't have sufficient tokens", err=True)
+            sys.exit(1)
+        elif account_balance < required_deposit:
+            click.secho("You are operating on a testnet. Tokens will be minted as required.")
         maybe_prompt(
             "I have read the current deposit and understand that continuing will transfer tokens"
         )

--- a/src/raiden_libs/service_registry.py
+++ b/src/raiden_libs/service_registry.py
@@ -289,8 +289,8 @@ def register_account(
         required_deposit = service_registry_contract.functions.currentPrice().call()
         click.secho(
             f"\nThe current required deposit is fmt_amount({required_deposit})"
-            "\n\tNote: The required deposit may change over time."
-            # TODO: add link to high level description of the auction format
+            "\n\tNote: The required deposit continuously decreases, but "
+            "\n\t      increases significantly after a deposit is made."
         )
         if web3.eth.chainId == 1:
             click.secho("You don't have sufficient tokens", err=True)

--- a/src/raiden_libs/service_registry.py
+++ b/src/raiden_libs/service_registry.py
@@ -59,7 +59,7 @@ DISCLAIMER = textwrap.dedent(
         | assume all risk related thereto and hereby release, waive, discharge   |
         | and covenant not to hold liable Brainbot Labs Establishment or any of  |
         | its officers, employees or affiliates from and for any direct or       |
-        | indirect damage resulting from the the software or the use thereof.    |
+        | indirect damage resulting from the software or the use thereof.        |
         | Such to the extent as permissible by applicable laws and regulations.  |
         +------------------------------------------------------------------------+
     """
@@ -176,7 +176,7 @@ def register(
     )
 
 
-# Seperate function to make testing easier
+# Separate function to make testing easier
 def register_account(
     private_key: str,
     web3: Web3,
@@ -393,7 +393,7 @@ def withdraw(
     caller_address = private_key_to_address(private_key)
     if to_canonical_address(withdrawer) != caller_address:
         log.error(
-            "You must used the key used to deposit when withdrawing",
+            "You must use the key used to deposit when withdrawing",
             expected=withdrawer,
             actual=to_checksum_address(caller_address),
         )

--- a/tests/libs/test_service_registry.py
+++ b/tests/libs/test_service_registry.py
@@ -33,7 +33,7 @@ def test_registration(
         web3=web3,
         contracts={CONTRACT_SERVICE_REGISTRY: service_registry},
         start_block=BlockNumber(0),
-        service_url="test",
+        service_url="http://test",
         accept_disclaimer=True,
         accept_all=True,
     )
@@ -42,4 +42,4 @@ def test_registration(
 
     # check that registration worked
     assert service_registry.functions.hasValidRegistration(account).call() is True
-    assert service_registry.functions.urls(account).call() == "test"
+    assert service_registry.functions.urls(account).call() == "http://test"


### PR DESCRIPTION
A large collection of UI improvements for the service registration. Highlights:
* info command to show past deposits
* extend command to prolong registration
* no need to remember your deposit address, `withdraw` will find it for you

Closes https://github.com/raiden-network/raiden-services/issues/768 and https://github.com/raiden-network/raiden-services/issues/490.