### PR TITLE
Build latest image in actions

### DIFF
--- a/.github/workflows/update_latest_image.yml
+++ b/.github/workflows/update_latest_image.yml
@@ -1,0 +1,24 @@
+name: Update `latest` image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  push_to_registry:
+    name: Update `latest` image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        run: |
+          docker login --username $DOCKER_USERNAME --password $DOCKER_TOKEN
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: raidennetwork/raiden-services:latest


### PR DESCRIPTION
Docker hub doesn't build images on demand any more without a paid subscription. So lets do this stuff by hand 😩 

This image is used by the `services-dev` server which runs he nightly services.