### PR TITLE
fix unhandled MatrixRequestError in PFS

### DIFF
--- a/src/raiden_libs/matrix.py
+++ b/src/raiden_libs/matrix.py
@@ -355,7 +355,12 @@ class ClientManager:
         self.user_manager = user_manager
         try:
             self._start_client(self.main_client.api.base_url)
-        except (TransportError, ConnectionError, MatrixRequestError):
+        except (TransportError, ConnectionError, MatrixRequestError) as ex:
+            log.error(
+                "Could not connect to main client",
+                server_url=self.main_client.api.base_url,
+                exception=ex,
+            )
             return
 
         for server_url in [


### PR DESCRIPTION
The failing scenarios described in [SP failure: lock expired](https://github.com/raiden-network/scenario-player/issues/667) were partly due to an unhandled exception in the PFS causing the PFS to stop syncing with a homeserver.

The bug happens when a server is currently unavailable and returning a `404` during `sync`. This happens when a Matrix server restarts. While the Matrix API translates this request error to a `MatrixRequestError`, [`GMatrixClient.listen_forever()`](https://github.com/raiden-network/raiden/blob/6455900101bdadade572689e83170b3a55ebc283/raiden/network/transport/matrix/client.py#L387) only handles `MatrixRequestError` when `error_code >= 500`. A `404` will be raised again and thrown back. This was an unhandled edge case in [`ClientManager.connect_client_forever()`](https://github.com/raiden-network/raiden-services/blob/fde698e3c8c21292bd95ac49ac3da87313fe9744/src/raiden_libs/matrix.py#L384)) and thus stopping this greenlet. Additionally, the greenlet exception was only handled during stop of the PFS which can happen at a much later time. Killing this greenlet will stop trying to reconnect to the homeserver. This leaves the PFS unconnected to the homeserver and thus not being able to receive messages and presence updates for its local users.

### solution 

The PFS will now handle the `MatrixRequestError`. To avoid situations where there is another unexpected exception raised, any other exception will be handled by logging and gracefully shutting down the PFS. Upon shutdown the exception in the greenlet will be raised again. The PFS will then be restarted. There should not be another unhandled exception though.