### PR TITLE
Prepare release 0.13.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.1
+current_version = 0.13.2
 commit = True
 tag = False
 
@@ -11,3 +11,4 @@ serialize = {major}.{minor}.{patch}
 
 [bumpversion:file:Dockerfile]
 serialize = {major}.{minor}.{patch}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+### 0.13.2 (2020-11-25)
+* Improve registration script ([#890](https://github.com/raiden-network/raiden-services/pull/890)) to allow for extension.
+* Longer timeouts for first Matrix sync ([#878](https://github.com/raiden-network/raiden-services/pull/878)).
+* Adaptions for newer Matrix usage in Raiden.
+* Dependency updates.
 
 ### 0.13.1 (2020-10-06)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
-LABEL Name=raiden-services Version=0.13.1 Maintainer="Raiden Network Team <contact@raiden.network>"
+LABEL Name=raiden-services Version=0.13.2 Maintainer="Raiden Network Team <contact@raiden.network>"
 EXPOSE 6000
 
 WORKDIR /services

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Brainbot Labs Est.'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.13.1'
+release = '0.13.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md") as readme_file:
 
 setup(
     name="raiden-services",
-    version="0.13.1",
+    version="0.13.2",
     license="MIT",
     description=DESCRIPTION,
     long_description=README,


### PR DESCRIPTION
Changes included:

### 0.13.2 (2020-11-25)
* Improve registration script ([#890](https://github.com/raiden-network/raiden-services/pull/890)) to allow for extension.
* Longer timeouts for first Matrix sync ([#878](https://github.com/raiden-network/raiden-services/pull/878)).
* Adaptions for newer Matrix usage in Raiden.
* Dependency updates.