### PR TITLE
Release 0.14.1: Disable thread logging, reset resolver settings, pin raiden

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.0
+current_version = 0.14.1
 commit = True
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+### 0.14.1 (2021-02-25)
+* Fix issues with DNS and logging ([#937](https://github.com/raiden-network/raiden-services/pull/937).
+* Pin `raiden` requirement to specific commit in absence of a recent release.
+
 ### 0.14.0 (2021-02-23)
 * Change communication model to `toDevice` messages ([#918](https://github.com/raiden-network/raiden-services/pull/918))
 * Change the presence tracking model ([#912](https://github.com/raiden-network/raiden-services/pull/912))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
-LABEL Name=raiden-services Version=0.14.0 Maintainer="Raiden Network Team <contact@raiden.network>"
+LABEL Name=raiden-services Version=0.14.1 Maintainer="Raiden Network Team <contact@raiden.network>"
 EXPOSE 6000
 
 WORKDIR /services

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Brainbot Labs Est.'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.14.0'
+release = '0.14.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@develop
+git+https://github.com/raiden-network/raiden.git@55c5d7e45cf8d4dd266bb2ff3aa04fc0861fac0a
 
 sentry-sdk[flask]==0.20.3
 prometheus_client==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md") as readme_file:
 
 setup(
     name="raiden-services",
-    version="0.14.0",
+    version="0.14.1",
     license="MIT",
     description=DESCRIPTION,
     long_description=README,

--- a/src/monitoring_service/cli.py
+++ b/src/monitoring_service/cli.py
@@ -1,7 +1,5 @@
-from gevent import monkey, config  # isort:skip # noqa
+from gevent import monkey  # isort:skip # noqa
 
-# there were some issues with the 'thread' resolver, remove it from the options
-config.resolver = ["dnspython", "ares", "block"]  # noqa
 monkey.patch_all(subprocess=False, thread=False)  # isort:skip # noqa
 
 from typing import Dict

--- a/src/pathfinding_service/cli.py
+++ b/src/pathfinding_service/cli.py
@@ -1,7 +1,5 @@
-from gevent import monkey, config  # isort:skip # noqa
+from gevent import monkey  # isort:skip # noqa
 
-# there were some issues with the 'thread' resolver, remove it from the options
-config.resolver = ["dnspython", "ares", "block"]  # noqa
 monkey.patch_all(subprocess=False, thread=False)  # isort:skip # noqa
 
 from typing import Dict, List

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -294,6 +294,7 @@ def connect_to_blockchain(
 
 
 def setup_sentry(enable_flask_integration: bool = False) -> None:
+    logging.logThreads = False
     sentry_dsn = os.environ.get("SENTRY_DSN")
     environment = os.environ.get("DEPLOY_ENV")
     if sentry_dsn is not None:

--- a/src/raiden_libs/logging.py
+++ b/src/raiden_libs/logging.py
@@ -14,6 +14,7 @@ def setup_logging(log_level: str, log_json: bool) -> None:
     """ Basic structlog setup """
 
     logging.basicConfig(level=log_level, stream=sys.stdout, format="%(message)s")
+    logging.logThreads = False
 
     logging.getLogger("web3").setLevel("INFO")
     logging.getLogger("urllib3").setLevel("INFO")


### PR DESCRIPTION
This sets up the version for a new release `0.14.1`

Patch changes:

- This fixes an issue when setting up `sentry`, where the gevent threading module monkeypatching wasn't completed, while the `sentry` setup already generated log events with thread logging enabled.

- This also removes a patch from the DNS resolver, that lead to problems when trying to resolve addresses from a VPN NS from within docker.

- Furthermore, the `raiden` dependency, formerly linked to the `develop` at github, is now linked to a specific commit. This is done to remove version ambiguity for the next release of `raiden-services`.