### PR TITLE
PFS: handle settled events for coop settle

### DIFF
--- a/src/pathfinding_service/model/token_network.py
+++ b/src/pathfinding_service/model/token_network.py
@@ -301,11 +301,8 @@ class TokenNetwork:
             )
         self.G.add_edge(channel_view.participant1, channel_view.participant2, view=channel_view)
 
-    def handle_channel_closed_event(self, channel_identifier: ChannelID) -> None:
-        """Close a channel. This doesn't mean that the channel is settled yet, but it cannot
-        transfer any more.
-
-        Corresponds to the ChannelClosed event."""
+    def handle_channel_removed_event(self, channel_identifier: ChannelID) -> None:
+        """Remove a channel from the token network."""
 
         # we need to unregister the channel_id here
         participant1, participant2 = self.channel_id_to_addresses.pop(channel_identifier)

--- a/tests/pathfinding/test_token_network.py
+++ b/tests/pathfinding/test_token_network.py
@@ -26,7 +26,7 @@ def test_tn_idempotency_of_channel_openings(
     assert len(token_network_model.channel_id_to_addresses) == 1
 
     # now close the channel
-    token_network_model.handle_channel_closed_event(channel_identifier=ChannelID(1))
+    token_network_model.handle_channel_removed_event(channel_identifier=ChannelID(1))
 
     # there should be no channels
     assert len(token_network_model.channel_id_to_addresses) == 0
@@ -52,7 +52,7 @@ def test_tn_multiple_channels_for_two_participants_opened(
     assert len(token_network_model.channel_id_to_addresses) == 2
 
     # now close one channel
-    token_network_model.handle_channel_closed_event(channel_identifier=ChannelID(1))
+    token_network_model.handle_channel_removed_event(channel_identifier=ChannelID(1))
 
     # there should be one channel left
     assert len(token_network_model.channel_id_to_addresses) == 1


### PR DESCRIPTION
Fixes https://github.com/raiden-network/raiden-services/issues/1040

Handle `ChannelSettled` events in the PFS. This wasn't necessary before, as there was always a `ChannelClosed` event emitted. But with cooperative settlement a single `ChannelSettled` might be emitted and must be handled.