### PR TITLE
Use legacy resolver until eth circular dependency is fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ install:
 	pip install -r requirements.txt
 
 install-dev:
-	pip install -U -r requirements-dev.txt
-	pip install -e .
+	pip install --use-deprecated=legacy-resolver -U -r requirements-dev.txt
+	pip install --use-deprecated=legacy-resolver -e .
 
 dist:
 	python3 setup.py sdist bdist_wheel


### PR DESCRIPTION
Eth packages have an circular dependency which are not compatible to each other. the new dependency resolver will not finish the installation.