### PR TITLE
Include matrix user ids in route response

### DIFF
--- a/src/pathfinding_service/exceptions.py
+++ b/src/pathfinding_service/exceptions.py
@@ -108,3 +108,9 @@ class NoRouteFound(ApiException):
     error_code = 2201
     http_code = 404
     msg = "No route between nodes found."
+
+
+class InconsistentInternalState(ApiException):
+    error_code = 2202
+    http_code = 500
+    msg = "The pathfinding service is temporarily in an inconsistent state. Please try again."

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -32,6 +32,7 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
 )
+from src.pathfinding_service.exceptions import InconsistentInternalState
 
 log = structlog.get_logger(__name__)
 
@@ -208,14 +209,17 @@ class Path:
 
     def to_dict(self) -> dict:
         assert self.fees is not None
-        return dict(
-            path=[to_checksum_address(node) for node in self.nodes],
-            matrix_users=[
-                self.reachability_state._address_to_userids[node]  # pylint: disable=W0212
-                for node in self.nodes
-            ],
-            estimated_fee=self.estimated_fee,
-        )
+        try:
+            return dict(
+                path=[to_checksum_address(node) for node in self.nodes],
+                matrix_users=[
+                    self.reachability_state._address_to_userids[node]  # pylint: disable=W0212
+                    for node in self.nodes
+                ],
+                estimated_fee=self.estimated_fee,
+            )
+        except KeyError:
+            raise InconsistentInternalState()
 
 
 class TokenNetwork:

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -210,6 +210,10 @@ class Path:
         assert self.fees is not None
         return dict(
             path=[to_checksum_address(node) for node in self.nodes],
+            matrix_users=[
+                self.reachability_state._address_to_userids[node]  # pylint: disable=W0212
+                for node in self.nodes
+            ],
             estimated_fee=self.estimated_fee,
         )
 

--- a/src/pathfinding_service/typing.py
+++ b/src/pathfinding_service/typing.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Dict, Set, Union
 
 from typing_extensions import Protocol
 
@@ -14,3 +14,5 @@ class AddressReachabilityProtocol(Protocol):
 
     def get_address_reachability(self, address: Address) -> AddressReachability:
         ...
+
+    _address_to_userids: Dict[Address, Set[str]]

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -78,7 +78,17 @@ def test_get_paths_via_debug_endpoint_a(
         assert response.status_code == 200
         paths = response.json()["result"]
         assert len(paths) == 1
-        assert paths == [{"path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]], "estimated_fee": 0}]
+        assert paths == [
+            {
+                "path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]],
+                "estimated_fee": 0,
+                "matrix_users": [
+                    hex_addrs[0] + "@homeserver",
+                    hex_addrs[1] + "@homeserver",
+                    hex_addrs[2] + "@homeserver",
+                ],
+            }
+        ]
 
     # now there must be a debug endpoint for that specific route
     url_debug = api_url + f"/v1/_debug/routes/{token_network_address}/{hex_addrs[0]}"
@@ -339,7 +349,17 @@ def test_get_paths(api_url: str, addresses: List[Address], token_network_model: 
     assert response.status_code == 200
     paths = response.json()["result"]
     assert len(paths) == 1
-    assert paths == [{"path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]], "estimated_fee": 0}]
+    assert paths == [
+        {
+            "path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]],
+            "matrix_users": [
+                hex_addrs[0] + "@homeserver",
+                hex_addrs[1] + "@homeserver",
+                hex_addrs[2] + "@homeserver",
+            ],
+            "estimated_fee": 0,
+        }
+    ]
 
     # check default value for num_path
     data = {"from": hex_addrs[0], "to": hex_addrs[2], "value": 10}

--- a/tests/pathfinding/test_graphs.py
+++ b/tests/pathfinding/test_graphs.py
@@ -128,10 +128,8 @@ def test_routing_simple(
         reachability_state=reachability_state,
     )
     assert len(paths) == 1
-    assert paths[0].to_dict() == {
-        "path": [hex_addrs[0], hex_addrs[1], hex_addrs[4], hex_addrs[3]],
-        "estimated_fee": 0,
-    }
+    assert paths[0].to_dict()["path"] == [hex_addrs[0], hex_addrs[1], hex_addrs[4], hex_addrs[3]]
+    assert paths[0].to_dict()["estimated_fee"] == 0
 
     # Not connected.
     no_paths = token_network_model.get_paths(
@@ -197,10 +195,8 @@ def test_routing_result_order(
     )
     # 5 paths requested, but only 1 is available
     assert len(paths) == 1
-    assert paths[0].to_dict() == {
-        "path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]],
-        "estimated_fee": 0,
-    }
+    assert paths[0].to_dict()["path"] == [hex_addrs[0], hex_addrs[1], hex_addrs[2]]
+    assert paths[0].to_dict()["estimated_fee"] == 0
 
 
 def addresses_to_indexes(path, addresses):

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -1,4 +1,7 @@
 from datetime import datetime
+from unittest import mock
+
+from eth_utils import to_checksum_address
 
 from raiden.network.transport.matrix import AddressReachability
 from raiden.network.transport.matrix.utils import ReachabilityState
@@ -10,6 +13,10 @@ class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
         self.reachabilities = reachabilities
         self.times = {address: datetime.utcnow() for address in reachabilities}
         self._userid_to_presence: dict = {}
+        self._address_to_userids: dict = mock.MagicMock()
+        self._address_to_userids.__getitem__ = (
+            lambda self, key: f"{to_checksum_address(key)}@homeserver"
+        )
 
     def get_address_reachability(self, address: Address) -> AddressReachability:
         return self.reachabilities.get(address, AddressReachability.UNKNOWN)


### PR DESCRIPTION
I'm using the protected `_address_to_userids` to make this work. It
would make sense to provide a public way to get this information during
a future refactoring.

Closes https://github.com/raiden-network/raiden-services/issues/928