### PR TITLE
Update raiden and fix chain_id problems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@61eb5870abc08a50fb1573f61306e04c4d9bad4b
+git+https://github.com/raiden-network/raiden.git@9e4ac56117314bc4630e8bf68da2424c01989025
 
 sentry-sdk[flask]==1.3.1
 prometheus_client==0.11.0

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,11 +1,12 @@
 from eth_utils import decode_hex
 
-from raiden.utils.typing import ChannelID, MonitoringServiceAddress, TokenNetworkAddress
+from raiden.utils.typing import ChainID, ChannelID, MonitoringServiceAddress, TokenNetworkAddress
 from raiden_libs.utils import private_key_to_address
 
 KEYSTORE_FILE_NAME = "keystore.txt"
 KEYSTORE_PASSWORD = "password"
 TEST_MSC_ADDRESS = MonitoringServiceAddress(b"9" * 20)
+TEST_CHAIN_ID = ChainID(0)
 
 DEFAULT_TOKEN_NETWORK_ADDRESS = TokenNetworkAddress(
     decode_hex("0x6e46B62a245D9EE7758B8DdCCDD1B85fF56B9Bc9")

--- a/tests/monitoring/fixtures/factories.py
+++ b/tests/monitoring/fixtures/factories.py
@@ -7,7 +7,7 @@ from raiden.utils.typing import ChannelID, Nonce, TokenAmount, TokenNetworkAddre
 from raiden_contracts.tests.utils.address import get_random_privkey
 from raiden_contracts.utils.type_aliases import ChainID, PrivateKey
 from raiden_libs.utils import private_key_to_address
-from tests.constants import TEST_MSC_ADDRESS
+from tests.constants import TEST_CHAIN_ID, TEST_MSC_ADDRESS
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def build_request_monitoring():
     non_closing_address = private_key_to_address(non_closing_privkey)
 
     def f(
-        chain_id: ChainID = ChainID(61),
+        chain_id: ChainID = TEST_CHAIN_ID,
         amount: TokenAmount = TokenAmount(50),
         nonce: Nonce = Nonce(1),
         channel_id: ChannelID = ChannelID(1),

--- a/tests/monitoring/fixtures/server.py
+++ b/tests/monitoring/fixtures/server.py
@@ -9,13 +9,7 @@ from web3 import Web3
 
 from monitoring_service.database import Database
 from monitoring_service.service import MonitoringService
-from raiden.utils.typing import (
-    Address,
-    BlockNumber,
-    BlockTimeout,
-    ChainID,
-    MonitoringServiceAddress,
-)
+from raiden.utils.typing import Address, BlockNumber, BlockTimeout, MonitoringServiceAddress
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_SERVICE_REGISTRY,
@@ -23,7 +17,7 @@ from raiden_contracts.constants import (
     CONTRACT_USER_DEPOSIT,
 )
 from request_collector.server import RequestCollector
-from tests.constants import TEST_MSC_ADDRESS
+from tests.constants import TEST_CHAIN_ID, TEST_MSC_ADDRESS
 
 log = logging.getLogger(__name__)
 
@@ -52,7 +46,7 @@ def default_cli_args_ms(default_cli_args) -> List[str]:
 def ms_database() -> Database:
     return Database(
         filename=":memory:",
-        chain_id=ChainID(61),
+        chain_id=TEST_CHAIN_ID,
         msc_address=TEST_MSC_ADDRESS,
         registry_address=Address(bytes([3] * 20)),
         receiver=Address(bytes([4] * 20)),
@@ -87,6 +81,7 @@ def monitoring_service(  # pylint: disable=too-many-arguments
     # We need a shared db between MS and RC so the MS can use MR saved by the RC
     ms.context.database = ms_database
     ms.database = ms_database
+    ms.chain_id = TEST_CHAIN_ID  # workaround for https://github.com/ethereum/web3.py/issues/1677
     return ms
 
 

--- a/tests/monitoring/monitoring_service/factories.py
+++ b/tests/monitoring/monitoring_service/factories.py
@@ -24,7 +24,7 @@ from raiden.utils.typing import (
 from raiden_contracts.constants import ChannelState
 from raiden_contracts.utils.type_aliases import PrivateKey
 from raiden_libs.utils import private_key_to_address
-from tests.constants import TEST_MSC_ADDRESS
+from tests.constants import TEST_CHAIN_ID, TEST_MSC_ADDRESS
 
 DEFAULT_TOKEN_NETWORK_ADDRESS = TokenNetworkAddress(bytes([1] * 20))
 DEFAULT_TOKEN_ADDRESS = TokenAddress(bytes([9] * 20))
@@ -40,7 +40,7 @@ DEFAULT_SETTLE_TIMEOUT = BlockTimeout(100)
 
 
 def create_signed_monitor_request(
-    chain_id: ChainID = ChainID(61),
+    chain_id: ChainID = TEST_CHAIN_ID,
     nonce: Nonce = Nonce(5),
     reward_amount: TokenAmount = DEFAULT_REWARD_AMOUNT,
     closing_privkey: PrivateKey = DEFAULT_PRIVATE_KEY1,

--- a/tests/pathfinding/test_blockchain_integration.py
+++ b/tests/pathfinding/test_blockchain_integration.py
@@ -13,7 +13,7 @@ from monitoring_service.states import HashedBalanceProof
 from pathfinding_service.constants import DEFAULT_REVEAL_TIMEOUT
 from pathfinding_service.model import ChannelView
 from pathfinding_service.service import PathfindingService
-from raiden.utils.typing import BlockNumber, BlockTimeout, ChainID, Nonce, TokenNetworkAddress
+from raiden.utils.typing import BlockNumber, BlockTimeout, Nonce, TokenNetworkAddress
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
@@ -21,6 +21,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.utils.type_aliases import PrivateKey
+from tests.constants import TEST_CHAIN_ID
 
 
 def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
@@ -142,7 +143,7 @@ def test_pfs_with_mocked_client(  # pylint: disable=too-many-arguments
             priv_key=get_private_key(clients[p2_index]),
             channel_identifier=channel_id,
             token_network_address=TokenNetworkAddress(to_canonical_address(token_network.address)),
-            chain_id=ChainID(61),
+            chain_id=TEST_CHAIN_ID,
             additional_hash="0x%064x" % 0,
             locked_amount=0,
             locksroot=encode_hex(LOCKSROOT_OF_NO_LOCKS),


### PR DESCRIPTION
The chain_id problems have been introduced by usage of the chain_id opcode in the contracts.