### PR TITLE
Return user capabilities as url

### DIFF
--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -530,8 +530,10 @@ def test_get_address_metadata(api_url: str, api_sut: PFSApi):
     user_manager.reachabilities[address] = AddressReachability.REACHABLE
 
     response = requests.get(url)
+    response_body = response.json()
     assert response.status_code == 200
-    assert response.json()["user_id"] == get_user_id_from_address(address)
+    assert response_body["user_id"] == get_user_id_from_address(address)
+    assert response_body["capabilities"].startswith("mxc://")
 
 
 #

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from eth_utils import to_normalized_address
 
+from raiden.api.v1.encoding import CapabilitiesSchema
 from raiden.network.transport.matrix import AddressReachability, UserPresence
 from raiden.network.transport.matrix.utils import (
     DisplayNameCache,
@@ -12,7 +13,9 @@ from raiden.network.transport.matrix.utils import (
 )
 from raiden.settings import CapabilitiesConfig
 from raiden.utils.capabilities import capconfig_to_dict
-from raiden.utils.typing import Address, Dict, PeerCapabilities
+from raiden.utils.typing import Address, Dict
+
+capabilities_schema = CapabilitiesSchema()
 
 
 def get_user_id_from_address(address: Union[str, bytes]):
@@ -22,7 +25,9 @@ def get_user_id_from_address(address: Union[str, bytes]):
 def get_address_metadata(address: Union[str, bytes]):
     return {
         "user_id": get_user_id_from_address(address),
-        "capabilities": PeerCapabilities(capconfig_to_dict(CapabilitiesConfig())),
+        "capabilities": capabilities_schema.load(capconfig_to_dict(CapabilitiesConfig()))[
+            "capabilities"
+        ],
         "displayname": None,
     }
 
@@ -59,8 +64,10 @@ class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
         """Return all known user ids for the given ``address``."""
         return self._address_to_userids[address]
 
-    def get_address_capabilities(self, address: Address) -> PeerCapabilities:
+    def get_address_capabilities(self, address: Address) -> str:
         """Return the protocol capabilities for ``address``."""
         if address in self.reachabilities:
-            return PeerCapabilities(capconfig_to_dict(CapabilitiesConfig()))
-        return PeerCapabilities({})
+            return capabilities_schema.load(capconfig_to_dict(CapabilitiesConfig()))[
+                "capabilities"
+            ]
+        return capabilities_schema.load({})["capabilities"]


### PR DESCRIPTION
Capabilities are returned as a dictionary in the AddressMetadata. To comply with the outer representation in the matrix profile as well, we could comply and also pass the capabilities as the avatar_url string