### PR TITLE
Fix bad imports from `src`

### DIFF
--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -15,7 +15,7 @@ from pathfinding_service.constants import (
     DIVERSITY_PEN_DEFAULT,
     FEE_PEN_DEFAULT,
 )
-from pathfinding_service.exceptions import InvalidFeeUpdate
+from pathfinding_service.exceptions import InconsistentInternalState, InvalidFeeUpdate
 from pathfinding_service.model.channel import Channel, ChannelView, FeeSchedule
 from pathfinding_service.typing import AddressReachabilityProtocol
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
@@ -32,7 +32,6 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
 )
-from src.pathfinding_service.exceptions import InconsistentInternalState
 
 log = structlog.get_logger(__name__)
 

--- a/src/raiden_libs/logging.py
+++ b/src/raiden_libs/logging.py
@@ -34,7 +34,7 @@ def setup_logging(log_level: str, log_json: bool) -> None:
         processors = shared_processors + [structlog.dev.ConsoleRenderer()]
 
     structlog.configure(
-        processors=processors,
+        processors=processors,  # type: ignore
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,

--- a/tests/libs/test_service_registry.py
+++ b/tests/libs/test_service_registry.py
@@ -8,7 +8,7 @@ from raiden.utils.typing import BlockNumber
 from raiden_contracts.constants import CONTRACT_SERVICE_REGISTRY
 from raiden_contracts.tests.utils.constants import DEFAULT_REGISTRATION_DURATION
 from raiden_libs.service_registry import info, register_account, withdraw
-from src.raiden_libs.utils import private_key_to_address
+from raiden_libs.utils import private_key_to_address
 
 
 def test_registration(


### PR DESCRIPTION
I relied on my autoimporter, but that apparently messed up in a smart
enough way to fool CI.