### PR TITLE
fix uncaught error in connecting to matrix server

### DIFF
--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -33,7 +33,6 @@ from raiden.network.transport.matrix.client import (
 )
 from raiden.network.transport.matrix.utils import (
     DisplayNameCache,
-    join_broadcast_room,
     login,
     make_client,
     make_room_alias,
@@ -440,9 +439,7 @@ class ClientManager:
             server = urlparse(matrix_client.api.base_url).netloc
             room_alias = f"#{self.broadcast_room_alias_prefix}:{server}"
 
-            broadcast_room = join_broadcast_room(
-                client=matrix_client, broadcast_room_alias=room_alias
-            )
+            broadcast_room = matrix_client.join_room(room_alias)
             broadcast_room_id = broadcast_room.room_id
 
             if matrix_client == self.main_client:

--- a/tests/libs/test_matrix.py
+++ b/tests/libs/test_matrix.py
@@ -196,7 +196,6 @@ def test_matrix_listener_smoke_test(get_accounts, get_private_key):
     with patch.multiple(
         "raiden_libs.matrix",
         make_client=Mock(return_value=client_mock),
-        join_broadcast_room=Mock(),
     ):
         listener = MatrixListener(
             private_key=get_private_key(c1),
@@ -299,7 +298,6 @@ def test_client_manager_start(get_accounts, get_private_key):
         make_client=Mock(return_value=client_mock),
         get_matrix_servers=Mock(return_value=server_urls),
         login=Mock(),
-        join_broadcast_room=Mock(),
     ):
         client_manager = ClientManager(
             available_servers=[f"https://example0{i}.com" for i in range(5)],


### PR DESCRIPTION
there was a `RaidenUnrecoverableError` uncaught from join_broadcast_room. I removed the call and joined directly by the `client.join_room` call