### PR TITLE
Change MatrixListener to only accept `to_device` messages

### DIFF
--- a/src/pathfinding_service/service.py
+++ b/src/pathfinding_service/service.py
@@ -22,7 +22,7 @@ from pathfinding_service.exceptions import (
 from pathfinding_service.model import IOU, TokenNetwork
 from pathfinding_service.model.channel import Channel
 from pathfinding_service.typing import DeferableMessage
-from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, UINT256_MAX, DeviceIDs
+from raiden.constants import UINT256_MAX, DeviceIDs
 from raiden.messages.abstract import Message
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
 from raiden.utils.typing import BlockNumber, BlockTimeout, ChainID, TokenNetworkAddress
@@ -101,7 +101,6 @@ class PathfindingService(gevent.Greenlet):
             private_key=private_key,
             chain_id=self.chain_id,
             device_id=DeviceIDs.PFS,
-            service_room_suffix=PATH_FINDING_BROADCASTING_ROOM,
             message_received_callback=self.handle_message,
             servers=matrix_servers,
         )

--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -395,8 +395,11 @@ class ClientManager:
         if server_url == self.main_client.api.base_url:
             client = self.main_client
         else:
+            # Also handle messages on the other clients,
+            # since to-device communication to the PFS only happens via the local user
+            # on each homeserver
             client = make_client(
-                handle_messages_callback=lambda messages: True,
+                handle_messages_callback=self.main_client.handle_messages_callback,
                 handle_member_join_callback=lambda room: None,
                 servers=[server_url],
                 http_pool_maxsize=4,

--- a/src/request_collector/server.py
+++ b/src/request_collector/server.py
@@ -9,7 +9,7 @@ from sentry_sdk import configure_scope
 from monitoring_service.constants import CHANNEL_CLOSE_MARGIN
 from monitoring_service.database import SharedDatabase
 from monitoring_service.states import MonitorRequest
-from raiden.constants import MONITORING_BROADCASTING_ROOM, DeviceIDs
+from raiden.constants import DeviceIDs
 from raiden.exceptions import InvalidSignature
 from raiden.messages.abstract import Message
 from raiden.messages.monitoring_service import RequestMonitoring
@@ -39,7 +39,6 @@ class RequestCollector(gevent.Greenlet):
             private_key=private_key,
             chain_id=self.chain_id,
             device_id=DeviceIDs.MS,
-            service_room_suffix=MONITORING_BROADCASTING_ROOM,
             message_received_callback=self.handle_message,
             servers=matrix_servers,
         )

--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -202,7 +202,6 @@ def test_matrix_listener_smoke_test(get_accounts, get_private_key):
             private_key=get_private_key(c1),
             chain_id=ChainID(61),
             device_id=DeviceIDs.PFS,
-            service_room_suffix="_service",
             message_received_callback=lambda _: None,
         )
         listener._run()  # pylint: disable=protected-access


### PR DESCRIPTION
Now the MatrixListener's sync-handler will also dispatch
to_device messages without an associated room to the message handler.
The message handler now also supports messages without an associated
room in it's call signature, while the message handling
does not need to be changed.

Resolves #914

We now switch to to-device communication for node-to-service
updates that were formerly handled by the respective service broadcast
room.
The services transport thus don't listen to messages in broadcast
rooms anymore and will only join the global discovery room
in order to still track user presences.

The sync message-handler ignores room messages and will only process
to-device messages.
The sync filter will ignore the discovery room messages for all matrix
clients of the services.

Resolves #915

This PR depends on (/ includes) #912 