### PR TITLE
Add debug log when discarding IOUs

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -230,7 +230,17 @@ def process_payment(  # pylint: disable=too-many-branches
     one_to_n_address: Address,
 ) -> None:
     if service_fee == 0:
+        if iou is not None:
+            log.debug(
+                "Discarding IOU, service fee is 0",
+                sender=to_checksum_address(iou.sender),
+                total_amount=iou.amount,
+                expiration_block=iou.expiration_block,
+            )
+        else:
+            log.debug("No IOU and service fee is 0")
         return
+
     if iou is None:
         raise exceptions.MissingIOU
 

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -52,7 +52,7 @@ def test_get_paths_via_debug_endpoint_with_debug_disabled(
     address_hex = to_checksum_address(addresses[0])
     url_debug = api_url + f"/v1/_debug/routes/{token_network_address_hex}/{address_hex}"
 
-    # now there must be a debug endpoint for that specific route
+    # now there must not be a debug endpoint for that specific route
     response_debug = requests.get(url_debug)
     assert response_debug.status_code == 404
 


### PR DESCRIPTION
#961 turned out harder than necessary to debug (nothing to find in log). This PR adds some logging in those cases.