### PR TITLE
Add endpoint user

### DIFF
--- a/src/pathfinding_service/exceptions.py
+++ b/src/pathfinding_service/exceptions.py
@@ -54,6 +54,11 @@ class UnsupportedChainID(ApiException):
     msg = "This service does not work on the given blockchain."
 
 
+class InvalidAddress(ApiException):
+    error_code = 2006
+    msg = "Invalid Ethereum address."
+
+
 # ### BadIOU 21xx ###
 
 
@@ -114,3 +119,9 @@ class InconsistentInternalState(ApiException):
     error_code = 2202
     http_code = 500
     msg = "The pathfinding service is temporarily in an inconsistent state. Please try again."
+
+
+class AddressNotOnline(ApiException):
+    error_code = 2203
+    http_code = 404
+    msg = "There is no user found online for given address."

--- a/src/pathfinding_service/typing.py
+++ b/src/pathfinding_service/typing.py
@@ -1,8 +1,9 @@
-from typing import Dict, Set, Union
+from typing import Set, Union
 
 from typing_extensions import Protocol
 
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
+from raiden.network.transport.matrix import UserPresence
 from raiden.network.transport.matrix.utils import AddressReachability
 from raiden.utils.typing import Address
 
@@ -15,4 +16,8 @@ class AddressReachabilityProtocol(Protocol):
     def get_address_reachability(self, address: Address) -> AddressReachability:
         ...
 
-    _address_to_userids: Dict[Address, Set[str]]
+    def get_userid_presence(self, user_id: str) -> UserPresence:
+        ...
+
+    def get_userids_for_address(self, address: Address) -> Set[str]:
+        ...

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -1,22 +1,25 @@
 from datetime import datetime
+from typing import Set, Union
 from unittest import mock
 
-from eth_utils import to_checksum_address
+from eth_utils import to_normalized_address
 
-from raiden.network.transport.matrix import AddressReachability
-from raiden.network.transport.matrix.utils import ReachabilityState
+from raiden.network.transport.matrix import AddressReachability, UserPresence
+from raiden.network.transport.matrix.utils import ReachabilityState, address_from_userid
 from raiden.utils.typing import Address, Dict
+
+
+def get_user_id_from_address(address: Union[str, bytes]):
+    return f"@{to_normalized_address(address)}:homeserver.com"
 
 
 class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
     def __init__(self, reachabilities: Dict[Address, AddressReachability]) -> None:
         self.reachabilities = reachabilities
         self.times = {address: datetime.utcnow() for address in reachabilities}
-        self._userid_to_presence: dict = {}
+        self._userid_to_presence: dict = mock.MagicMock()
         self._address_to_userids: dict = mock.MagicMock()
-        self._address_to_userids.__getitem__ = (
-            lambda self, key: f"{to_checksum_address(key)}@homeserver"
-        )
+        self._address_to_userids.__getitem__ = lambda self, key: {get_user_id_from_address(key)}
 
     def get_address_reachability(self, address: Address) -> AddressReachability:
         return self.reachabilities.get(address, AddressReachability.UNKNOWN)
@@ -26,3 +29,17 @@ class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
             self.reachabilities.get(address, AddressReachability.UNKNOWN),
             self.times.get(address, datetime.utcnow()),
         )
+
+    def get_userid_presence(self, user_id: str) -> UserPresence:
+        """ Return the current presence state of ``user_id``. """
+        address = address_from_userid(user_id)
+        return (
+            UserPresence.ONLINE
+            if address is not None
+            and self.get_address_reachability(address) == AddressReachability.REACHABLE
+            else UserPresence.UNKNOWN
+        )
+
+    def get_userids_for_address(self, address: Address) -> Set[str]:
+        """ Return all known user ids for the given ``address``. """
+        return self._address_to_userids[address]


### PR DESCRIPTION
This PR adds an endpoint where the PFS returns a `user_id` for a given address if this user is online derived from synapse's presence state. If there is no user online then a `404` will be returned.

This endpoint is specifically going to be used for direct payments but can also be used for other use cases.

There are additional minor fixes in the tests as they did not use the correct interface for `get_user_ids_for_address` in the user manager as well irregular matrix user ids. 



fixes: #930