### PR TITLE
use utcnow everywhere

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -479,7 +479,7 @@ class AddressMetadataResource(PathfinderResource):
                     "displayname": displayname,
                 }, 200
 
-        offline_since = datetime.now() - user_manager.seen_offline_at(address)
+        offline_since = datetime.utcnow() - user_manager.seen_offline_at(address)
         raise exceptions.AddressNotOnline(
             address=checksummed_address, seen_offline_since=offline_since.total_seconds()
         )

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -76,7 +76,7 @@ def start_profiler(output_dir: Optional[str]) -> Optional[Any]:
     from raiden.utils.profiling.sampler import FlameGraphCollector, SignalSampler
 
     os.makedirs(output_dir, exist_ok=True)
-    now = datetime.datetime.now()
+    now = datetime.datetime.utcnow()
     stack_path = os.path.join(output_dir, f"{now:%Y%m%d_%H%M}_stack.data")
     stack_stream = open(stack_path, "w")  # pylint: disable=consider-using-with
     flame = FlameGraphCollector(stack_stream)

--- a/src/raiden_libs/user_address.py
+++ b/src/raiden_libs/user_address.py
@@ -70,7 +70,7 @@ class UserAddressManager:
         self._listener_id: Optional[UUID] = None
         self._capabilities_schema = CapabilitiesSchema()
         self._first_seen_offline: Dict[Address, datetime] = {}
-        self._service_started_at = datetime.now()
+        self._service_started_at = datetime.utcnow()
 
     def start(self) -> None:
         """Start listening for presence updates.
@@ -257,7 +257,7 @@ class UserAddressManager:
         # for capabilities, we get the "first" uid that showed the `new_presence`
         present_uid = presence_to_uid[new_presence].pop()
         capabilities = self.query_capabilities_for_user_id(present_uid)
-        now = datetime.now()
+        now = datetime.utcnow()
 
         self.log.debug(
             "Changing address reachability state",


### PR DESCRIPTION
Fixes https://github.com/raiden-network/raiden/issues/7043

The original idea was to replace the usage of naive datetime with timezone aware timestamps, but since the code seems to [actively reject](https://github.com/netcriptus/raiden-services/blob/master/src/pathfinding_service/service.py#L341) the use of the proposed format, and the reason is unclear, for now I'll just make sure all timestamps being used are coming from `utcnow` instead of just `now`.