### PR TITLE
Less RPC calls in IOU check

### DIFF
--- a/src/pathfinding_service/api.py
+++ b/src/pathfinding_service/api.py
@@ -262,6 +262,7 @@ def process_payment(  # pylint: disable=too-many-branches
         raise exceptions.InvalidSignature
 
     # Compare with known IOU
+    latest_block = pathfinding_service.blockchain_state.latest_committed_block
     active_iou = pathfinding_service.database.get_iou(sender=iou.sender, claimed=False)
     if active_iou:
         if active_iou.expiration_block != iou.expiration_block:
@@ -275,7 +276,7 @@ def process_payment(  # pylint: disable=too-many-branches
         if claimed_iou:
             raise exceptions.IOUAlreadyClaimed
 
-        min_expiry = pathfinding_service.web3.eth.block_number + MIN_IOU_EXPIRY
+        min_expiry = latest_block + MIN_IOU_EXPIRY
         if iou.expiration_block < min_expiry:
             raise exceptions.IOUExpiredTooEarly(min_expiry=min_expiry)
         expected_amount = service_fee
@@ -286,7 +287,6 @@ def process_payment(  # pylint: disable=too-many-branches
 
     # Check client's deposit in UserDeposit contract
     udc = pathfinding_service.user_deposit_contract
-    latest_block = pathfinding_service.web3.eth.block_number
     udc_balance = get_pessimistic_udc_balance(
         udc=udc,
         address=iou.sender,

--- a/src/raiden_libs/blockchain.py
+++ b/src/raiden_libs/blockchain.py
@@ -278,11 +278,14 @@ def get_pessimistic_udc_balance(
 ) -> TokenAmount:
     """Get the effective UDC balance using the block with the lowest result.
 
-    Blocks between the latest confirmed block and the latest block are considered.
+    Blocks between the latest confirmed block and the latest block should be
+    considered. For performance reasons, only the bounds of that range are
+    checked. This is acceptable, since the effectiveBalance calculation already
+    guards against withdraws by the user.
     """
     return min(
         udc.functions.effectiveBalance(address).call(block_identifier=BlockNumber(block))
-        for block in range(from_block, to_block + 1)
+        for block in [from_block, to_block + 1]
     )
 
 


### PR DESCRIPTION
Remove RPC calls to get block number for IOU check, since these can be slow and we keep our block number up to date in the DB.

Also reduce number of RPC calls to UDC.getEffectiveBalance to increase performance. There are schemes that are both faster and slightly safer than this approach, but this is good simple tradeoff for now.