### PR TITLE
Return matrix user ids in dict

### DIFF
--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -208,13 +208,11 @@ class Path:
 
     def to_dict(self) -> dict:
         assert self.fees is not None
+        user_id_of = self.reachability_state._address_to_userids  # pylint: disable=W0212
         try:
             return dict(
                 path=[to_checksum_address(node) for node in self.nodes],
-                matrix_users=[
-                    self.reachability_state._address_to_userids[node]  # pylint: disable=W0212
-                    for node in self.nodes
-                ],
+                matrix_users={to_checksum_address(node): user_id_of[node] for node in self.nodes},
                 estimated_fee=self.estimated_fee,
             )
         except KeyError:

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -82,11 +82,11 @@ def test_get_paths_via_debug_endpoint_a(
             {
                 "path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]],
                 "estimated_fee": 0,
-                "matrix_users": [
-                    hex_addrs[0] + "@homeserver",
-                    hex_addrs[1] + "@homeserver",
-                    hex_addrs[2] + "@homeserver",
-                ],
+                "matrix_users": {
+                    hex_addrs[0]: hex_addrs[0] + "@homeserver",
+                    hex_addrs[1]: hex_addrs[1] + "@homeserver",
+                    hex_addrs[2]: hex_addrs[2] + "@homeserver",
+                },
             }
         ]
 
@@ -352,11 +352,11 @@ def test_get_paths(api_url: str, addresses: List[Address], token_network_model: 
     assert paths == [
         {
             "path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]],
-            "matrix_users": [
-                hex_addrs[0] + "@homeserver",
-                hex_addrs[1] + "@homeserver",
-                hex_addrs[2] + "@homeserver",
-            ],
+            "matrix_users": {
+                hex_addrs[0]: hex_addrs[0] + "@homeserver",
+                hex_addrs[1]: hex_addrs[1] + "@homeserver",
+                hex_addrs[2]: hex_addrs[2] + "@homeserver",
+            },
             "estimated_fee": 0,
         }
     ]


### PR DESCRIPTION
Returning a mapping instead of a list should make this more pleasant to
use in the client.