### PR TITLE
Forever reconnect to other clients upon failure

### DIFF
--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -22,7 +22,7 @@ from pathfinding_service.exceptions import (
 from pathfinding_service.model import IOU, TokenNetwork
 from pathfinding_service.model.channel import Channel
 from pathfinding_service.typing import DeferableMessage
-from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, UINT256_MAX
+from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, UINT256_MAX, DeviceIDs
 from raiden.messages.abstract import Message
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
 from raiden.utils.typing import BlockNumber, BlockTimeout, ChainID, TokenNetworkAddress
@@ -100,6 +100,7 @@ class PathfindingService(gevent.Greenlet):
         self.matrix_listener = MatrixListener(
             private_key=private_key,
             chain_id=self.chain_id,
+            device_id=DeviceIDs.PFS,
             service_room_suffix=PATH_FINDING_BROADCASTING_ROOM,
             message_received_callback=self.handle_message,
             servers=matrix_servers,

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -16,7 +16,7 @@ from monitoring_service.constants import (
     MATRIX_RATE_LIMIT_ALLOWED_BYTES,
     MATRIX_RATE_LIMIT_RESET_INTERVAL,
 )
-from raiden.constants import Environment, Networks
+from raiden.constants import DeviceIDs, Environment, Networks
 from raiden.exceptions import SerializationError, TransportError
 from raiden.messages.abstract import Message, SignedMessage
 from raiden.network.transport.matrix.client import (
@@ -133,6 +133,7 @@ class MatrixListener(gevent.Greenlet):
         self,
         private_key: PrivateKey,
         chain_id: ChainID,
+        device_id: DeviceIDs,
         service_room_suffix: str,
         message_received_callback: Callable[[Message], None],
         servers: Optional[List[str]] = None,
@@ -140,12 +141,14 @@ class MatrixListener(gevent.Greenlet):
         super().__init__()
 
         self.chain_id = chain_id
+        self.device_id = device_id
         self.service_room_suffix = service_room_suffix
         self.message_received_callback = message_received_callback
         self._displayname_cache = DisplayNameCache()
         self.startup_finished = AsyncResult()
         self._client_manager = ClientManager(
             available_servers=servers,
+            device_id=self.device_id,
             broadcast_room_alias_prefix=make_room_alias(chain_id, service_room_suffix),
             chain_id=self.chain_id,
             private_key=private_key,
@@ -294,6 +297,7 @@ class ClientManager:
     def __init__(
         self,
         available_servers: Optional[List[str]],
+        device_id: DeviceIDs,
         broadcast_room_alias_prefix: str,
         chain_id: ChainID,
         private_key: bytes,
@@ -303,6 +307,7 @@ class ClientManager:
         self.local_signer = LocalSigner(private_key=private_key)
         self.broadcast_room_alias_prefix = broadcast_room_alias_prefix
         self.chain_id = chain_id
+        self.device_id = device_id
         self.broadcast_room_id: Optional[RoomID] = None
         self.broadcast_room: Optional[Room] = None
         self.startup_finished = AsyncResult()
@@ -435,7 +440,7 @@ class ClientManager:
         exception_str = "Could not login/register to matrix."
 
         try:
-            login(matrix_client, signer=self.local_signer)
+            login(matrix_client, signer=self.local_signer, device_id=self.device_id)
             exception_str = "Could not join broadcasting room."
             server = urlparse(matrix_client.api.base_url).netloc
             room_alias = f"#{self.broadcast_room_alias_prefix}:{server}"

--- a/src/raiden_libs/utils.py
+++ b/src/raiden_libs/utils.py
@@ -37,21 +37,11 @@ class MultiClientUserAddressManager(UserAddressManager):
     def __init__(
         self,
         client: GMatrixClient,
-        server_url_to_other_clients: Dict[str, GMatrixClient],
         displayname_cache: DisplayNameCache,
         _log_context: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(client, displayname_cache, noop_reachability, _log_context=_log_context)
-
-        # additional listener ids without the one from the main client
-        self.server_url_to_other_clients = server_url_to_other_clients
-        self._other_client_to_listener_id: Dict[GMatrixClient, Optional[UUID]] = {
-            client: None for client in self.server_url_to_other_clients.values()
-        }
-
-    @property
-    def server_url_to_all_clients(self) -> Dict[str, GMatrixClient]:
-        return {**self.server_url_to_other_clients, self._client.api.base_url: self._client}
+        self.server_url_to_listener_id: Dict[str, UUID] = {}
 
     def start(self) -> None:
         """Start listening for presence updates.
@@ -59,22 +49,26 @@ class MultiClientUserAddressManager(UserAddressManager):
         Should be called before ``.login()`` is called on the underlying client."""
         assert self._listener_id is None, "UserAddressManager.start() called twice"
         self._stop_event.clear()
-        self._listener_id = self._client.add_presence_listener(
-            self._create_presence_listener(self._client)
-        )
+        self._listener_id = self.add_client(self._client)
 
-        for client in self.server_url_to_other_clients.values():
-            self._other_client_to_listener_id[client] = self._client.add_presence_listener(
-                self._create_presence_listener(client)
-            )
+    def add_client(self, client: GMatrixClient) -> UUID:
+        server_url = client.api.base_url
+        self.server_url_to_listener_id[server_url] = client.add_presence_listener(
+            self._create_presence_listener(server_url)
+        )
+        return self.server_url_to_listener_id[server_url]
+
+    def remove_client(self, client: GMatrixClient) -> None:
+        listener_id = self.server_url_to_listener_id.pop(client.api.base_url, None)
+        if listener_id is not None:
+            client.remove_presence_listener(listener_id)
 
     def stop(self) -> None:
-        for client, listener_id in self._other_client_to_listener_id.items():
-            client.remove_presence_listener(listener_id)
+        self.server_url_to_listener_id = {}
         super().stop()
 
     def _create_presence_listener(
-        self, client: GMatrixClient
+        self, client_server_url: str
     ) -> Callable[[Dict[str, Any], int], None]:
         def _filter_presence(event: Dict[str, Any], presence_update_id: int) -> None:
             """
@@ -84,20 +78,22 @@ class MultiClientUserAddressManager(UserAddressManager):
             exists. This is a fallback if the client could not connect to another server
             """
             sender_server = event["sender"].split(":")[-1]
-
+            receiver_server = urlparse(client_server_url).netloc
+            main_client_server = urlparse(self._client.api.base_url).netloc
             other_clients_servers = {
                 urlparse(server_url).netloc
-                for server_url in self.server_url_to_other_clients.keys()
+                for server_url in self.server_url_to_listener_id
+                if server_url != self._client.api.base_url
             }
 
             # if this comes from the main client's sync consume all presences of users
             # which do not have a client in other clients. If other client for user's
             # homeserver exists, presence will be consumed by other client's sync
-            if client == self._client:
+            if receiver_server == main_client_server:
                 if sender_server not in other_clients_servers:
                     self._presence_listener(event, presence_update_id)
 
-            elif sender_server == urlparse(client.api.base_url).netloc:
+            elif sender_server == receiver_server:
                 self._presence_listener(event, presence_update_id)
 
         return _filter_presence

--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -9,7 +9,7 @@ from sentry_sdk import configure_scope
 from monitoring_service.constants import CHANNEL_CLOSE_MARGIN
 from monitoring_service.database import SharedDatabase
 from monitoring_service.states import MonitorRequest
-from raiden.constants import MONITORING_BROADCASTING_ROOM
+from raiden.constants import MONITORING_BROADCASTING_ROOM, DeviceIDs
 from raiden.exceptions import InvalidSignature
 from raiden.messages.abstract import Message
 from raiden.messages.monitoring_service import RequestMonitoring
@@ -38,6 +38,7 @@ class RequestCollector(gevent.Greenlet):
         self.matrix_listener = MatrixListener(
             private_key=private_key,
             chain_id=self.chain_id,
+            device_id=DeviceIDs.MS,
             service_room_suffix=MONITORING_BROADCASTING_ROOM,
             message_received_callback=self.handle_message,
             servers=matrix_servers,

--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -8,8 +8,10 @@ from unittest import mock
 from unittest.mock import Mock, patch
 from uuid import uuid1
 
+import gevent
 import pytest
 from eth_utils import encode_hex, to_canonical_address
+from gevent.event import AsyncResult
 
 from monitoring_service.states import HashedBalanceProof
 from raiden.messages.monitoring_service import RequestMonitoring
@@ -28,6 +30,7 @@ from raiden.utils.typing import (
 )
 from raiden_contracts.tests.utils import LOCKSROOT_OF_NO_LOCKS, deepcopy
 from raiden_libs.matrix import (
+    ClientManager,
     MatrixListener,
     RateLimiter,
     deserialize_messages,
@@ -219,6 +222,9 @@ def test_filter_presences_by_client(presence_event, server_index):
         uuids_to_callbacks[uuid] = listener
         return uuid
 
+    def _mock_remove_presence_listener(listener_id):
+        uuids_to_callbacks.pop(listener_id)
+
     def _mock_presence_listener(
         self, event: Dict[str, Any], presence_update_id: int  # pylint: disable=unused-argument
     ) -> None:
@@ -228,6 +234,7 @@ def test_filter_presences_by_client(presence_event, server_index):
         client = Mock()
         client.api.base_url = server_url
         client.add_presence_listener = _mock_add_presence_listener
+        client.remove_presence_listener = _mock_remove_presence_listener
         server_url_to_clients[server_url] = client
 
     main_client = server_url_to_clients.pop(server_urls[0])
@@ -237,10 +244,12 @@ def test_filter_presences_by_client(presence_event, server_index):
     ):
         uam = MultiClientUserAddressManager(
             client=main_client,
-            server_url_to_other_clients=server_url_to_clients,
             displayname_cache=DisplayNameCache(),
         )
         uam.start()
+
+        for client in server_url_to_clients.values():
+            uam.add_client(client)
 
         # call presence listener on all clients
         for listener in uuids_to_callbacks.values():
@@ -252,12 +261,9 @@ def test_filter_presences_by_client(presence_event, server_index):
         assert len(server_url_to_processed_presence) == expected_presences
 
         # drop the client of the last homeserver in the list
-        # and remove all listeners
-        uuid = uam._other_client_to_listener_id.pop(  # pylint: disable=protected-access
-            server_url_to_clients[server_urls[-1]]
-        )
-        uuids_to_callbacks.pop(uuid)
-        uam.server_url_to_other_clients.pop(server_urls[-1])
+        # and remove listener
+        client = server_url_to_clients[server_urls[-1]]
+        uam.remove_client(client)
 
         # only call the listener of the main client
         # if the presence event comes from the server with the dropped client
@@ -268,3 +274,57 @@ def test_filter_presences_by_client(presence_event, server_index):
             expected_presences += 1
 
         assert len(server_url_to_processed_presence) == expected_presences
+
+
+def test_client_manager_start(get_accounts, get_private_key):
+    server_urls = [f"https://example0{i}.com" for i in range(5)]
+
+    (c1,) = get_accounts(1)
+    private_key = get_private_key(c1)
+    client_mock = Mock()
+    client_mock.api.base_url = "https://example00.com"
+    client_mock.user_id = "1"
+    client_mock.sync_worker = AsyncResult()
+    start_client_counter = 0
+
+    def mock_start_client(server_url: str):  # pylint: disable=unused-argument
+        nonlocal start_client_counter
+        client_mock.sync_worker = AsyncResult()
+        start_client_counter += 1
+        return client_mock
+
+    with patch.multiple(
+        "raiden_libs.matrix",
+        make_client=Mock(return_value=client_mock),
+        get_matrix_servers=Mock(return_value=server_urls),
+        login=Mock(),
+        join_broadcast_room=Mock(),
+    ):
+        client_manager = ClientManager(
+            available_servers=[f"https://example0{i}.com" for i in range(5)],
+            broadcast_room_alias_prefix="_service",
+            chain_id=ChainID(1),
+            private_key=private_key,
+            handle_matrix_sync=lambda s: True,
+        )
+
+        client_manager._start_client = mock_start_client  # pylint: disable=protected-access
+
+        assert client_manager.known_servers == server_urls
+
+        uam = MultiClientUserAddressManager(
+            client=client_manager.main_client,
+            displayname_cache=DisplayNameCache(),
+        )
+        uam.start()
+        client_manager.user_manager = uam
+        client_manager.stop_event.clear()
+
+        gevent.spawn(client_manager.connect_client_forever, client_mock.api.base_url)
+        gevent.sleep(2)
+        client_mock.sync_worker.set(True)
+        gevent.sleep(2)
+        client_manager.stop_event.set()
+        client_mock.sync_worker.set(True)
+
+        assert start_client_counter == 2

--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -14,6 +14,7 @@ from eth_utils import encode_hex, to_canonical_address
 from gevent.event import AsyncResult
 
 from monitoring_service.states import HashedBalanceProof
+from raiden.constants import DeviceIDs
 from raiden.messages.monitoring_service import RequestMonitoring
 from raiden.network.transport.matrix.utils import DisplayNameCache
 from raiden.storage.serialization.serializer import DictSerializer, MessageSerializer
@@ -200,6 +201,7 @@ def test_matrix_listener_smoke_test(get_accounts, get_private_key):
         listener = MatrixListener(
             private_key=get_private_key(c1),
             chain_id=ChainID(61),
+            device_id=DeviceIDs.PFS,
             service_room_suffix="_service",
             message_received_callback=lambda _: None,
         )
@@ -304,6 +306,7 @@ def test_client_manager_start(get_accounts, get_private_key):
             available_servers=[f"https://example0{i}.com" for i in range(5)],
             broadcast_room_alias_prefix="_service",
             chain_id=ChainID(1),
+            device_id=DeviceIDs.PFS,
             private_key=private_key,
             handle_matrix_sync=lambda s: True,
         )


### PR DESCRIPTION
This PR introduces the ClientManager which controls the status of matrix clients to their respective home server. Each home server has a `connect_client_worker` which will trigger the creation of a new client if the connection to the homeserver fails. 

A reconnect is described by creating a new client object, logging into the server, joining broadcast rooms and starting the greenlet `listen_forever`.