### PR TITLE
Track address by presence updates

### DIFF
--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -135,10 +135,6 @@ class PathfindingService(gevent.Greenlet):
             for cv in channel.views:
                 network_for_address[cv.token_network_address].add_channel_view(cv)
 
-            # Register channel participants for presence tracking
-            self.matrix_listener.follow_address_presence(channel.participant1)
-            self.matrix_listener.follow_address_presence(channel.participant2)
-
         return network_for_address
 
     def _run(self) -> None:  # pylint: disable=method-hidden
@@ -253,9 +249,6 @@ class PathfindingService(gevent.Greenlet):
             return
 
         log.info("Received ChannelOpened event", event_=event)
-
-        self.matrix_listener.follow_address_presence(event.participant1, refresh=True)
-        self.matrix_listener.follow_address_presence(event.participant2, refresh=True)
 
         channel = token_network.handle_channel_opened_event(
             channel_identifier=event.channel_identifier,

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -199,22 +199,6 @@ class MatrixListener(gevent.Greenlet):
             self._client_manager.stop()
             gevent.joinall({startup_finished_greenlet}, raise_error=True, timeout=0)
 
-    def follow_address_presence(self, address: Address, refresh: bool = False) -> None:
-        self.user_manager.add_address(address)
-
-        if refresh:
-            self.user_manager.populate_userids_for_address(address)
-            self.user_manager.track_address_presence(
-                address=address, user_ids=self.user_manager.get_userids_for_address(address)
-            )
-
-        log.debug(
-            "Tracking address",
-            address=to_checksum_address(address),
-            current_presence=self.user_manager.get_address_reachability(address),
-            refresh=refresh,
-        )
-
     def _get_user_from_user_id(self, user_id: str) -> User:
         """Creates an User from an user_id, if none, or fetch a cached User """
         assert self._broadcast_room

--- a/src/raiden_libs/utils.py
+++ b/src/raiden_libs/utils.py
@@ -4,9 +4,13 @@ from uuid import UUID
 from coincurve import PrivateKey, PublicKey
 from eth_utils import keccak
 
-from raiden.network.transport.matrix import AddressReachability
+from raiden.network.transport.matrix import AddressReachability, UserPresence
 from raiden.network.transport.matrix.client import GMatrixClient
-from raiden.network.transport.matrix.utils import DisplayNameCache, UserAddressManager
+from raiden.network.transport.matrix.utils import (
+    DisplayNameCache,
+    UserAddressManager,
+    address_from_userid,
+)
 from raiden.utils.typing import Address, Any, Callable, Dict, Optional
 from raiden_contracts.utils.type_aliases import PrivateKey as PrivateKeyType
 
@@ -97,3 +101,54 @@ class MultiClientUserAddressManager(UserAddressManager):
                 self._presence_listener(event, presence_update_id)
 
         return _filter_presence
+
+    def _presence_listener(self, event: Dict[str, Any], presence_update_id: int) -> None:
+        """
+        Update cached user presence state from Matrix presence events.
+
+        Due to the possibility of nodes using accounts on multiple homeservers a composite
+        address state is synthesised from the cached individual user presence states.
+
+        This is a copy from the super class with a slight change.
+        Any user will automatically be added to the whitelist whenever the PFS receives
+        a presence update. We do this since we can assume that the PFS needs to know
+        about all raiden users.
+        """
+        if self._stop_event.ready():
+            return
+
+        user_id = event["sender"]
+
+        if event["type"] != "m.presence" or user_id == self._user_id:
+            return
+
+        address = address_from_userid(user_id)
+
+        # not a user authenticated by EthAuthProvider
+        if address is None:
+            return
+
+        user = self._user_from_id(user_id, event["content"].get("displayname"))
+
+        if not user:
+            return
+
+        self._displayname_cache.warm_users([user])
+        # If for any reason we cannot resolve the displayname, then there was a server error.
+        # Any properly logged in user that joined a room, will have a displayname.
+        # A reason for not resolving it could be rate limiting by the other server.
+        if user.displayname is None:
+            new_state = UserPresence.SERVER_ERROR
+            self._set_user_presence(user_id, new_state, presence_update_id)
+            return
+
+        address = self._validate_userid_signature(user)
+        if not address:
+            return
+
+        self.add_userid_for_address(address, user_id)
+
+        new_state = UserPresence(event["content"]["presence"])
+
+        self._set_user_presence(user_id, new_state, presence_update_id)
+        self._maybe_address_reachability_changed(address)

--- a/tests/pathfinding/test_service.py
+++ b/tests/pathfinding/test_service.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime
 from typing import List
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from eth_utils import decode_hex, to_checksum_address
@@ -293,11 +293,6 @@ def test_token_channel_opened(pathfinding_service_mock, token_network_model):
     pathfinding_service_mock.handle_event(channel_event)
     assert len(pathfinding_service_mock.token_networks) == 1
     assert len(token_network_model.channel_id_to_addresses) == 1
-
-    # Check that presence of these addresses is followed
-    pathfinding_service_mock.matrix_listener.follow_address_presence.assert_has_calls(
-        [call(PARTICIPANT1, refresh=True), call(PARTICIPANT2, refresh=True)]
-    )
 
 
 def test_token_channel_closed(pathfinding_service_mock, token_network_model):


### PR DESCRIPTION
This is alternative 2 from the discussion in #910 .

Instead of tracking presences by a channel open event, presences are being tracked once we receive a presence update from any user in the global room.

We assume that any user in the global room is a raiden user and will eventually create or already has created at least one channel.

In the future, spamming prevention should be set in place. We assume that spamming a global room will first result in a DoS attack against the server before it hits the PFS.

In order to hold the UserAddressManager in a reasonable size, any `leave` event for a user from a global room (which is effectively a user being purged due to 2 days of inactivity) could be used to untrack the address. This is an optimization and not part of the PR currently.

depends on: #909