### PR TITLE
Release 2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 2.0.0
 commit = True
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 2.0.0 (2022-04-29)
+
+* Update contracts to 0.50.0 (https://github.com/raiden-network/raiden-services/pull/1195)
+* Adapt to use timestamps instead of block numbers (https://github.com/raiden-network/raiden-services/pull/1144)
+* Reschedule too early transactions (https://github.com/raiden-network/raiden-services/pull/1152)
+* Automatically adapt number of confirmation blocks (https://github.com/raiden-network/raiden-services/pull/1156)
+* Optimize transaction retry algorithm (https://github.com/raiden-network/raiden-services/pull/1158)
+* Add new gas price strategy `rpc` (https://github.com/raiden-network/raiden-services/pull/1165)
+* Fix the usage of POSIX UTC timestamps (https://github.com/raiden-network/raiden-services/pull/1172)
+
 ### 1.0.0 (2021-12-08)
 * Update contracts to 0.40.0 (https://github.com/raiden-network/raiden-services/pull/1121)
 * Fix a bug when whitelisting users in Matrix (https://github.com/raiden-network/raiden-services/pull/1110)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-LABEL Name=raiden-services Version=1.0.0 Maintainer="Raiden Network Team <contact@raiden.network>"
+LABEL Name=raiden-services Version=2.0.0 Maintainer="Raiden Network Team <contact@raiden.network>"
 EXPOSE 6000
 
 WORKDIR /services

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Brainbot Labs Est.'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+release = '2.0.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open("README.md", encoding="utf-8") as readme_file:
 
 setup(
     name="raiden-services",
-    version="1.0.0",
+    version="2.0.0",
     license="MIT",
     description=DESCRIPTION,
     long_description=README,


### PR DESCRIPTION
Prepare the next release.

GitHub release notes draft (looks different there...):

* Update contracts to 0.50.0 (https://github.com/raiden-network/raiden-services/pull/1195)
* Adapt to use timestamps instead of block numbers (https://github.com/raiden-network/raiden-services/pull/1144)
* Reschedule too early transactions (https://github.com/raiden-network/raiden-services/pull/1152)
* Automatically adapt number of confirmation blocks (https://github.com/raiden-network/raiden-services/pull/1156)
* Optimize transaction retry algorithm (https://github.com/raiden-network/raiden-services/pull/1158)
* Add new gas price strategy `rpc` (https://github.com/raiden-network/raiden-services/pull/1165)
* Fix the usage of POSIX UTC timestamps (https://github.com/raiden-network/raiden-services/pull/1172)