### PR TITLE
add support for the new 'rpc' gas price

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/raiden-network/raiden.git@arbitrum-v0.1.0#egg=raiden
+git+https://github.com/raiden-network/raiden.git@arbitrum-v0.2.0#egg=raiden
 
 sentry-sdk[flask]==1.5.6
 prometheus_client==0.12.0

--- a/src/raiden_libs/cli.py
+++ b/src/raiden_libs/cli.py
@@ -157,11 +157,12 @@ def blockchain_options(contracts: List[str]) -> Callable:
                 "Set the gas price for ethereum transactions. If not provided "
                 "the 'normal' gas price startegy is used.\n"
                 "Available options:\n"
-                '"fast" - transactions are usually mined within 60 seconds\n'
                 '"normal" - transactions are usually mined within 5 minutes\n'
+                '"fast" - transactions are usually mined within 60 seconds\n'
+                '"rpc" - using the current price defined by the connected RPC node\n'
                 "<GAS_PRICE> - use given gas price\n"
             ),
-            type=GasPriceChoiceType(["normal", "fast"]),
+            type=GasPriceChoiceType(["normal", "fast", "rpc"]),
             default="fast",
             show_default=True,
         ),


### PR DESCRIPTION
Closes #1162 

The parser for the gas price parameter has become extended with a new price strategy. This 'rpc' strategy is especially important to run the RSB for Arbitrum networks.