### PR TITLE
Experiment if monkey_patching thread works

### DIFF
--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -2,7 +2,7 @@ from gevent import monkey, config  # isort:skip # noqa
 
 # there were some issues with the 'thread' resolver, remove it from the options
 config.resolver = ["dnspython", "ares", "block"]  # noqa
-monkey.patch_all(subprocess=False, thread=False)  # isort:skip # noqa
+monkey.patch_all(subprocess=False)  # isort:skip # noqa
 
 from typing import Dict
 

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -2,7 +2,7 @@ from gevent import monkey, config  # isort:skip # noqa
 
 # there were some issues with the 'thread' resolver, remove it from the options
 config.resolver = ["dnspython", "ares", "block"]  # noqa
-monkey.patch_all(subprocess=False, thread=False)  # isort:skip # noqa
+monkey.patch_all(subprocess=False)  # isort:skip # noqa
 
 from typing import Dict, List
 

--- a/src/request_collector/cli.py
+++ b/src/request_collector/cli.py
@@ -1,6 +1,6 @@
 from gevent import monkey  # isort:skip # noqa
 
-monkey.patch_all(subprocess=False, thread=False)  # isort:skip # noqa
+monkey.patch_all(subprocess=False)  # isort:skip # noqa
 
 import os.path
 import sys


### PR DESCRIPTION
Since release `v0.14.0` there is a problem with `gevent.threading`:

```
2021-02-24 08:21.55 [info     ] Initializing sentry            dsn=https://.....
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/services/src/pathfinding_service/cli.py", line 158, in <module>
    setup_sentry(enable_flask_integration=True)
  File "/services/src/raiden_libs/cli.py", line 308, in setup_sentry
    environment=environment,
  File "/usr/local/lib/python3.7/site-packages/sentry_sdk/hub.py", line 105, in _init
    client = Client(*args, **kwargs)  # type: ignore
  File "/usr/local/lib/python3.7/site-packages/sentry_sdk/client.py", line 85, in __init__
    self._init_impl()
  File "/usr/local/lib/python3.7/site-packages/sentry_sdk/client.py", line 127, in _init_impl
    "auto_enabling_integrations"
  File "/usr/local/lib/python3.7/site-packages/sentry_sdk/integrations/__init__.py", line 99, in setup_integrations
    logger.debug("Setting up integrations (with default = %s)", with_defaults)
  File "/usr/local/lib/python3.7/logging/__init__.py", line 1366, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/local/lib/python3.7/logging/__init__.py", line 1513, in _log
    exc_info, func, extra, sinfo)
  File "/usr/local/lib/python3.7/logging/__init__.py", line 1483, in makeRecord
    sinfo)
  File "/usr/local/lib/python3.7/logging/__init__.py", line 331, in __init__
    self.threadName = threading.current_thread().name
AttributeError: module 'gevent.threading' has no attribute 'current_thread'
```

This is an attempt if allowing monkeypatching for `thread` fixes it.