### PR TITLE
Make `Event` base class a non dataclass

### DIFF
--- a/src/raiden_libs/events.py
+++ b/src/raiden_libs/events.py
@@ -12,8 +12,7 @@ from raiden.utils.typing import (
 )
 
 
-@dataclass
-class Event:
+class Event:  # pylint: disable=too-few-public-methods
     """Base class for events."""
 
 


### PR DESCRIPTION
Python dataclasses inheritance can't mix between frozen and non-frozen classes.

There was a bug in Python that skipped this check for base classes without fields.

We benefited from this bug since the `raiden_libs.events.Event` base-class is non-frozen, yet the derived classes in `monitoring_service.events` are.

The [bug got fixed](https://bugs.python.org/issue43176) and the fix released in Python 3.8.10 and 3.9.5.

This causes our current usage to break with a TypeError.

Luckily, since we don't use any dataclass specific features on the base-class, we can simply remove the `@dataclass` decorator from it.