### PR TITLE
Add last_seen data to offline nodes

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -472,7 +472,7 @@ class AddressMetadataResource(PathfinderResource):
                 return {"user_id": user_id, "capabilities": capabilities}, 200
 
         raise exceptions.AddressNotOnline(
-            address=checksummed_address, last_seem=user_manager.last_seem_online(address)
+            address=checksummed_address, last_seen=user_manager.last_seen_online(address)
         )
 
     @staticmethod

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -473,7 +473,7 @@ class AddressMetadataResource(PathfinderResource):
 
         offline_since = datetime.now() - user_manager.seen_offline_at(address)
         raise exceptions.AddressNotOnline(
-            address=checksummed_address, seen_offline_since=offline_since.seconds
+            address=checksummed_address, seen_offline_since=offline_since.total_seconds()
         )
 
     @staticmethod

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -471,7 +471,9 @@ class AddressMetadataResource(PathfinderResource):
                 capabilities = user_manager.get_address_capabilities(address)
                 return {"user_id": user_id, "capabilities": capabilities}, 200
 
-        raise exceptions.AddressNotOnline(address=checksummed_address)
+        raise exceptions.AddressNotOnline(
+            address=checksummed_address, last_seem=user_manager.last_seem_online(address)
+        )
 
     @staticmethod
     def _validate_address_argument(address: str) -> Address:

--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -471,8 +471,9 @@ class AddressMetadataResource(PathfinderResource):
                 capabilities = user_manager.get_address_capabilities(address)
                 return {"user_id": user_id, "capabilities": capabilities}, 200
 
+        offline_since = datetime.now() - user_manager.seen_offline_at(address)
         raise exceptions.AddressNotOnline(
-            address=checksummed_address, last_seen=user_manager.last_seen_online(address)
+            address=checksummed_address, seen_offline_since=offline_since.seconds
         )
 
     @staticmethod

--- a/src/raiden_libs/user_address.py
+++ b/src/raiden_libs/user_address.py
@@ -69,6 +69,7 @@ class UserAddressManager:
         self._log = None
         self._listener_id: Optional[UUID] = None
         self._capabilities_schema = CapabilitiesSchema()
+        self._last_seem_online: Dict[Address, Any] = {}
 
     def start(self) -> None:
         """Start listening for presence updates.
@@ -93,6 +94,9 @@ class UserAddressManager:
         # This must return a copy of the current keys, because the container
         # may be modified while these values are used. Issue: #5240
         return set(self._address_to_userids)
+
+    def last_seem_online(self, address: Address) -> Optional[str]:
+        return self._last_seem_online.get(address, None)
 
     def is_address_known(self, address: Address) -> bool:
         """Is the given ``address`` reachability being monitored?"""
@@ -266,6 +270,8 @@ class UserAddressManager:
         self._address_to_reachabilitystate[address] = ReachabilityState(
             new_address_reachability, now
         )
+        if new_presence == UserPresence.ONLINE:
+            self._last_seem_online[address] = str(now)
         self._address_to_capabilities[address] = capabilities
         self._address_reachability_changed_callback(address, new_address_reachability)
 

--- a/src/raiden_libs/user_address.py
+++ b/src/raiden_libs/user_address.py
@@ -69,7 +69,7 @@ class UserAddressManager:
         self._log = None
         self._listener_id: Optional[UUID] = None
         self._capabilities_schema = CapabilitiesSchema()
-        self._last_seem_online: Dict[Address, Any] = {}
+        self._last_seen_online: Dict[Address, Any] = {}
 
     def start(self) -> None:
         """Start listening for presence updates.
@@ -95,8 +95,8 @@ class UserAddressManager:
         # may be modified while these values are used. Issue: #5240
         return set(self._address_to_userids)
 
-    def last_seem_online(self, address: Address) -> Optional[str]:
-        return self._last_seem_online.get(address, None)
+    def last_seen_online(self, address: Address) -> Optional[str]:
+        return self._last_seen_online.get(address, None)
 
     def is_address_known(self, address: Address) -> bool:
         """Is the given ``address`` reachability being monitored?"""
@@ -271,7 +271,7 @@ class UserAddressManager:
             new_address_reachability, now
         )
         if new_presence == UserPresence.ONLINE:
-            self._last_seem_online[address] = str(now)
+            self._last_seen_online[address] = str(now)
         self._address_to_capabilities[address] = capabilities
         self._address_reachability_changed_callback(address, new_address_reachability)
 

--- a/src/raiden_libs/user_address.py
+++ b/src/raiden_libs/user_address.py
@@ -69,7 +69,7 @@ class UserAddressManager:
         self._log = None
         self._listener_id: Optional[UUID] = None
         self._capabilities_schema = CapabilitiesSchema()
