### PR TITLE
add capabilities to address_metadata_endpoint

### DIFF
--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -80,8 +80,8 @@ class Path:
         self.value = value
         self.reachability_state = reachability_state
         self.fees = self._check_validity_and_calculate_fees()
-        self.matrix_users = self._get_address_metadata() if self.fees is not None else None
-        self.is_valid = self.fees is not None and self.matrix_users is not None
+        self.metadata = self._get_address_metadata() if self.fees is not None else None
+        self.is_valid = self.fees is not None and self.metadata is not None
         log.debug("Created Path object", nodes=nodes, is_valid=self.is_valid, fees=self.fees)
 
     def _calculate_fees(self) -> Optional[List[FeeAmount]]:
@@ -146,7 +146,7 @@ class Path:
         self,
     ) -> Optional[Dict[str, Dict[str, Union[str, PeerCapabilities]]]]:
         # Check node reachabilities
-        user_ids: Dict[str, Dict[str, Union[str, PeerCapabilities]]] = {}
+        metadata: Dict[str, Dict[str, Union[str, PeerCapabilities]]] = {}
         for node in self.nodes:
             node_user_ids = self.reachability_state.get_userids_for_address(node)
             checksummed_address = to_checksum_address(node)
@@ -156,7 +156,7 @@ class Path:
                     UserPresence.UNAVAILABLE,
                 ]:
                     capabilities = self.reachability_state.get_address_capabilities(node)
