### PR TITLE
Add endpoint to return all online addresses

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -23,6 +23,7 @@ from web3 import Web3
 from werkzeug.exceptions import NotFound
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
+import raiden.utils.typing as raiden_typing
 from pathfinding_service import exceptions, metrics
 from pathfinding_service.constants import (
     API_PATH,
@@ -38,7 +39,7 @@ from pathfinding_service.model.feedback import FeedbackToken
 from pathfinding_service.model.token_network import Path, TokenNetwork
 from pathfinding_service.service import PathfindingService
 from raiden.exceptions import InvalidSignature
-from raiden.network.transport.matrix.utils import UserPresence
+from raiden.network.transport.matrix.utils import AddressReachability, UserPresence
 from raiden.utils.signer import recover
 from raiden.utils.typing import (
     Address,
@@ -510,6 +511,18 @@ class SuggestPartnerResource(PathfinderResource):
         return suggestions, 200
 
 
+class OnlineAddressesResource(PathfinderResource):
+    def get(self) -> Tuple[List[raiden_typing.ChecksumAddress], int]:
+        user_manager = self.pathfinding_service.matrix_listener.user_manager
+        online_addresses = [
+            to_checksum_address(address)
+            for address in user_manager.known_addresses
+            if user_manager.get_address_reachability(address) == AddressReachability.REACHABLE
+        ]
+
+        return online_addresses, 200
+
+
 class DebugPathResource(PathfinderResource):
     def get(  # pylint: disable=no-self-use
         self,
@@ -666,6 +679,7 @@ class PFSApi:
                 {},
                 "suggest_partner",
             ),
+            ("/v1/online_addresses", OnlineAddressesResource, {}, "online_addresses"),
             ("/v1/info", InfoResource, {}, "info"),
             ("/v2/info", InfoResource2, {}, "info2"),
             (

--- a/tests/pathfinding/test_api.py
+++ b/tests/pathfinding/test_api.py
@@ -18,7 +18,7 @@ from pathfinding_service.constants import DEFAULT_INFO_MESSAGE
 from pathfinding_service.model import IOU, TokenNetwork
 from pathfinding_service.model.feedback import FeedbackToken
 from raiden.network.transport.matrix import AddressReachability
-from raiden.tests.utils.factories import make_signer
+from raiden.tests.utils.factories import make_address, make_signer
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,
@@ -722,3 +722,16 @@ def test_suggest_partner_api(api_url: str, token_network_model: TokenNetwork):
     url = api_url + f"/v1/{token_network_address_hex}/suggest_partner"
     response = requests.get(url)
     assert response.status_code == 200
+
+
+@pytest.mark.usefixtures("api_sut")
+def test_online_addresses(api_url: str, reachability_state):
+    online_addr = make_address()
+    reachability_state.reachabilities = {
+        online_addr: AddressReachability.REACHABLE,
+        make_address(): AddressReachability.UNREACHABLE,
+    }
+    url = api_url + "/v1/online_addresses"
+    response = requests.get(url)
+    assert response.status_code == 200
+    assert response.json() == [to_checksum_address(online_addr)]

--- a/tests/pathfinding/utils.py
+++ b/tests/pathfinding/utils.py
@@ -41,6 +41,10 @@ class SimpleReachabilityContainer:  # pylint: disable=too-few-public-methods
         self._address_to_userids.__getitem__ = lambda self, key: {get_user_id_from_address(key)}
         self._displayname_cache = DisplayNameCache()
 
+    @property
+    def known_addresses(self) -> Set[Address]:
+        return set(self.reachabilities.keys())
+
     def get_address_reachability(self, address: Address) -> AddressReachability:
         return self.reachabilities.get(address, AddressReachability.UNKNOWN)
 


### PR DESCRIPTION
This makes it possible to run the Raiden explorer efficiently.

Closes https://github.com/raiden-network/raiden-services/issues/1007.