-        self._last_seen_online: Dict[Address, Any] = {}
+        self._first_seen_offline: Dict[Address, Any] = {}
 
     def start(self) -> None:
         """Start listening for presence updates.
@@ -95,8 +95,8 @@ class UserAddressManager:
         # may be modified while these values are used. Issue: #5240
         return set(self._address_to_userids)
 
-    def last_seen_online(self, address: Address) -> Optional[str]:
-        return self._last_seen_online.get(address, None)
+    def seen_offline_at(self, address: Address) -> datetime:
+        return self._first_seen_offline.get(address, datetime.fromtimestamp(0))
 
     def is_address_known(self, address: Address) -> bool:
         """Is the given ``address`` reachability being monitored?"""
@@ -270,8 +270,8 @@ class UserAddressManager:
         self._address_to_reachabilitystate[address] = ReachabilityState(
             new_address_reachability, now
         )
-        if new_presence == UserPresence.ONLINE:
-            self._last_seen_online[address] = str(now)
+        if new_presence == UserPresence.OFFLINE:
+            self._first_seen_offline[address] = now
         self._address_to_capabilities[address] = capabilities
         self._address_reachability_changed_callback(address, new_address_reachability)
 

--- a/src/raiden_libs/user_address.py
+++ b/src/raiden_libs/user_address.py
@@ -69,7 +69,8 @@ class UserAddressManager:
         self._log = None
         self._listener_id: Optional[UUID] = None
         self._capabilities_schema = CapabilitiesSchema()
-        self._first_seen_offline: Dict[Address, Any] = {}
+        self._first_seen_offline: Dict[Address, datetime] = {}
+        self._service_started_at = datetime.now()
 
     def start(self) -> None:
         """Start listening for presence updates.
@@ -96,7 +97,7 @@ class UserAddressManager:
         return set(self._address_to_userids)
 
     def seen_offline_at(self, address: Address) -> datetime:
-        return self._first_seen_offline.get(address, datetime.fromtimestamp(0))
+        return self._first_seen_offline.get(address, self._service_started_at)
 
     def is_address_known(self, address: Address) -> bool:
         """Is the given ``address`` reachability being monitored?"""

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -525,7 +525,7 @@ def test_get_offline_address_metadata(api_url: str):
     assert response.status_code == 404
 
     response_body = response.json()
-    assert response_body["error_details"]["last_seem"] is not None
+    assert response_body["error_details"]["last_seen"] is not None
 
 
 @pytest.mark.usefixtures("api_sut")

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -525,7 +525,7 @@ def test_get_offline_address_metadata(api_url: str):
     assert response.status_code == 404
 
     response_body = response.json()
-    assert response_body["error_details"]["last_seen"] is not None
+    assert response_body["error_details"]["seen_offline_since"] is not None
 
 
 @pytest.mark.usefixtures("api_sut")

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -517,12 +517,22 @@ def test_get_info2(api_url: str, api_sut, pathfinding_service_mock):
 
 
 @pytest.mark.usefixtures("api_sut")
-def test_get_address_metadata(api_url: str, api_sut: PFSApi):
+def test_get_offline_address_metadata(api_url: str):
     address = make_signer().address
     checksummed_address = to_checksum_address(address)
     url = f"{api_url}/v1/address/{checksummed_address}/metadata"
     response = requests.get(url)
     assert response.status_code == 404
+
+    response_body = response.json()
+    assert response_body["error_details"]["last_seem"] is not None
+
+
+@pytest.mark.usefixtures("api_sut")
+def test_get_address_metadata(api_url: str, api_sut: PFSApi):
+    address = make_signer().address
+    checksummed_address = to_checksum_address(address)
+    url = f"{api_url}/v1/address/{checksummed_address}/metadata"
 
     user_manager = api_sut.pathfinding_service.matrix_listener.user_manager
     user_manager.reachabilities[address] = AddressReachability.REACHABLE

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -50,7 +50,7 @@ class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
             self.times.get(address, datetime.utcnow()),
         )
 
-    def last_seem_online(self, address):
+    def last_seen_online(self, address):
         if address and self.get_address_reachability(address) == AddressReachability.REACHABLE:
             return datetime.utcnow()
         return str(datetime.utcnow() - timedelta(hours=1))

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -50,10 +50,10 @@ class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
             self.times.get(address, datetime.utcnow()),
         )
 
-    def last_seen_online(self, address):
+    def seen_offline_at(self, address):
         if address and self.get_address_reachability(address) == AddressReachability.REACHABLE:
             return datetime.utcnow()
-        return str(datetime.utcnow() - timedelta(hours=1))
+        return datetime.utcnow() - timedelta(hours=1)
 
     def get_userid_presence(self, user_id: str) -> UserPresence:
         """Return the current presence state of ``user_id``."""

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Set, Union
 from unittest import mock
 
@@ -49,6 +49,11 @@ class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
             self.reachabilities.get(address, AddressReachability.UNKNOWN),
             self.times.get(address, datetime.utcnow()),
         )
+
+    def last_seem_online(self, address):
+        if address and self.get_address_reachability(address) == AddressReachability.REACHABLE:
+            return datetime.utcnow()
+        return str(datetime.utcnow() - timedelta(hours=1))
 
     def get_userid_presence(self, user_id: str) -> UserPresence:
         """Return the current presence state of ``user_id``."""


### PR DESCRIPTION
Closes #991 

Adding `last_seen` information to offline nodes. This will help the decision to delete inactive nodes.