-                    user_ids[checksummed_address] = {
+                    metadata[checksummed_address] = {
                         "user_id": user_id,
                         "capabilities": capabilities,
                     }
@@ -164,7 +164,7 @@ class Path:
                     # this user for the given address. There should not be another user online
                     break
 
-            if checksummed_address not in user_ids:
+            if checksummed_address not in metadata:
                 log.debug(
                     "Path invalid because of unavailable node",
                     node=node,
@@ -172,7 +172,7 @@ class Path:
                 )
                 return None
 
-        return user_ids
+        return metadata
 
     def _check_validity_and_calculate_fees(self) -> Optional[List[FeeAmount]]:
         """Checks validity of this path and calculates fees if valid.
@@ -234,7 +234,7 @@ class Path:
         try:
             return dict(
                 path=[to_checksum_address(node) for node in self.nodes],
-                address_metadata=self.matrix_users,
+                address_metadata=self.metadata,
                 estimated_fee=self.estimated_fee,
             )
         except KeyError:

--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from copy import copy
 from datetime import datetime, timedelta
 from itertools import islice
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import networkx as nx
 import structlog
@@ -30,6 +30,7 @@ from raiden.utils.typing import (
     FeeAmount,
     PaymentAmount,
     PaymentWithFeeAmount,
+    PeerCapabilities,
     TokenAmount,
     TokenNetworkAddress,
 )
@@ -79,7 +80,7 @@ class Path:
         self.value = value
         self.reachability_state = reachability_state
         self.fees = self._check_validity_and_calculate_fees()
-        self.matrix_users = self._get_matrix_users() if self.fees is not None else None
+        self.matrix_users = self._get_address_metadata() if self.fees is not None else None
         self.is_valid = self.fees is not None and self.matrix_users is not None
         log.debug("Created Path object", nodes=nodes, is_valid=self.is_valid, fees=self.fees)
 
@@ -141,9 +142,11 @@ class Path:
 
         return fees
 
-    def _get_matrix_users(self) -> Optional[Dict[str, str]]:
+    def _get_address_metadata(
+        self,
+    ) -> Optional[Dict[str, Dict[str, Union[str, PeerCapabilities]]]]:
         # Check node reachabilities
-        user_ids: Dict[str, str] = {}
+        user_ids: Dict[str, Dict[str, Union[str, PeerCapabilities]]] = {}
         for node in self.nodes:
             node_user_ids = self.reachability_state.get_userids_for_address(node)
             checksummed_address = to_checksum_address(node)
@@ -152,7 +155,11 @@ class Path:
                     UserPresence.ONLINE,
                     UserPresence.UNAVAILABLE,
                 ]:
-                    user_ids[checksummed_address] = user_id
+                    capabilities = self.reachability_state.get_address_capabilities(node)
+                    user_ids[checksummed_address] = {
+                        "user_id": user_id,
+                        "capabilities": capabilities,
+                    }
                     # if a reachable user is found we arbitrarily choose
                     # this user for the given address. There should not be another user online
                     break
@@ -227,7 +234,7 @@ class Path:
         try:
             return dict(
                 path=[to_checksum_address(node) for node in self.nodes],
-                matrix_users=self.matrix_users,
+                address_metadata=self.matrix_users,
                 estimated_fee=self.estimated_fee,
             )
         except KeyError:

--- a/src/pathfinding_service/typing.py
+++ b/src/pathfinding_service/typing.py
@@ -5,7 +5,7 @@ from typing_extensions import Protocol
 from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
 from raiden.network.transport.matrix import UserPresence
 from raiden.network.transport.matrix.utils import AddressReachability
-from raiden.utils.typing import Address
+from raiden.utils.typing import Address, PeerCapabilities
 
 DeferableMessage = Union[PFSFeeUpdate, PFSCapacityUpdate]
 
@@ -20,4 +20,7 @@ class AddressReachabilityProtocol(Protocol):
         ...
 
     def get_userids_for_address(self, address: Address) -> Set[str]:
+        ...
+
+    def get_address_capabilities(self, address: Address) -> PeerCapabilities:
         ...

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -35,7 +35,7 @@ from raiden_contracts.tests.utils import get_random_privkey
 from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.utils import private_key_to_address
 from tests.pathfinding.test_database import db_has_feedback_for
-from tests.pathfinding.utils import get_user_id_from_address
+from tests.pathfinding.utils import get_address_metadata, get_user_id_from_address
 
 ID_12 = 12
 ID_123 = 123
@@ -85,10 +85,10 @@ def test_get_paths_via_debug_endpoint_a(
             {
                 "path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]],
                 "estimated_fee": 0,
-                "matrix_users": {
-                    hex_addrs[0]: get_user_id_from_address(hex_addrs[0]),
-                    hex_addrs[1]: get_user_id_from_address(hex_addrs[1]),
-                    hex_addrs[2]: get_user_id_from_address(hex_addrs[2]),
+                "address_metadata": {
+                    hex_addrs[0]: get_address_metadata(hex_addrs[0]),
+                    hex_addrs[1]: get_address_metadata(hex_addrs[1]),
+                    hex_addrs[2]: get_address_metadata(hex_addrs[2]),
                 },
             }
         ]
@@ -355,10 +355,10 @@ def test_get_paths(api_url: str, addresses: List[Address], token_network_model: 
     assert paths == [
         {
             "path": [hex_addrs[0], hex_addrs[1], hex_addrs[2]],
-            "matrix_users": {
-                hex_addrs[0]: get_user_id_from_address(hex_addrs[0]),
-                hex_addrs[1]: get_user_id_from_address(hex_addrs[1]),
-                hex_addrs[2]: get_user_id_from_address(hex_addrs[2]),
+            "address_metadata": {
+                hex_addrs[0]: get_address_metadata(hex_addrs[0]),
+                hex_addrs[1]: get_address_metadata(hex_addrs[1]),
+                hex_addrs[2]: get_address_metadata(hex_addrs[2]),
             },
             "estimated_fee": 0,
         }

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -519,10 +519,10 @@ def test_get_info2(api_url: str, api_sut, pathfinding_service_mock):
 
 
 @pytest.mark.usefixtures("api_sut")
-def test_get_user(api_url: str, api_sut: PFSApi):
+def test_get_address_metadata(api_url: str, api_sut: PFSApi):
     address = make_signer().address
     checksummed_address = to_checksum_address(address)
-    url = f"{api_url}/v1/user/{checksummed_address}"
+    url = f"{api_url}/v1/address/{checksummed_address}/metadata"
     response = requests.get(url)
     assert response.status_code == 404
 

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -15,6 +15,13 @@ def get_user_id_from_address(address: Union[str, bytes]):
     return f"@{to_normalized_address(address)}:homeserver.com"
 
 
+def get_address_metadata(address: Union[str, bytes]):
+    return {
+        "user_id": get_user_id_from_address(address),
+        "capabilities": PeerCapabilities(capconfig_to_dict(CapabilitiesConfig())),
+    }
+
+
 class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
     def __init__(self, reachabilities: Dict[Address, AddressReachability]) -> None:
         self.reachabilities = reachabilities

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -6,7 +6,9 @@ from eth_utils import to_normalized_address
 
 from raiden.network.transport.matrix import AddressReachability, UserPresence
 from raiden.network.transport.matrix.utils import ReachabilityState, address_from_userid
-from raiden.utils.typing import Address, Dict
+from raiden.settings import CapabilitiesConfig
+from raiden.utils.capabilities import capconfig_to_dict
+from raiden.utils.typing import Address, Dict, PeerCapabilities
 
 
 def get_user_id_from_address(address: Union[str, bytes]):
@@ -43,3 +45,9 @@ class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
     def get_userids_for_address(self, address: Address) -> Set[str]:
         """ Return all known user ids for the given ``address``. """
         return self._address_to_userids[address]
+
+    def get_address_capabilities(self, address: Address) -> PeerCapabilities:
+        """ Return the protocol capabilities for ``address``. """
+        if address in self.reachabilities:
+            return PeerCapabilities(capconfig_to_dict(CapabilitiesConfig()))
+        return PeerCapabilities({})


### PR DESCRIPTION
This PR adds capabilities to the address metadata

It also renames the endpoint to `/v1/address/<checksummed_address>/metadata`. 

The return value in case of success looks like
```
{"user_id": <user_id>, "capabilities": <capabilities>}
```

Its the simplistic consistent approach to have capabilities somewhat fetchable from the PFS. It needs to be sorted out whether , how and when these information are actually necessary. 

Also the route metadata information are renamed to `address_metadata` and come in the format 
```
{<address>: {"user_id": <user_id>, "capabilities": <capabilities>}}
```


Maybe this could be defined as its own type in the Raiden client and then be used by the services.
 

fixes: #939 